### PR TITLE
Adds date selector, combines queries, adds js files

### DIFF
--- a/application/blueprints/report/views.py
+++ b/application/blueprints/report/views.py
@@ -1,12 +1,11 @@
 from flask import Blueprint, render_template
 
 from application.data_access.datasette_queries import (
+    get_contributions_and_erroring_endpoints,
     get_endpoint_errors_and_successes_by_week,
     get_endpoints_added_by_week,
     get_issue_counts,
     get_logs,
-    get_number_of_contributions,
-    get_number_of_erroring_endpoints,
 )
 
 report_bp = Blueprint("reporting", __name__, url_prefix="/reporting")
@@ -27,8 +26,10 @@ def overview():
     #     reverse=True,
     # )
     logs_df = get_logs()
-    summary_contributions = get_number_of_contributions()
-    summary_endpoint_errors = get_number_of_erroring_endpoints()
+    (
+        summary_contributions,
+        summary_endpoint_errors,
+    ) = get_contributions_and_erroring_endpoints()
     errors, warnings = get_issue_counts()
     endpoints_added_timeseries = get_endpoints_added_by_week()
     (

--- a/application/blueprints/report/views.py
+++ b/application/blueprints/report/views.py
@@ -3,6 +3,7 @@ from flask import Blueprint, render_template
 from application.data_access.datasette_queries import (
     get_endpoint_errors_and_successes_by_week,
     get_endpoints_added_by_week,
+    get_issue_counts,
     get_logs,
     get_number_of_contributions,
     get_number_of_erroring_endpoints,
@@ -28,6 +29,7 @@ def overview():
     logs_df = get_logs()
     summary_contributions = get_number_of_contributions()
     summary_endpoint_errors = get_number_of_erroring_endpoints()
+    errors, warnings = get_issue_counts()
     endpoints_added_timeseries = get_endpoints_added_by_week()
     (
         endpoint_successes_timeseries,
@@ -37,6 +39,8 @@ def overview():
     summary_metrics = {
         "contributions": summary_contributions,
         "endpoint_errors": summary_endpoint_errors,
+        "errors": errors,
+        "warnings": warnings,
     }
     graphs = {
         "endpoints_added_timeseries": endpoints_added_timeseries,

--- a/application/data_access/datasette_queries.py
+++ b/application/data_access/datasette_queries.py
@@ -61,6 +61,24 @@ def get_logs():
         return None
 
 
+def get_issue_counts():
+    sql = """
+        select
+            it.severity, count(*) as count
+        from issue i
+        inner join issue_type it
+        where i.issue_type = it.issue_type
+        group by it.severity
+    """
+    issues_df = get_datasette_query("digital-land", sql)
+    if issues_df is not None:
+        errors = issues_df[issues_df["severity"] == "error"].iloc[0]["count"]
+        warning = issues_df[issues_df["severity"] == "warning"].iloc[0]["count"]
+        return errors, warning
+    else:
+        return None
+
+
 def get_number_of_contributions():
     current_date = datetime.datetime.now().date()
     date_query = f" where substr(l.entry_date, 1, 10) = '{current_date}'"
@@ -120,7 +138,7 @@ def get_endpoints_added_by_week():
         last_year_endpoints_added_df["week"] = pd.to_numeric(
             last_year_endpoints_added_df["week"]
         )
-        dates = generate_dates(20)
+        dates = generate_weeks(20)
 
         endpoints_added = []
         for date in dates:
@@ -171,7 +189,7 @@ def get_endpoint_errors_and_successes_by_week(logs_df):
         last_year_endpoint_errors_df["week"]
     )
 
-    dates = generate_dates(20)
+    dates = generate_weeks(20)
 
     successes_by_week = []
     error_percentages_by_week = []
@@ -241,7 +259,7 @@ def get_endpoint_errors_and_successes_by_week(logs_df):
 #     return all_datasets
 
 
-def generate_dates(number_of_weeks):
+def generate_weeks(number_of_weeks):
     now = datetime.datetime.now()
     monday = now - datetime.timedelta(days=now.weekday())
     dates = []

--- a/application/templates/reporting/overview.html
+++ b/application/templates/reporting/overview.html
@@ -24,8 +24,8 @@
 <h2>Today's Summary: </h2>
 <p class="govuk-body">Contributions: {{ summary_metrics.contributions }}</p>
 <p class="govuk-body">Endpoint errors: {{ summary_metrics.endpoint_errors }}</p>
-<p class="govuk-body">Data errors: </p>
-<p class="govuk-body">Data warnings: </p>
+<p class="govuk-body">Data errors: {{ summary_metrics.errors }}</p>
+<p class="govuk-body">Data warnings: {{ summary_metrics.warnings }}</p>
 <p class="govuk-body">New resources: </p>
 
 <h2>Endpoints added per week:</h2>

--- a/application/templates/reporting/overview.html
+++ b/application/templates/reporting/overview.html
@@ -21,12 +21,28 @@
 <h2>Organisations</h2>
 <h2>Summary Tables</h2>
 
-<h2>Today's Summary: </h2>
-<p class="govuk-body">Contributions: {{ summary_metrics.contributions }}</p>
-<p class="govuk-body">Endpoint errors: {{ summary_metrics.endpoint_errors }}</p>
+<h2 id="summary-title">Today's Summary: </h2>
+<p id="contributions" class="govuk-body">Contributions: </p>
+<p id="errors" class="govuk-body">Endpoint errors: </p>
 <p class="govuk-body">Data errors: {{ summary_metrics.errors }}</p>
 <p class="govuk-body">Data warnings: {{ summary_metrics.warnings }}</p>
-<p class="govuk-body">New resources: </p>
+<p class="govuk-body">New resources: WIP</p>
+
+<input type="date" class="date-selector" id="date-selector" onchange="handleChange(event);"></input>
+
+<script>
+  const handleChange = (e) => {
+    console.log(e.target.value);
+    document.getElementById('summary-title').innerHTML = event.target.value.concat(" Summary")
+    contributions_index = {{ summary_metrics.contributions.dates | safe}}.indexOf(e.target.value)
+    errors_index = {{ summary_metrics.endpoint_errors.dates | safe}}.indexOf(e.target.value)
+    document.getElementById('contributions').innerHTML = "Contributions: ".concat({{ summary_metrics.contributions.contributions | safe}}[contributions_index])
+    document.getElementById('errors').innerHTML = "Endpoint errors: ".concat({{ summary_metrics.endpoint_errors.errors | safe}}[errors_index])
+  }
+  const dateSelector = document.querySelector("#date-selector")
+  dateSelector.addEventListener("selectionchange", handleChange)
+
+</script>
 
 <h2>Endpoints added per week:</h2>
 <div>
@@ -146,4 +162,17 @@
     }
   }});
 </script>
+<script>
+  console.log({{summary_metrics | safe}})
+</script>
+<script src="{{ assetPath | default('/assets') }}/javascripts/reporting-summary.js"></script>
+<script>
+  let today = new Date()
+  date = today.toISOString().split('T')[0]
+  contributions_index = {{ summary_metrics.contributions.dates | safe}}.indexOf(date)
+  errors_index = {{ summary_metrics.endpoint_errors.dates | safe}}.indexOf(date)
+  document.getElementById('contributions').innerHTML = "Contributions: ".concat({{ summary_metrics.contributions.contributions | safe}}[contributions_index])
+  document.getElementById('errors').innerHTML = "Endpoint errors: ".concat({{ summary_metrics.endpoint_errors.errors | safe}}[errors_index])
+</script>
+
 {% endblock content %}

--- a/application/templates/reporting/overview.html
+++ b/application/templates/reporting/overview.html
@@ -29,21 +29,6 @@
 <p class="govuk-body">Data warnings: {{ summary_metrics.warnings }}</p>
 <p class="govuk-body">New resources: WIP</p>
 
-<script {% if config["ENV"] == "production" %}nonce="{{ csp_nonce() }}"{% endif %}>
-  const handleChange = (e) => {
-    console.log(e.target.value);
-    document.getElementById('summary-title').innerHTML = e.target.value.concat(" Summary")
-    contributions_index = {{ summary_metrics.contributions.dates | safe}}.indexOf(e.target.value)
-    errors_index = {{ summary_metrics.endpoint_errors.dates | safe}}.indexOf(e.target.value)
-    document.getElementById('contributions').innerHTML = "Contributions: ".concat({{ summary_metrics.contributions.contributions | safe}}[contributions_index])
-    document.getElementById('errors').innerHTML = "Endpoint errors: ".concat({{ summary_metrics.endpoint_errors.errors | safe}}[errors_index])}
-
-  const dateSelector = document.querySelector("#date-selector")
-  dateSelector.addEventListener("change", handleChange)
-
-
-</script>
-
 <h2>Endpoints added per week:</h2>
 <div>
   <canvas id="endpoint_added_graph"></canvas>
@@ -168,8 +153,6 @@
 <script type="module" {% if config["ENV"] == "production" %}nonce="{{ csp_nonce() }}"{% endif %}>
     import SummaryMetrics from "{{ assetPath | default('/assets') }}/javascripts/reporting-summary.js"
     const summary_metrics = new SummaryMetrics({{summary_metrics | safe}}).init()
-    // const dateSelector = document.querySelector("#date-selector")
-    // dateSelector.addEventListener("change", summary_metrics.updateMetrics)
 </script>
 
 {% endblock content %}

--- a/application/templates/reporting/overview.html
+++ b/application/templates/reporting/overview.html
@@ -29,7 +29,7 @@
 <p class="govuk-body">Data warnings: {{ summary_metrics.warnings }}</p>
 <p class="govuk-body">New resources: WIP</p>
 
-<script>
+<script {% if config["ENV"] == "production" %}nonce="{{ csp_nonce() }}"{% endif %}>
   const handleChange = (e) => {
     console.log(e.target.value);
     document.getElementById('summary-title').innerHTML = e.target.value.concat(" Summary")
@@ -165,7 +165,7 @@
 <script>
   console.log({{summary_metrics | safe}})
 </script>
-<script type="module">
+<script type="module" {% if config["ENV"] == "production" %}nonce="{{ csp_nonce() }}"{% endif %}>
     import SummaryMetrics from "{{ assetPath | default('/assets') }}/javascripts/reporting-summary.js"
     const summary_metrics = new SummaryMetrics({{summary_metrics | safe}}).init()
     // const dateSelector = document.querySelector("#date-selector")

--- a/application/templates/reporting/overview.html
+++ b/application/templates/reporting/overview.html
@@ -45,111 +45,13 @@
   <canvas id="endpoint_error_graph"></canvas>
 </div>
 
-<script {% if config["ENV"] == "production" %}nonce="{{ csp_nonce() }}"{% endif %}>
-  const endpoints_ctx = document.getElementById('endpoint_added_graph');
-
-  new Chart(endpoints_ctx, {
-    type: 'line',
-    data: {
-      datasets: [{
-        label: '# of endpoints added per week',
-        data: {{graphs.endpoints_added_timeseries | safe}},
-        borderWidth: 1
-      }]
-    },
-    options: {
-      parsing: {
-        xAxisKey: 'date',
-        yAxisKey: 'count'
-      },
-      scales: {
-        y: {
-          title: {
-            display: true,
-            text: "Endpoints added"
-        },
-          beginAtZero: true
-        },
-        x: {
-          title: {
-            display: true,
-            text: "Week"
-        }
-      }
-    }
-  }});
+<script type="module" {% if config["ENV"] == "production" %}nonce="{{ csp_nonce() }}"{% endif %}>
+  import TimeseriesChart from "{{ assetPath | default('/assets') }}/javascripts/utilities/timeseries-chart.js"
+  const endpoint_added_timeseries = new TimeseriesChart("Week", "date", "Endpoints added", "count", '# of endpoints added per week', {{graphs.endpoints_added_timeseries | safe}}, "endpoint_added_graph").init()
+  const resources_downloaded_timeseries = new TimeseriesChart("Week", "date", "Resources downloaded", "count", "# of resources downloaded per week", {{graphs.endpoint_successes_timeseries | safe}}, "resources_downloaded_graph").init()
+  const endpoint_errors_timeseries = new TimeseriesChart("Week", "date", "Error %", "count", "% of active endpoints erroring per week", {{graphs.endpoint_errors_timeseries | safe}}, "endpoint_error_graph").init()
 </script>
 
-<script {% if config["ENV"] == "production" %}nonce="{{ csp_nonce() }}"{% endif %}>
-  const resources_ctx = document.getElementById('resources_downloaded_graph');
-
-  new Chart(resources_ctx, {
-    type: 'line',
-    data: {
-      datasets: [{
-        label: '# of resources downloaded per week',
-        data: {{graphs.endpoint_successes_timeseries | safe}},
-        borderWidth: 1
-      }]
-    },
-    options: {
-      parsing: {
-        xAxisKey: 'date',
-        yAxisKey: 'count'
-      },
-      scales: {
-        y: {
-          title: {
-            display: true,
-            text: "Resources downloaded"
-        },
-        },
-        x: {
-          title: {
-            display: true,
-            text: "Week"
-        }
-      }
-    }
-  }});
-</script>
-
-<script {% if config["ENV"] == "production" %}nonce="{{ csp_nonce() }}"{% endif %}>
-  const endpoint_errors_ctx = document.getElementById('endpoint_error_graph');
-
-  new Chart(endpoint_errors_ctx, {
-    type: 'line',
-    data: {
-      datasets: [{
-        label: '% of active endpoints erroring',
-        data: {{graphs.endpoint_errors_timeseries | safe}},
-        borderWidth: 1
-      }]
-    },
-    options: {
-      parsing: {
-        xAxisKey: 'date',
-        yAxisKey: 'count'
-      },
-      scales: {
-        y: {
-          title: {
-            display: true,
-            text: "Error %"
-        },
-        },
-        x: {
-          title: {
-            display: true,
-            text: "Week"
-        }
-      }
-    }
-  }});
-</script>
-<script>
-  console.log({{summary_metrics | safe}})
-</script>
 <script type="module" {% if config["ENV"] == "production" %}nonce="{{ csp_nonce() }}"{% endif %}>
     import SummaryMetrics from "{{ assetPath | default('/assets') }}/javascripts/reporting-summary.js"
     const summary_metrics = new SummaryMetrics({{summary_metrics | safe}}).init()

--- a/application/templates/reporting/overview.html
+++ b/application/templates/reporting/overview.html
@@ -24,23 +24,23 @@
 <h2 id="summary-title">Today's Summary: </h2>
 <p id="contributions" class="govuk-body">Contributions: </p>
 <p id="errors" class="govuk-body">Endpoint errors: </p>
+<input type="date" id="date-selector"></input>
 <p class="govuk-body">Data errors: {{ summary_metrics.errors }}</p>
 <p class="govuk-body">Data warnings: {{ summary_metrics.warnings }}</p>
 <p class="govuk-body">New resources: WIP</p>
 
-<input type="date" class="date-selector" id="date-selector" onchange="handleChange(event);"></input>
-
 <script>
   const handleChange = (e) => {
     console.log(e.target.value);
-    document.getElementById('summary-title').innerHTML = event.target.value.concat(" Summary")
+    document.getElementById('summary-title').innerHTML = e.target.value.concat(" Summary")
     contributions_index = {{ summary_metrics.contributions.dates | safe}}.indexOf(e.target.value)
     errors_index = {{ summary_metrics.endpoint_errors.dates | safe}}.indexOf(e.target.value)
     document.getElementById('contributions').innerHTML = "Contributions: ".concat({{ summary_metrics.contributions.contributions | safe}}[contributions_index])
-    document.getElementById('errors').innerHTML = "Endpoint errors: ".concat({{ summary_metrics.endpoint_errors.errors | safe}}[errors_index])
-  }
+    document.getElementById('errors').innerHTML = "Endpoint errors: ".concat({{ summary_metrics.endpoint_errors.errors | safe}}[errors_index])}
+
   const dateSelector = document.querySelector("#date-selector")
-  dateSelector.addEventListener("selectionchange", handleChange)
+  dateSelector.addEventListener("change", handleChange)
+
 
 </script>
 
@@ -165,14 +165,11 @@
 <script>
   console.log({{summary_metrics | safe}})
 </script>
-<script src="{{ assetPath | default('/assets') }}/javascripts/reporting-summary.js"></script>
-<script>
-  let today = new Date()
-  date = today.toISOString().split('T')[0]
-  contributions_index = {{ summary_metrics.contributions.dates | safe}}.indexOf(date)
-  errors_index = {{ summary_metrics.endpoint_errors.dates | safe}}.indexOf(date)
-  document.getElementById('contributions').innerHTML = "Contributions: ".concat({{ summary_metrics.contributions.contributions | safe}}[contributions_index])
-  document.getElementById('errors').innerHTML = "Endpoint errors: ".concat({{ summary_metrics.endpoint_errors.errors | safe}}[errors_index])
+<script type="module">
+    import SummaryMetrics from "{{ assetPath | default('/assets') }}/javascripts/reporting-summary.js"
+    const summary_metrics = new SummaryMetrics({{summary_metrics | safe}}).init()
+    // const dateSelector = document.querySelector("#date-selector")
+    // dateSelector.addEventListener("change", summary_metrics.updateMetrics)
 </script>
 
 {% endblock content %}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,5 +19,12 @@ module.exports = [
       file: 'application/static/javascripts/app-resource-mapping.js',
       format: 'iife'
     }
+  },
+  {
+    input: 'src/javascripts/reporting-summary.js',
+    output: {
+      file: 'application/static/javascripts/reporting-summary.js',
+      // format: 'iife'
+    }
   }
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,5 +26,12 @@ module.exports = [
       file: 'application/static/javascripts/reporting-summary.js',
       // format: 'iife'
     }
+  },
+  {
+    input: 'src/javascripts/utilities/timeseries-chart.js',
+    output: {
+      file: 'application/static/javascripts/utilities/timeseries-chart.js',
+      // format: 'iife'
+    }
   }
 ]

--- a/src/javascripts/reporting-summary.js
+++ b/src/javascripts/reporting-summary.js
@@ -1,32 +1,33 @@
-function SummaryMetrics(summary_metrics) {
-    this.summary_metrics = summary_metrics;
+class SummaryMetrics {
+    constructor(summary_metrics) {
+        this.summary_metrics = summary_metrics;
+        const dateSelector = document.querySelector("#date-selector")
+        dateSelector.addEventListener("change", this.updateMetrics.bind(this))
+    }
+
+    init() {
+        console.log("hello from init function");
+        const today = new Date();
+        const date = today.toISOString().split('T')[0];
+        const contributions_index = this.summary_metrics.contributions.dates.indexOf(date);
+        const errors_index = this.summary_metrics.endpoint_errors.dates.indexOf(date);
+        document.getElementById('contributions').innerHTML = "Contributions: ".concat(this.summary_metrics.contributions.contributions[contributions_index]);
+        document.getElementById('errors').innerHTML = "Endpoint errors: ".concat(this.summary_metrics.endpoint_errors.errors[errors_index]);
+        return this
+    }
+
+    updateMetrics (e) {
+            console.log("hello from update function");
+            if (e != undefined) {
+                console.log(e.target.value);
+                console.log(this)
+                document.getElementById('summary-title').innerHTML = e.target.value.concat(" Summary");
+                const contributions_index = this.summary_metrics.contributions.dates.indexOf(e.target.value);
+                const errors_index =this.summary_metrics.endpoint_errors.dates.indexOf(e.target.value);
+                document.getElementById('contributions').innerHTML = "Contributions: ".concat(this.summary_metrics.contributions.contributions[contributions_index]);
+                document.getElementById('errors').innerHTML = "Endpoint errors: ".concat(this.summary_metrics.endpoint_errors.errors[errors_index]);
+            }
+    }
 }
-
-SummaryMetrics.prototype.init = function () {
-    console.log("hello from init function");
-    const today = new Date();
-    const date = today.toISOString().split('T')[0];
-    const contributions_index = this.summary_metrics.contributions.dates.indexOf(date);
-    const errors_index = this.summary_metrics.endpoint_errors.dates.indexOf(date);
-    document.getElementById('contributions').innerHTML = "Contributions: ".concat(this.summary_metrics.contributions.contributions[contributions_index]);
-    document.getElementById('errors').innerHTML = "Endpoint errors: ".concat(this.summary_metrics.endpoint_errors.errors[errors_index]);
-
-
-
-    return this
-};
-
-// SummaryMetrics.prototype.updateMetrics = function (e) {
-//     console.log("hello from update function");
-//     if (e != undefined) {
-//     console.log(e.target.value);
-//     console.log(this)
-//     document.getElementById('summary-title').innerHTML = e.target.value.concat(" Summary");
-//     const contributions_index = this.summary_metrics.contributions.dates.indexOf(e.target.value);
-//     const errors_index =this.summary_metrics.endpoint_errors.dates.indexOf(e.target.value);
-//     document.getElementById('contributions').innerHTML = "Contributions: ".concat(this.summary_metrics.contributions.contributions[contributions_index]);
-//     document.getElementById('errors').innerHTML = "Endpoint errors: ".concat(this.summary_metrics.endpoint_errors.errors[errors_index]);
-//     }
-// };
 
 export { SummaryMetrics as default };

--- a/src/javascripts/reporting-summary.js
+++ b/src/javascripts/reporting-summary.js
@@ -1,0 +1,32 @@
+function SummaryMetrics(summary_metrics) {
+    this.summary_metrics = summary_metrics;
+}
+
+SummaryMetrics.prototype.init = function () {
+    console.log("hello from init function");
+    const today = new Date();
+    const date = today.toISOString().split('T')[0];
+    const contributions_index = this.summary_metrics.contributions.dates.indexOf(date);
+    const errors_index = this.summary_metrics.endpoint_errors.dates.indexOf(date);
+    document.getElementById('contributions').innerHTML = "Contributions: ".concat(this.summary_metrics.contributions.contributions[contributions_index]);
+    document.getElementById('errors').innerHTML = "Endpoint errors: ".concat(this.summary_metrics.endpoint_errors.errors[errors_index]);
+
+
+
+    return this
+};
+
+// SummaryMetrics.prototype.updateMetrics = function (e) {
+//     console.log("hello from update function");
+//     if (e != undefined) {
+//     console.log(e.target.value);
+//     console.log(this)
+//     document.getElementById('summary-title').innerHTML = e.target.value.concat(" Summary");
+//     const contributions_index = this.summary_metrics.contributions.dates.indexOf(e.target.value);
+//     const errors_index =this.summary_metrics.endpoint_errors.dates.indexOf(e.target.value);
+//     document.getElementById('contributions').innerHTML = "Contributions: ".concat(this.summary_metrics.contributions.contributions[contributions_index]);
+//     document.getElementById('errors').innerHTML = "Endpoint errors: ".concat(this.summary_metrics.endpoint_errors.errors[errors_index]);
+//     }
+// };
+
+export { SummaryMetrics as default };

--- a/src/javascripts/reporting-summary.js
+++ b/src/javascripts/reporting-summary.js
@@ -6,7 +6,6 @@ class SummaryMetrics {
     }
 
     init() {
-        console.log("hello from init function");
         const today = new Date();
         const date = today.toISOString().split('T')[0];
         const contributions_index = this.summary_metrics.contributions.dates.indexOf(date);
@@ -17,10 +16,7 @@ class SummaryMetrics {
     }
 
     updateMetrics (e) {
-            console.log("hello from update function");
             if (e != undefined) {
-                console.log(e.target.value);
-                console.log(this)
                 document.getElementById('summary-title').innerHTML = e.target.value.concat(" Summary");
                 const contributions_index = this.summary_metrics.contributions.dates.indexOf(e.target.value);
                 const errors_index =this.summary_metrics.endpoint_errors.dates.indexOf(e.target.value);

--- a/src/javascripts/utilities/timeseries-chart.js
+++ b/src/javascripts/utilities/timeseries-chart.js
@@ -1,0 +1,50 @@
+class TimeseriesChart {
+    constructor (xAxisTitle, xAxisKey, yAxisTitle, yAxisKey, label, data, htmlId, options) {
+        this.xAxisTitle = xAxisTitle
+        this.xAxisKey = xAxisKey
+        this.yAxisTitle = yAxisTitle
+        this.yAxisKey = yAxisKey
+        this.label = label
+        this.data = data
+        this.htmlId = htmlId
+        this.options = options
+    }
+
+    init() {
+        const graph_ctx = document.getElementById(this.htmlId);
+
+        return new Chart(graph_ctx, {
+            type: 'line',
+            data: {
+            datasets: [{
+                label: this.label,
+                data: this.data,
+                borderWidth: 1
+            }]
+            },
+            options: {
+                parsing: {
+                    xAxisKey: this.xAxisKey,
+                    yAxisKey: this.yAxisKey
+                },
+                scales: {
+                    y: {
+                    title: {
+                        display: true,
+                        text: this.yAxisTitle
+                    },
+                    beginAtZero: true
+                    },
+                    x: {
+                        title: {
+                            display: true,
+                            text: this.xAxisTitle
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+
+export {TimeseriesChart as default}


### PR DESCRIPTION
This PR adds a date selector to the overview page allowing the viewing of some summary metrics for any date in the past 2 years.
In order to do this 2 queries to obtain data about endpoints erroring/succeeding have been combined into a single query.
Also tidies up the front end by moving all the javascripts into their own files.