### PR TITLE
Fix 'nan' in overview status table

### DIFF
--- a/application/data_access/odp_summaries/status.py
+++ b/application/data_access/odp_summaries/status.py
@@ -52,7 +52,6 @@ def get_odp_status_summary(dataset_types, cohorts):
     sql = """
         select
             rle.organisation,
-            rle.name,
             rle.collection,
             rle.pipeline,
             rle.endpoint,
@@ -104,7 +103,6 @@ def get_odp_status_summary(dataset_types, cohorts):
                     datasets,
                 )
             )
-
         # Calculate overview stats
         percentages = 0.0
         datasets_added = 0

--- a/application/data_access/odp_summaries/utils.py
+++ b/application/data_access/odp_summaries/utils.py
@@ -48,15 +48,18 @@ def get_provisions(selected_cohorts, all_cohorts):
     SELECT
         p.cohort,
         p.organisation,
-        c.start_date as cohort_start_date
+        c.start_date as cohort_start_date,
+        org.name as name
     FROM
         provision p
     INNER JOIN
         cohort c on c.cohort = p.cohort
+    JOIN organisation org
     WHERE
         p.provision_reason = "expected"
     AND p.project == "open-digital-planning"
     {cohort_clause}
+    AND org.organisation == p.organisation
     GROUP BY
         p.organisation
     ORDER BY


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

'nan' was shown in the [status ](https://config-manager-prototype.herokuapp.com/reporting/odp-summary/status)summary table due to joining on `organisation` between query results for `provision` and `reporting_latest_endpoint`; as no endpoint was available for the organisation `NYUA`, the name received 'nan`. This PR adds the organisation name to the initial provision query instead of relying on the one from `reporting_latest_endpoints`.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link: https://mhclgdigital.atlassian.net/jira/software/projects/DATA/boards/229?selectedIssue=DATA-943
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings



## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: config manager has no tests!
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?