### PR TITLE
add endpoint end date filter

### DIFF
--- a/application/data_access/odp_summaries/conformance.py
+++ b/application/data_access/odp_summaries/conformance.py
@@ -51,6 +51,7 @@ def get_column_field_summary(dataset_clause, offset):
     sql = f"""
     select * from endpoint_dataset_resource_summary
     where resource != ''
+    and endpoint_end_date=''
     and ({dataset_clause})
     limit 1000 offset {offset}
     """
@@ -63,6 +64,7 @@ def get_issue_summary(dataset_clause, offset):
     sql = f"""
     select  * from endpoint_dataset_issue_type_summary
     where ({dataset_clause})
+    and endpoint_end_date = ''
     limit 1000 offset {offset}
     """
     issue_summary_df = get_datasette_query("performance", sql)

--- a/application/data_access/odp_summaries/issue.py
+++ b/application/data_access/odp_summaries/issue.py
@@ -282,6 +282,7 @@ def get_issue_summary_by_issue_type(dataset_clause, offset):
     FROM
         endpoint_dataset_issue_type_summary
     {dataset_clause}
+    and endpoint_end_date = ''
     limit 1000 offset {offset}
     """
     print(sql)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The summary tables in the performance DB will be changed to include information endpoints that are not active. This PR adds a filter so that it excludes endpoints with an end date - ie nothing should change when the summary tables include extra information

## Related Tickets & Documents

https://trello.com/c/NJSZQBUZ/3512-perf-db-general-changes
