### PR TITLE
remove deprecated sass mixin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI
 on:
   push:
-      branches:
+    branches:
+      - main
+  pull_request:
+    branches:
       - main
   workflow_dispatch:
 
@@ -24,39 +27,39 @@ jobs:
     #       - 5432:5432
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Set up python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
 
-    - name: Install dependencies
-      run: |
-        make init
+      - name: Install dependencies
+        run: |
+          make init
 
-    - name: Lint
-      run: |
-        make lint
+      - name: Lint
+        run: |
+          make lint
 
-    # - name: Setup database
-    #   run: |
-    #     psql -h localhost -c "CREATE DATABASE data_manager WITH TEMPLATE postgres" -U postgres
-    #   env:
-    #     PGPASSWORD: postgres
+      # - name: Setup database
+      #   run: |
+      #     psql -h localhost -c "CREATE DATABASE data_manager WITH TEMPLATE postgres" -U postgres
+      #   env:
+      #     PGPASSWORD: postgres
 
-    # - name: Migrate database
-    #   run: |
-    #     make upgrade-db
-    #   env:
-    #     DATABASE_URL: postgresql://postgres:postgres@localhost/config_manager
+      # - name: Migrate database
+      #   run: |
+      #     make upgrade-db
+      #   env:
+      #     DATABASE_URL: postgresql://postgres:postgres@localhost/config_manager
 
-    # - name: Test
-    #   run: |
-    #     make load-test-data
-    #     make test
-    #     make test-functional
-    #   env:
-    #     DATABASE_URL: postgresql://postgres:postgres@localhost/config_manager
+      # - name: Test
+      #   run: |
+      #     make load-test-data
+      #     make test
+      #     make test-functional
+      #   env:
+      #     DATABASE_URL: postgresql://postgres:postgres@localhost/config_manager

--- a/application/data_access/odp_summaries/conformance.py
+++ b/application/data_access/odp_summaries/conformance.py
@@ -174,12 +174,14 @@ def get_odp_conformance_summary(dataset_types, cohorts):
     issue_df["field"] = issue_df["field"].replace("entity", "reference")
     # Filter out issues for fields not in dataset field (specification)
     issue_df["field"] = issue_df.apply(
-        lambda row: row["field"]
-        if row["field"]
-        in dataset_field_df[dataset_field_df["dataset"] == row["dataset"]][
-            "field"
-        ].values
-        else None,
+        lambda row: (
+            row["field"]
+            if row["field"]
+            in dataset_field_df[dataset_field_df["dataset"] == row["dataset"]][
+                "field"
+            ].values
+            else None
+        ),
         axis=1,
     )
 
@@ -288,8 +290,12 @@ def get_odp_conformance_summary(dataset_types, cohorts):
     )
 
     provisions_with_100_pct_match = final_count[final_count["field_matched_pct"] == 1.0]
-    percent_100_field_match = round(len(provisions_with_100_pct_match) / len(final_count) * 100, 1) if len(final_count) else 0
-    
+    percent_100_field_match = (
+        round(len(provisions_with_100_pct_match) / len(final_count) * 100, 1)
+        if len(final_count)
+        else 0
+    )
+
     out_cols = [
         "cohort",
         "organisation_name",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "digital-land-frontend": "https://gitpkg.now.sh/digital-land/digital-land-frontend/package?main",
-    "govuk-frontend": "^4.0.1"
+    "govuk-frontend": "^5.9.0"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",

--- a/src/scss/objects/_moj-width-container.scss
+++ b/src/scss/objects/_moj-width-container.scss
@@ -13,10 +13,6 @@ $moj-gutter-half: $moj-gutter / 2;
   // Limit the width of the container to the page width
   max-width: $width;
 
-  @include govuk-if-ie8 {
-    width: $width;
-  }
-
   // On mobile, add half width gutters
   margin: 0 $moj-gutter-half;
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

IE mixins are deprecated and no longer available


