### PR TITLE
Update overview table styling

### DIFF
--- a/application/templates/overview/main-dataset-table.html
+++ b/application/templates/overview/main-dataset-table.html
@@ -54,7 +54,7 @@
           class="govuk-table__header govuk-table__header--numeric govuk-!-text-align-centre"
           aria-sort="none"
         >
-          <span> Most recent endpoint </span>
+          Most recent endpoint
         </th>
         <th
           scope="col"
@@ -142,13 +142,13 @@
           class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"
           data-sort-value="{{ dataset['latest_endpoint'] }}"
         >
-          <span>{{ dataset['latest_endpoint'] }}</span>
+          {{ dataset['latest_endpoint'] }}
         </td>
         <td
           class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"
           data-sort-value="{{ dataset['total']|to_int }}"
         >
-          <span>{{ dataset['total'] }}</span>
+          {{ dataset['total'] }}
         </td>
         <td
           class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"

--- a/application/templates/overview/main-dataset-table.html
+++ b/application/templates/overview/main-dataset-table.html
@@ -1,62 +1,183 @@
 <div class="data-table__wrapper" data-module="data-table">
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--l govuk-visually-hidden">Table of datasets</caption>
-      <thead class="govuk-table__head dl-table__head--sticky">
-        <!-- <tr class="govuk-table__row">
+  <table class="govuk-table">
+    <caption
+      class="govuk-table__caption govuk-table__caption--l govuk-visually-hidden"
+    >
+      Table of datasets
+    </caption>
+    <thead class="govuk-table__head dl-table__head--sticky">
+      <!-- <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header govuk-\!-width-one-quarter"></th>
           <th scope="col" class="govuk-table__header dl-cell-date"></th>
           <th scope="colgroup" colspan="2" class="govuk-table__header">Organisations</th>
           <th scope="col" class="govuk-table__header dl-cell-date"></th>
           <th scope="col" class="govuk-table__header dl-cell-date"></th>
         </tr>-->
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header dl-table__header--border-right govuk-\!-width-one-quarter" aria-sort="none">Name</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Typology</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Organisations (current/expected)</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Started</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Resources</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Days since update</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Most recent endpoint</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Endpoints (active/total)</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Frequency of updates</th>
+      <tr class="govuk-table__row">
+        <th
+          scope="col"
+          class="govuk-table__header dl-table__header--border-right govuk-\!-width-one-quarter"
+          aria-sort="none"
+        >
+          Name
+        </th>
+        <th
+          scope="col"
+          class="govuk-table__header govuk-table__header--numeric govuk-!-text-align-centre"
+          aria-sort="none"
+        >
+          Typology
+        </th>
+        <th
+          scope="col"
+          class="govuk-table__header govuk-table__header--numeric govuk-!-text-align-centre"
+          aria-sort="none"
+        >
+          Organisations (current/expected)
+        </th>
+        <th
+          scope="col"
+          class="govuk-table__header govuk-table__header--numeric govuk-!-text-align-centre"
+          aria-sort="none"
+        >
+          Started
+        </th>
+        <th
+          scope="col"
+          class="govuk-table__header govuk-table__header--numeric govuk-!-text-align-centre"
+          aria-sort="none"
+        >
+          Endpoints (active/total)
+        </th>
+        <th
+          scope="col"
+          class="govuk-table__header govuk-table__header--numeric govuk-!-text-align-centre"
+          aria-sort="none"
+        >
+          <span> Most recent endpoint </span>
+        </th>
+        <th
+          scope="col"
+          class="govuk-table__header govuk-table__header--numeric govuk-!-text-align-centre"
+          aria-sort="none"
+        >
+          Resources
+        </th>
+        <th
+          scope="col"
+          class="govuk-table__header govuk-table__header--numeric govuk-!-text-align-centre"
+          aria-sort="none"
+        >
+          Days since update
+        </th>
+        <th
+          scope="col"
+          class="govuk-table__header govuk-table__header--numeric govuk-!-text-align-centre"
+          aria-sort="none"
+        >
+          Frequency of updates
+        </th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      {% for k, dataset in datasets.items() %}
+      <tr
+        class="govuk-table__row{{ ' dl-row--inactive' if not dataset.pipeline }}"
+      >
+        <td
+          scope="row"
+          class="govuk-table__cell dl-table__header--border-right"
+          data-sort-value="{{ dataset.name }}"
+        >
+          {% set dataset_url_str = dataset.name|lower|replace(" ", "-") %}
+          <a
+            href="{{ url_for('dataset.dataset_overview', dataset=dataset_url_str) }}"
+            class="govuk-link govuk-link--bold"
+            >{{ dataset.name }}</a
+          >
+        </td>
+        <td
+          class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"
+          data-sort-value="{{ dataset['typology'] }}"
+        >
+          {{ dataset['typology'] }}
+        </td>
+        <td
+          class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"
+          data-sort-value="{{ dataset['publishers']|to_int }}"
+        >
+          <a
+            class="govuk-link govuk-link--text-colour"
+            href="{{ url_for('dataset.dataset_overview', dataset=dataset_url_str, _anchor='publishers') }}"
+            >{{ dataset['publishers'] }}</a
+          >
+          / {{ dataset['expected_publishers'] }}
+        </td>
 
+        <td
+          class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"
+        >
+          {% if dataset['first'] %} {{ dataset['first'] }} {% elif
+          dataset.pipeline %}
 
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        {% for k, dataset in datasets.items() %}
-        <tr class="govuk-table__row{{ ' dl-row--inactive' if not dataset.pipeline }}">
-          <td scope="row" class="govuk-table__cell dl-table__header--border-right" data-sort-value="{{ dataset.name }}">
-            {% set dataset_url_str = dataset.name|lower|replace(" ", "-") %}
-            <a href="{{ url_for('dataset.dataset_overview', dataset=dataset_url_str) }}" class="govuk-link govuk-link--bold">{{ dataset.name }}</a>
-          </td>
-          <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ dataset['typology'] }}">{{ dataset['typology'] }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ dataset['publishers']|to_int }}"><a class="govuk-link govuk-link--text-colour" href="{{ url_for('dataset.dataset_overview', dataset=dataset_url_str, _anchor='publishers') }}">{{ dataset['publishers'] }}</a> / {{ dataset['expected_publishers'] }}</td>
-          <td class="govuk-table__cell">{% if dataset['first'] %}
-            {{ dataset['first'] }}
-          {% elif dataset.pipeline %}
-            <strong class="govuk-tag govuk-tag--yellow">No data</strong>
+          <strong class="govuk-tag govuk-tag--yellow">No data</strong>
           {% else %}
-            <strong class="govuk-tag govuk-tag--grey">Backlog</strong>
-          {% endif %}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ dataset['total']|to_int }}"><span>{{ dataset['total'] }}</span></td>
-          <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ dataset['latest']|days_since if dataset['latest'] }}">{{ dataset['latest']|days_since if dataset['latest'] }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ dataset['latest_endpoint'] }}">{{ dataset['latest_endpoint'] }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ dataset['active']|to_int }}"><a class="govuk-link govuk-link--text-colour" href="{{ url_for('dataset.dataset_overview', dataset=dataset_url_str, _anchor='publishers') }}">{{ dataset['active'] }}</a> / {{ dataset['total'] }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ dataset['frequency-of-updates']}}">{{dataset['frequency-of-updates']}}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-    <div class="table-key">
-      <div class="govuk-!-margin-bottom-2">
-        <span class="govuk-tag govuk-tag--grey govuk-tag--small">Backlog</span>
-        <span class="dl-small-text">Datasets we know about but have not started collecting data.</span>
-      </div>
-      <div class="govuk-!-margin-bottom-2">
-        <span class="govuk-tag govuk-tag--yellow govuk-tag--small">No data</span>
-        <span class="dl-small-text">Datasets with a pipeline but no resources collected.</span>
-      </div>
-    </div>
+          <strong class="govuk-tag govuk-tag--grey">Backlog</strong>
+          {% endif %}
+        </td>
 
+        <td
+          class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"
+          data-sort-value="{{ dataset['active']|to_int }}"
+        >
+          <a
+            class="govuk-link govuk-link--text-colour"
+            href="{{ url_for('dataset.dataset_overview', dataset=dataset_url_str, _anchor='publishers') }}"
+            >{{ dataset['active'] }}</a
+          >
+          / {{ dataset['total'] }}
+        </td>
+        <td
+          id="latest-endpoint-cell"
+          class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"
+          data-sort-value="{{ dataset['latest_endpoint'] }}"
+        >
+          <span>{{ dataset['latest_endpoint'] }}</span>
+        </td>
+        <td
+          class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"
+          data-sort-value="{{ dataset['total']|to_int }}"
+        >
+          <span>{{ dataset['total'] }}</span>
+        </td>
+        <td
+          class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"
+          data-sort-value="{{ dataset['latest']|days_since if dataset['latest'] }}"
+        >
+          {{ dataset['latest']|days_since if dataset['latest'] }}
+        </td>
+        <td
+          class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"
+          data-sort-value="{{ dataset['frequency-of-updates']}}"
+        >
+          {{dataset['frequency-of-updates']}}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <div class="table-key">
+    <div class="govuk-!-margin-bottom-2">
+      <span class="govuk-tag govuk-tag--grey govuk-tag--small">Backlog</span>
+      <span class="dl-small-text"
+        >Datasets we know about but have not started collecting data.</span
+      >
+    </div>
+    <div class="govuk-!-margin-bottom-2">
+      <span class="govuk-tag govuk-tag--yellow govuk-tag--small">No data</span>
+      <span class="dl-small-text"
+        >Datasets with a pipeline but no resources collected.</span
+      >
+    </div>
+  </div>
 </div>

--- a/application/templates/overview/main-dataset-table.html
+++ b/application/templates/overview/main-dataset-table.html
@@ -115,7 +115,7 @@
         </td>
 
         <td
-          class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"
+          class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre app-table_cell--date"
         >
           {% if dataset['first'] %} {{ dataset['first'] }} {% elif
           dataset.pipeline %}
@@ -139,7 +139,7 @@
         </td>
         <td
           id="latest-endpoint-cell"
-          class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre"
+          class="govuk-table__cell govuk-table__cell--numeric govuk-!-text-align-centre app-table_cell--date"
           data-sort-value="{{ dataset['latest_endpoint'] }}"
         >
           {{ dataset['latest_endpoint'] }}

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -28,60 +28,61 @@
   font-weight: 700;
 }
 
-.govuk-table__header:last-child, .govuk-table__cell:last-child {
+.govuk-table__header:last-child,
+.govuk-table__cell:last-child {
   padding-right: 15px;
 }
 
 // styles for reporting tables*
 
 .reporting-bad-background {
-  background: rgba(govuk-colour("red"),0.5);
+  background: rgba(govuk-colour("red"), 0.5);
 }
 
 .reporting-good-background {
-  background: rgba(govuk-colour("green"),0.5);
+  background: rgba(govuk-colour("green"), 0.5);
 }
 
 .reporting-medium-background {
-  background: rgba(govuk-colour("yellow"),0.5);
+  background: rgba(govuk-colour("yellow"), 0.5);
 }
 
 .reporting-null-background {
-  background: rgba(govuk-colour("black"),0.1);
+  background: rgba(govuk-colour("black"), 0.1);
 }
 
 .reporting-100-background {
-  background: rgba(govuk-colour("green"),1)
+  background: rgba(govuk-colour("green"), 1);
 }
 .reporting-90-100-background {
-  background: rgba(govuk-colour("green"),0.9)
+  background: rgba(govuk-colour("green"), 0.9);
 }
 .reporting-80-90-background {
-  background: rgba(govuk-colour("green"),0.8)
+  background: rgba(govuk-colour("green"), 0.8);
 }
 .reporting-70-80-background {
-  background: rgba(govuk-colour("green"),0.7)
+  background: rgba(govuk-colour("green"), 0.7);
 }
 .reporting-60-70-background {
-  background: rgba(govuk-colour("green"),0.6)
+  background: rgba(govuk-colour("green"), 0.6);
 }
 .reporting-50-60-background {
-  background: rgba(govuk-colour("green"),0.5)
+  background: rgba(govuk-colour("green"), 0.5);
 }
 .reporting-40-50-background {
-  background: rgba(govuk-colour("green"),0.4)
+  background: rgba(govuk-colour("green"), 0.4);
 }
 .reporting-30-40-background {
-  background: rgba(govuk-colour("green"),0.3)
+  background: rgba(govuk-colour("green"), 0.3);
 }
 .reporting-20-30-background {
-  background: rgba(govuk-colour("green"),0.2)
+  background: rgba(govuk-colour("green"), 0.2);
 }
 .reporting-10-20-background {
-  background: rgba(govuk-colour("green"),0.1)
+  background: rgba(govuk-colour("green"), 0.1);
 }
 .reporting-00-10-background {
-  background: rgba(govuk-colour("green"),0.05)
+  background: rgba(govuk-colour("green"), 0.05);
 }
 
 .dl-table__header--border-right {
@@ -92,4 +93,8 @@
 .dl-table__header--border-right + .govuk-table__cell {
   padding-left: 10px;
   padding-right: 10px;
+}
+
+.app-table_cell--date {
+  min-width: 10ch;
 }


### PR DESCRIPTION
Associated ticket: https://trello.com/c/9F1t8h15/1343-overview-of-datasets-front-end-edits-121
- Changes the order of the columns, centers the values, and sets min date length cell so always one line


Visual changes:
BEFORE:
![image](https://github.com/user-attachments/assets/f531a1fc-90e7-45e4-a3f1-7160338a1512)


AFTER:
![image](https://github.com/user-attachments/assets/84c809db-4104-4212-81f6-7b503ea677e9)
