### PR TITLE
Use tasks-log, add doc crawler, check retired endpoints

### DIFF
--- a/application/blueprints/datamanager/controllers/check.py
+++ b/application/blueprints/datamanager/controllers/check.py
@@ -199,7 +199,7 @@ def handle_check_results(request_id, result):
         if item.get("task-source") != "column-field" and item.get("summary")
     ]
     passed_checks = [
-        f"All rows have {entry['field']} present"
+        f"Column mapped: {entry['field']}"
         for entry in column_mapping
         if entry.get("field")
     ]

--- a/application/blueprints/datamanager/controllers/check.py
+++ b/application/blueprints/datamanager/controllers/check.py
@@ -40,7 +40,7 @@ _ROWS_PER_PAGE = 500
 
 
 def handle_check_results(request_id, result):
-    # Extract org code, TODO bit hacky as submit and manage use this param for code / value
+    # Extract org code
     organisation_code = result.get("params", {}).get("organisationName")
     dataset_id = result.get("params", {}).get("dataset")
     if not organisation_code:
@@ -161,39 +161,48 @@ def handle_check_results(request_id, result):
 
     # Error summary parsing from overall response
     data = (result.get("response") or {}).get("data") or {}
-    error_summary = data.get("error-summary", []) or []
-    column_field_log = data.get("column-field-log", []) or []
+    task_log = data.get("task-log", []) or []
+    column_mapping = data.get("column-mapping", []) or []
 
-    # Build converted, transformed and issue log tables
+    # Build converted, transformed and issue log tables.
+    # column-mapping has the same {field, column} shape that build_check_tables needs.
     (
         converted_table,
         transformed_table,
         issue_log_table,
         spec_fields,
-    ) = build_check_tables(column_field_log, resp_details)
+    ) = build_check_tables(column_mapping, resp_details)
 
     # Build column mapping rows for inline configure UI
     unmapped_columns = converted_table.get("unmapped_columns", set())
     user_column_mapping = result.get("params", {}).get("column_mapping") or {}
     mapping_rows = build_column_mapping_rows(
-        column_field_log, unmapped_columns, user_column_mapping
+        column_mapping, unmapped_columns, user_column_mapping
     )
     # Merge spec fields with all dataset fields so the mapping dropdown includes
-    # fields that aren't present in this check's column-field-log
+    # fields that aren't present in this check's column-mapping
     spec_fields = (spec_fields | set(get_field_names_for_dataset(dataset_id))) - {
         "IGNORE"
     }
 
-    # Checks: must_fix is missing columns in column_field_log, passed_checks is columns that exist
-    # (even if missing values exist still passes), fixable is everything in error_summary (issue_logs combined)
-    must_fix, fixable, passed_checks = [], [], []
-    for err in error_summary:
-        fixable.append(err)
-    for col in column_field_log:
-        if not col.get("missing"):
-            passed_checks.append(f"All rows have {col.get('field')} present")
-        else:
-            must_fix.append(f"Missing required field: {col.get('field')}")
+    # must_fix: task-log entries flagged as missing columns (task-source == "column-field")
+    # fixable: all other task-log issues (value errors, etc.)
+    # passed_checks: every field that column-mapping confirms is present
+    must_fix = [
+        item["summary"]
+        for item in task_log
+        if item.get("task-source") == "column-field" and item.get("summary")
+    ]
+    fixable = [
+        item["summary"]
+        for item in task_log
+        if item.get("task-source") != "column-field" and item.get("summary")
+    ]
+    passed_checks = [
+        f"All rows have {entry['field']} present"
+        for entry in column_mapping
+        if entry.get("field")
+    ]
     allow_add_data = len(must_fix) == 0
 
     can_override = False

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -289,6 +289,7 @@ def handle_check_transform(request_id, req):
 
     endpoint_in_doc = check_endpoint_in_doc(documentation_url, endpoint_url)
     doc_is_gov_uk = is_gov_uk_url(documentation_url)
+    endpoint_is_gov_uk = is_gov_uk_url(endpoint_url)
 
     return render_template(
         "datamanager/check-transform.html",
@@ -313,6 +314,7 @@ def handle_check_transform(request_id, req):
         entity_page_end=entity_page_end,
         endpoint_in_doc=endpoint_in_doc,
         doc_is_gov_uk=doc_is_gov_uk,
+        endpoint_is_gov_uk=endpoint_is_gov_uk,
         endpoint_url=endpoint_url,
         documentation_url=documentation_url,
     )

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -6,6 +6,7 @@ from . import ControllerError
 from ..services.async_api import fetch_response_details
 from ..services.dataset import get_dataset_name
 from ..services.organisation import get_org_entity, get_organisation_name
+from ..services.doc_crawler import check_endpoint_in_doc, is_gov_uk_url
 from ..services.endpoint import get_endpoint_urls_for_hashes
 from ..services.planning_data import (
     get_entities_for_organisation_and_dataset,
@@ -120,6 +121,9 @@ def handle_check_transform(request_id, req):
     organisation_display = get_organisation_name(organisation_code)
     dataset_display = get_dataset_name(dataset_id, default=dataset_id)
 
+    endpoint_url = params.get("url", "")
+    documentation_url = params.get("documentation_url", "")
+
     status = req.get("status")
 
     if status == "FAILED":
@@ -132,6 +136,9 @@ def handle_check_transform(request_id, req):
         )
 
     if status in {"PENDING", "PROCESSING", "QUEUED"} or req.get("response") is None:
+        # Pre-warm the cache so the result is ready when the job completes.
+        if endpoint_url and documentation_url:
+            check_endpoint_in_doc(documentation_url, endpoint_url)
         return render_template(
             "datamanager/check-transform-loading.html",
             request_id=request_id,
@@ -159,9 +166,13 @@ def handle_check_transform(request_id, req):
     if isinstance(existing_endpoints, str):
         existing_endpoints = [existing_endpoints] if existing_endpoints else []
     if existing_endpoints:
-        endpoint_urls = get_endpoint_urls_for_hashes(existing_endpoints)
+        endpoint_data = get_endpoint_urls_for_hashes(existing_endpoints)
         existing_endpoints = [
-            {"endpoint": h, "endpoint-url": endpoint_urls.get(h, "")}
+            {
+                "endpoint": h,
+                "endpoint-url": endpoint_data.get(h, {}).get("endpoint_url", ""),
+                "end-date": endpoint_data.get(h, {}).get("end_date", ""),
+            }
             for h in existing_endpoints
         ]
 
@@ -276,6 +287,9 @@ def handle_check_transform(request_id, req):
         "columnNameProcessing": "none",
     }
 
+    endpoint_in_doc = check_endpoint_in_doc(documentation_url, endpoint_url)
+    doc_is_gov_uk = is_gov_uk_url(documentation_url)
+
     return render_template(
         "datamanager/check-transform.html",
         request_id=request_id,
@@ -297,4 +311,8 @@ def handle_check_transform(request_id, req):
         has_next_entity_page=has_next_entity_page,
         entity_page_start=entity_page_start,
         entity_page_end=entity_page_end,
+        endpoint_in_doc=endpoint_in_doc,
+        doc_is_gov_uk=doc_is_gov_uk,
+        endpoint_url=endpoint_url,
+        documentation_url=documentation_url,
     )

--- a/application/blueprints/datamanager/services/doc_crawler.py
+++ b/application/blueprints/datamanager/services/doc_crawler.py
@@ -6,8 +6,6 @@ import requests
 
 from application.extensions import cache
 
-from ..utils import REQUESTS_TIMEOUT
-
 logger = logging.getLogger(__name__)
 
 _DOC_CRAWLER_TIMEOUT = 10

--- a/application/blueprints/datamanager/services/doc_crawler.py
+++ b/application/blueprints/datamanager/services/doc_crawler.py
@@ -1,0 +1,110 @@
+import logging
+from html.parser import HTMLParser
+from urllib.parse import urljoin, urlparse
+
+import requests
+
+from application.extensions import cache
+
+from ..utils import REQUESTS_TIMEOUT
+
+logger = logging.getLogger(__name__)
+
+_DOC_CRAWLER_TIMEOUT = 10
+
+
+def is_gov_uk_url(url):
+    """Return True if url's hostname is gov.uk or a subdomain of gov.uk."""
+    if not url:
+        return False
+    try:
+        hostname = urlparse(url).hostname or ""
+        return hostname == "gov.uk" or hostname.endswith(".gov.uk")
+    except Exception:
+        return False
+
+
+class _HrefCollector(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.hrefs = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "a":
+            for name, value in attrs:
+                if name == "href" and value:
+                    self.hrefs.append(value.strip())
+
+
+def _hrefs_match(href, endpoint_url, documentation_url):
+    """Return True if href resolves to endpoint_url under any matching strategy."""
+    endpoint_parsed = urlparse(endpoint_url)
+    endpoint_path = endpoint_parsed.path
+
+    # Exact full URL match
+    if href == endpoint_url:
+        return True
+
+    # Resolve relative href against documentation URL and compare
+    try:
+        resolved = urljoin(documentation_url, href)
+        if resolved == endpoint_url:
+            return True
+    except Exception:
+        pass
+
+    # Path-only match (e.g. /downloads/file/3149/... == endpoint path)
+    if href == endpoint_path:
+        return True
+
+    # Compare the path portion of an absolute href
+    try:
+        href_parsed = urlparse(href)
+        if href_parsed.path and href_parsed.path == endpoint_path:
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+@cache.memoize(timeout=3600)
+def check_endpoint_in_doc(documentation_url, endpoint_url):
+    """
+    Fetch documentation_url and check whether endpoint_url is linked from it.
+
+    Returns a dict:
+        found (bool): True if the endpoint URL was found in the page's links
+        matched_href (str|None): the raw href value that matched, if any
+        error (str|None): description of any fetch/parse error
+    """
+    if not documentation_url or not endpoint_url:
+        return {"found": False, "matched_href": None, "error": "Missing URL"}
+
+    try:
+        resp = requests.get(
+            documentation_url,
+            timeout=_DOC_CRAWLER_TIMEOUT,
+            allow_redirects=True,
+            headers={"User-Agent": "digital-land-config-manager/1.0"},
+        )
+        resp.raise_for_status()
+    except requests.exceptions.Timeout:
+        logger.warning("Timeout fetching doc URL: %s", documentation_url)
+        return {"found": False, "matched_href": None, "error": "Request timed out"}
+    except requests.exceptions.RequestException as exc:
+        logger.warning("Error fetching doc URL %s: %s", documentation_url, exc)
+        return {"found": False, "matched_href": None, "error": str(exc)}
+
+    collector = _HrefCollector()
+    try:
+        collector.feed(resp.text)
+    except Exception as exc:
+        logger.warning("Error parsing HTML from %s: %s", documentation_url, exc)
+        return {"found": False, "matched_href": None, "error": "HTML parse error"}
+
+    for href in collector.hrefs:
+        if _hrefs_match(href, endpoint_url, documentation_url):
+            return {"found": True, "matched_href": href, "error": None}
+
+    return {"found": False, "matched_href": None, "error": None}

--- a/application/blueprints/datamanager/services/endpoint.py
+++ b/application/blueprints/datamanager/services/endpoint.py
@@ -31,9 +31,11 @@ def get_endpoint_urls_for_hashes(hashes: list) -> dict:
         data = response.json()
         for row in data.get("rows", []):
             h = row.get("endpoint")
-            ep_url = row.get("endpoint_url", "")
             if h:
-                result[h] = ep_url
+                result[h] = {
+                    "endpoint_url": row.get("endpoint_url", ""),
+                    "end_date": row.get("end_date") or "",
+                }
     except Exception as e:
         logger.error(f"Failed to fetch endpoint URLs for hashes: {e}", exc_info=True)
 

--- a/application/blueprints/datamanager/utils/__init__.py
+++ b/application/blueprints/datamanager/utils/__init__.py
@@ -175,10 +175,20 @@ def build_check_tables(column_field_log, resp_details):
         "unmapped_columns": unmapped_columns,
     }
 
-    # Transformed table: entry_number + columns from column_field_log "field" key
+    # Transformed table: entry_number + columns from column_field_log "field" key,
+    # plus any extra fields present in the data but not in column_mapping
     transformed_headers = ["entry_number"] + [
         entry["field"] for entry in column_field_log if entry.get("field")
     ]
+    known_transformed = set(transformed_headers)
+    for row in resp_details:
+        for item in row.get("transformed_row") or []:
+            if isinstance(item, dict):
+                field = item.get("field")
+                if field and field not in known_transformed:
+                    transformed_headers.append(field)
+                    known_transformed.add(field)
+
     transformed_rows = []
     for row in resp_details:
         transformed = row.get("transformed_row") or []

--- a/application/blueprints/datamanager/utils/csv_formats.py
+++ b/application/blueprints/datamanager/utils/csv_formats.py
@@ -130,7 +130,12 @@ def build_source_csv_preview(
     if not source_present:
         src_source = source_summary_data.get("new_source_entry", {})
         if pipelines_append_required:
-            src_source = {**src_source, "pipelines": pipelines_append_required.get("updated", src_source.get("pipelines", ""))}
+            src_source = {
+                **src_source,
+                "pipelines": pipelines_append_required.get(
+                    "updated", src_source.get("pipelines", "")
+                ),
+            }
         src_row = [str(src_source.get(col, "") or "") for col in src_cols]
         source_csv_table_params = {
             "columns": src_cols,
@@ -145,7 +150,12 @@ def build_source_csv_preview(
     else:
         src_source = source_summary_data.get("existing_source_entry", {})
         if pipelines_append_required:
-            src_source = {**src_source, "pipelines": pipelines_append_required.get("updated", src_source.get("pipelines", ""))}
+            src_source = {
+                **src_source,
+                "pipelines": pipelines_append_required.get(
+                    "updated", src_source.get("pipelines", "")
+                ),
+            }
         src_row = [str(src_source.get(col, "") or "") for col in src_cols]
         source_csv_table_params = {
             "columns": src_cols,

--- a/application/blueprints/datamanager/utils/csv_formats.py
+++ b/application/blueprints/datamanager/utils/csv_formats.py
@@ -124,9 +124,13 @@ def build_source_csv_preview(
     source_present = source_summary_data.get("documentation_url_in_source_csv")
     will_create_source_text = "No" if source_present else "Yes"
 
+    pipelines_append_required = source_summary_data.get("pipelines_append_required")
+
     source_csv_text = ""
     if not source_present:
         src_source = source_summary_data.get("new_source_entry", {})
+        if pipelines_append_required:
+            src_source = {**src_source, "pipelines": pipelines_append_required.get("updated", src_source.get("pipelines", ""))}
         src_row = [str(src_source.get(col, "") or "") for col in src_cols]
         source_csv_table_params = {
             "columns": src_cols,
@@ -140,6 +144,8 @@ def build_source_csv_preview(
             source_csv_text = _row_to_csv(src_row)
     else:
         src_source = source_summary_data.get("existing_source_entry", {})
+        if pipelines_append_required:
+            src_source = {**src_source, "pipelines": pipelines_append_required.get("updated", src_source.get("pipelines", ""))}
         src_row = [str(src_source.get(col, "") or "") for col in src_cols]
         source_csv_table_params = {
             "columns": src_cols,

--- a/application/templates/datamanager/check-transform.html
+++ b/application/templates/datamanager/check-transform.html
@@ -176,21 +176,36 @@
 
     {% if endpoint_url and documentation_url %}
     {% set _doc_found = endpoint_in_doc.found %}
-    {% set _doc_error = endpoint_in_doc.error %}
-    {% set _has_issue = not _doc_found or not doc_is_gov_uk %}
-    <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-6" style="background-color: #f3f2f1; padding: 15px 20px; border-left: 4px solid {{ '#d4351c' if _has_issue else '#00703c' }};">
+    {% set _access_error = endpoint_in_doc.error %}
+    {# Red: doc URL not gov.uk (always). Green: doc gov.uk + found. Orange: doc gov.uk + (access error or endpoint gov.uk but not found). Red: doc gov.uk + not found + endpoint not gov.uk. #}
+    {% if not doc_is_gov_uk %}
+      {% set _border_colour = '#d4351c' %}
+    {% elif _doc_found %}
+      {% set _border_colour = '#00703c' %}
+    {% elif _access_error or endpoint_is_gov_uk %}
+      {% set _border_colour = '#f47738' %}
+    {% else %}
+      {% set _border_colour = '#d4351c' %}
+    {% endif %}
+    <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-6" style="background-color: #f3f2f1; padding: 15px 20px; border-left: 4px solid {{ _border_colour }};">
       <details data-module="govuk-details" style="margin: 0;">
         <summary style="cursor: pointer; list-style: none; display: flex; align-items: center; justify-content: space-between;">
-          <span class="govuk-heading-m" style="display: inline; margin: 0; color: {{ '#d4351c' if _has_issue else '#00703c' }};">
-            Endpoint URL in Doc URL
+          <span class="govuk-heading-m" style="display: inline; margin: 0; color: {{ _border_colour }};">
+            Endpoint URL in Source URL (documentation-url) Check
             {% if not doc_is_gov_uk %}
             <strong class="govuk-tag govuk-tag--red" style="margin-left: 10px; vertical-align: middle;">Non-gov.uk domain</strong>
             {% endif %}
-            <strong class="govuk-tag {{ 'govuk-tag--green' if _doc_found else 'govuk-tag--red' }}" style="margin-left: 6px; vertical-align: middle;">
-              {{ 'Found' if _doc_found else 'Not found' }}
-            </strong>
+            {% if not doc_is_gov_uk %}
+            <strong class="govuk-tag govuk-tag--red" style="margin-left: 6px; vertical-align: middle;">{{ 'Found' if _doc_found else ('Unable to access' if _access_error else 'Not found') }}</strong>
+            {% elif _doc_found %}
+            <strong class="govuk-tag govuk-tag--green" style="margin-left: 6px; vertical-align: middle;">Found</strong>
+            {% elif _access_error or endpoint_is_gov_uk %}
+            <strong class="govuk-tag govuk-tag--orange" style="margin-left: 6px; vertical-align: middle;">{{ 'Unable to access' if _access_error else 'Not found' }}</strong>
+            {% else %}
+            <strong class="govuk-tag govuk-tag--red" style="margin-left: 6px; vertical-align: middle;">Not found</strong>
+            {% endif %}
           </span>
-          <span class="govuk-body" style="margin: 0; font-size: 1.2em; color: {{ '#d4351c' if _has_issue else '#00703c' }};">&#9660;</span>
+          <span class="govuk-body" style="margin: 0; font-size: 1.2em; color: {{ _border_colour }};">&#9660;</span>
         </summary>
         <div class="govuk-!-margin-top-4">
           {% if not doc_is_gov_uk %}
@@ -205,11 +220,17 @@
           <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">Documentation URL</dt>
-              <dd class="govuk-summary-list__value"><a class="govuk-link" href="{{ documentation_url }}" target="_blank" rel="noopener noreferrer">{{ documentation_url }}</a></dd>
+              <dd class="govuk-summary-list__value">
+                <a class="govuk-link" href="{{ documentation_url }}" target="_blank" rel="noopener noreferrer" style="word-break: break-all;">{{ documentation_url }}</a>
+                <strong class="govuk-tag {{ 'govuk-tag--green' if doc_is_gov_uk else 'govuk-tag--red' }}" style="margin-left: 6px; vertical-align: middle; font-size: 0.75rem;">{{ 'gov.uk' if doc_is_gov_uk else 'non-gov.uk' }}</strong>
+              </dd>
             </div>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">Endpoint URL</dt>
-              <dd class="govuk-summary-list__value"><code style="word-break: break-all;">{{ endpoint_url }}</code></dd>
+              <dd class="govuk-summary-list__value">
+                <code style="word-break: break-all;">{{ endpoint_url }}</code>
+                <strong class="govuk-tag {{ 'govuk-tag--green' if endpoint_is_gov_uk else 'govuk-tag--grey' }}" style="margin-left: 6px; vertical-align: middle; font-size: 0.75rem;">{{ 'gov.uk' if endpoint_is_gov_uk else 'non-gov.uk' }}</strong>
+              </dd>
             </div>
             {% if _doc_found %}
             <div class="govuk-summary-list__row">
@@ -218,24 +239,18 @@
             </div>
             {% endif %}
           </dl>
-          {% if _doc_error %}
-          <div class="govuk-warning-text govuk-!-margin-bottom-0">
-            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-            <strong class="govuk-warning-text__text">
-              <span class="govuk-visually-hidden">Warning</span>
-              Could not check the documentation URL: {{ _doc_error }}
-            </strong>
-          </div>
-          {% elif _doc_found %}
+          {% if _doc_found %}
           <p class="govuk-body govuk-!-margin-bottom-0">The endpoint URL was found as a link on the documentation page.</p>
+          {% elif _access_error %}
+          <p class="govuk-body govuk-!-margin-bottom-1"><strong>The documentation URL could not be accessed.</strong></p>
+          <p class="govuk-body govuk-!-margin-bottom-1">Reason: {{ _access_error }}</p>
+          <p class="govuk-body govuk-!-margin-bottom-0">The page may require authentication or be temporarily unavailable. Please open the documentation URL manually to verify it is correct and publicly accessible.</p>
+          {% elif endpoint_is_gov_uk %}
+          <p class="govuk-body govuk-!-margin-bottom-1"><strong>The endpoint URL was not found as a direct link on this page.</strong></p>
+          <p class="govuk-body govuk-!-margin-bottom-0">The endpoint URL is on a gov.uk domain so this may be expected — some endpoint types such as ArcGIS or other map service URLs do not appear as clickable links even on the correct documentation page. Please open the documentation URL and confirm it refers to this dataset and endpoint.</p>
           {% else %}
-          <div class="govuk-warning-text govuk-!-margin-bottom-0">
-            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-            <strong class="govuk-warning-text__text">
-              <span class="govuk-visually-hidden">Warning</span>
-              The endpoint URL could not be found as a link on the documentation page. Please verify the documentation URL is correct and links to the endpoint.
-            </strong>
-          </div>
+          <p class="govuk-body govuk-!-margin-bottom-1"><strong>The endpoint URL was not found as a link on the documentation page and is not on a gov.uk domain.</strong></p>
+          <p class="govuk-body govuk-!-margin-bottom-0">This needs a manual check — please verify the documentation URL is the correct page for this dataset and that the endpoint URL is accurate. If the endpoint is an ArcGIS or other external map service, confirm it is still accessible and correctly referenced.</p>
           {% endif %}
         </div>
       </details>

--- a/application/templates/datamanager/check-transform.html
+++ b/application/templates/datamanager/check-transform.html
@@ -130,6 +130,13 @@
       </div>
     </div>
 
+    <ul class="govuk-list govuk-body-s govuk-!-margin-top-4 govuk-!-margin-bottom-2" style="color: #505a5f;">
+      <li><strong style="color: #00703c;">&#9679;</strong> <strong>Green</strong> — No action needed</li>
+      <li><strong style="color: #f47738;">&#9679;</strong> <strong>Orange</strong> — Manual check needed</li>
+      <li><strong style="color: #d4351c;">&#9679;</strong> <strong>Red</strong> — Sign off needed</li>
+      <li><strong style="color: #1d70b8;">&#9679;</strong> <strong>Blue</strong> — Optional action</li>
+    </ul>
+
     {% set _is_error = entity_growth_check.error %}
     <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-6" style="background-color: #f3f2f1; padding: 15px 20px; border-left: 4px solid {{ '#d4351c' if _is_error else '#00703c' }};">
       <details data-module="govuk-details" style="margin: 0;">
@@ -201,6 +208,9 @@
             <strong class="govuk-tag govuk-tag--green" style="margin-left: 6px; vertical-align: middle;">Found</strong>
             {% elif _access_error or endpoint_is_gov_uk %}
             <strong class="govuk-tag govuk-tag--orange" style="margin-left: 6px; vertical-align: middle;">{{ 'Unable to access' if _access_error else 'Not found' }}</strong>
+            {% if not _access_error and endpoint_is_gov_uk %}
+            <strong class="govuk-tag govuk-tag--green" style="margin-left: 6px; vertical-align: middle;">gov.uk domain</strong>
+            {% endif %}
             {% else %}
             <strong class="govuk-tag govuk-tag--red" style="margin-left: 6px; vertical-align: middle;">Not found</strong>
             {% endif %}

--- a/application/templates/datamanager/check-transform.html
+++ b/application/templates/datamanager/check-transform.html
@@ -174,6 +174,74 @@
       </details>
     </div>
 
+    {% if endpoint_url and documentation_url %}
+    {% set _doc_found = endpoint_in_doc.found %}
+    {% set _doc_error = endpoint_in_doc.error %}
+    {% set _has_issue = not _doc_found or not doc_is_gov_uk %}
+    <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-6" style="background-color: #f3f2f1; padding: 15px 20px; border-left: 4px solid {{ '#d4351c' if _has_issue else '#00703c' }};">
+      <details data-module="govuk-details" style="margin: 0;">
+        <summary style="cursor: pointer; list-style: none; display: flex; align-items: center; justify-content: space-between;">
+          <span class="govuk-heading-m" style="display: inline; margin: 0; color: {{ '#d4351c' if _has_issue else '#00703c' }};">
+            Endpoint URL in Doc URL
+            {% if not doc_is_gov_uk %}
+            <strong class="govuk-tag govuk-tag--red" style="margin-left: 10px; vertical-align: middle;">Non-gov.uk domain</strong>
+            {% endif %}
+            <strong class="govuk-tag {{ 'govuk-tag--green' if _doc_found else 'govuk-tag--red' }}" style="margin-left: 6px; vertical-align: middle;">
+              {{ 'Found' if _doc_found else 'Not found' }}
+            </strong>
+          </span>
+          <span class="govuk-body" style="margin: 0; font-size: 1.2em; color: {{ '#d4351c' if _has_issue else '#00703c' }};">&#9660;</span>
+        </summary>
+        <div class="govuk-!-margin-top-4">
+          {% if not doc_is_gov_uk %}
+          <div class="govuk-warning-text govuk-!-margin-bottom-4">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-visually-hidden">Warning</span>
+              The documentation URL is not on a gov.uk domain. Please confirm this is the correct page for this dataset.
+            </strong>
+          </div>
+          {% endif %}
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Documentation URL</dt>
+              <dd class="govuk-summary-list__value"><a class="govuk-link" href="{{ documentation_url }}" target="_blank" rel="noopener noreferrer">{{ documentation_url }}</a></dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Endpoint URL</dt>
+              <dd class="govuk-summary-list__value"><code style="word-break: break-all;">{{ endpoint_url }}</code></dd>
+            </div>
+            {% if _doc_found %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Matched link</dt>
+              <dd class="govuk-summary-list__value"><code style="word-break: break-all;">{{ endpoint_in_doc.matched_href }}</code></dd>
+            </div>
+            {% endif %}
+          </dl>
+          {% if _doc_error %}
+          <div class="govuk-warning-text govuk-!-margin-bottom-0">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-visually-hidden">Warning</span>
+              Could not check the documentation URL: {{ _doc_error }}
+            </strong>
+          </div>
+          {% elif _doc_found %}
+          <p class="govuk-body govuk-!-margin-bottom-0">The endpoint URL was found as a link on the documentation page.</p>
+          {% else %}
+          <div class="govuk-warning-text govuk-!-margin-bottom-0">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-visually-hidden">Warning</span>
+              The endpoint URL could not be found as a link on the documentation page. Please verify the documentation URL is correct and links to the endpoint.
+            </strong>
+          </div>
+          {% endif %}
+        </div>
+      </details>
+    </div>
+    {% endif %}
+
     {% if pipelines_append_required %}
     <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-6" style="background-color: #f3f2f1; padding: 15px 20px; border-left: 4px solid #f47738;">
       <details data-module="govuk-details" style="margin: 0;">
@@ -221,11 +289,15 @@
             {% for ep in existing_endpoints %}
             {% set ep_hash = ep.endpoint if ep is mapping else ep %}
             {% set ep_url = ep['endpoint-url'] if ep is mapping else ep %}
+            {% set ep_end_date = ep['end-date'] if ep is mapping else "" %}
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="retire-endpoint-{{ loop.index }}" name="retire_endpoints" type="checkbox" value="{{ ep_hash }}">
+              <input class="govuk-checkboxes__input" id="retire-endpoint-{{ loop.index }}" name="retire_endpoints" type="checkbox" value="{{ ep_hash }}" {% if ep_end_date %}disabled{% endif %}>
               <label class="govuk-label govuk-checkboxes__label" for="retire-endpoint-{{ loop.index }}">
                 <code style="word-break: break-all;">{{ ep_url }}</code>
                 <span class="govuk-hint govuk-!-margin-bottom-0" style="font-size: 0.8rem; word-break: break-all;">{{ ep_hash }}</span>
+                {% if ep_end_date %}
+                <span class="govuk-tag govuk-tag--grey" style="margin-top: 4px;">Already retired {{ ep_end_date }}</span>
+                {% endif %}
               </label>
             </div>
             {% endfor %}

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -165,6 +165,20 @@
       </div>
     </div><!-- /.govuk-grid-row -->
 
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">Data Explore</h2>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <a class="app-tools-list__item" href="https://digital-land.github.io/planning-data-flow/" target="_blank" rel="noopener noreferrer">
+          <div style="display:flex; justify-content:space-between; align-items:flex-start;">
+            <h3 class="govuk-heading-s app-tools-list__item__heading" style="margin-bottom:0;">Planning Data Flow</h3>
+            <strong class="govuk-tag govuk-tag--yellow" style="margin-left:8px; white-space:nowrap;">Demo</strong>
+          </div>
+          <p class="govuk-body govuk-!-margin-top-2">Explore and visualise the flow of planning data through the pipeline.</p>
+        </a>
+      </div>
+    </div><!-- /.govuk-grid-row -->
+
     <h2 class="govuk-heading-m govuk-!-margin-top-9">Sources and endpoints</h2>
 
     <div class="govuk-grid-row">

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -131,41 +131,28 @@
     </div><!-- /.govuk-grid-row -->
     {% endif %}
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-9">Configuration</h2>
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">Reporting</h2>
 
+    {% if not authentication_on or session['user'] %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-        <a class="app-tools-list__item" href="{{ url_for('dataset.index')}}">
-          <h3 class="govuk-heading-s app-tools-list__item__heading">Pipeline configuration for datasets</h3>
-          <p class="govuk-body">Configure the processing of source data into digital land datasets</p>
-        </a>
-      </div>
-    </div><!-- /.govuk-grid-row -->
-
-    <h2 class="govuk-heading-m govuk-!-margin-top-9">Reporting (under construction)</h2>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <a class="app-tools-list__item" href="{{ url_for('reporting.overview')}}">
+        <a class="app-tools-list__item" href="https://app.powerbi.com/groups/me/reports/9876ebce-899c-4703-8d61-934335d7a425/977eac7558000db9950d?ctid=bf346810-9c7d-43de-a872-24a2ef3995a8&experience=power-bi" target="_blank" rel="noopener noreferrer">
           <h3 class="govuk-heading-s app-tools-list__item__heading">Overview</h3>
-          <p class="govuk-body">General metrics on the platform</p>
-        </a>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <a class="app-tools-list__item" href="{{ url_for('reporting.overview_of_datasets')}}">
-          <h3 class="govuk-heading-s app-tools-list__item__heading">Overview of Datasets</h3>
-          <p class="govuk-body">An overview of the entire platform</p>
-        </a>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <a class="app-tools-list__item" href="{{ url_for('reporting.odp_status_summary')}}">
-          <h3 class="govuk-heading-s app-tools-list__item__heading">ODP Summary</h3>
-          <p class="govuk-body">Summary metrics for ODP cohorts</p>
+          <p class="govuk-body">Platform overview report in Power BI.</p>
         </a>
       </div>
     </div><!-- /.govuk-grid-row -->
+    {% else %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-inset-text">
+          <p class="govuk-body">You must be <a href="{{ url_for('auth.login') }}" class="govuk-link">logged in</a> to view reports.</p>
+        </div>
+      </div>
+    </div><!-- /.govuk-grid-row -->
+    {% endif %}
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-9">Data Explore</h2>
+<h2 class="govuk-heading-m govuk-!-margin-top-9">Data Explore</h2>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
@@ -177,40 +164,30 @@
           <p class="govuk-body govuk-!-margin-top-2">Explore and visualise the flow of planning data through the pipeline.</p>
         </a>
       </div>
-    </div><!-- /.govuk-grid-row -->
-
-    <h2 class="govuk-heading-m govuk-!-margin-top-9">Sources and endpoints</h2>
-
-    <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-        <a class="app-tools-list__item" href="{{ url_for('source.search') }}">
-          <h3 class="govuk-heading-s app-tools-list__item__heading">Find a source</h3>
-          <p class="govuk-body">Use this tool to find a source.</p>
-        </a>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <a class="app-tools-list__item" href="{{ url_for('source.add') }}">
-          <h3 class="govuk-heading-s app-tools-list__item__heading">Add a source</h3>
-          <p class="govuk-body">Use this tool to add new sources for a dataset.</p>
-        </a>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <a class="app-tools-list__item" href="{{ url_for('source.search') }}">
-          <h3 class="govuk-heading-s app-tools-list__item__heading">Edit source</h3>
-          <p class="govuk-body">Use this tool to edit a source.</p>
+        <a class="app-tools-list__item" href="https://datasette.planning.data.gov.uk/" target="_blank" rel="noopener noreferrer">
+          <h3 class="govuk-heading-s app-tools-list__item__heading">Datasette</h3>
+          <p class="govuk-body">SQL search across all platform data stored in S3.</p>
         </a>
       </div>
     </div><!-- /.govuk-grid-row -->
+
 
   </section>
 
   <section class="govuk-width-container app-tools-list">
     <h2 class="govuk-heading-m">Documentation</h2>
     <div class="govuk-grid-row">
+<div class="govuk-grid-column-one-third">
+        <a class="app-tools-list__item" href="https://digital-land.github.io/technical-documentation/" target="_blank" rel="noopener noreferrer">
+          <h3 class="govuk-heading-s app-tools-list__item__heading">Technical documentation</h3>
+          <p class="govuk-body">Technical reference for the Planning Data platform.</p>
+        </a>
+      </div>
       <div class="govuk-grid-column-one-third">
-        <a class="app-tools-list__item" href="https://docs.google.com/document/d/1F7dAbsRjallMzsgdPNhwszdzV9OpENx_rWWYssLxdvE/edit?usp=sharing">
-          <h3 class="govuk-heading-s app-tools-list__item__heading">Ops manual</h3>
-          <p class="govuk-body">Documentation for a set of data management related procedures.</p>
+        <a class="app-tools-list__item" href="https://handbook.planning.data.gov.uk/" target="_blank" rel="noopener noreferrer">
+          <h3 class="govuk-heading-s app-tools-list__item__heading">Handbook</h3>
+          <p class="govuk-body">Guidance and ways of working for the Planning Data team.</p>
         </a>
       </div>
     </div><!-- /.govuk-grid-row -->

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -136,7 +136,7 @@
     {% if not authentication_on or session['user'] %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-        <a class="app-tools-list__item" href="https://app.powerbi.com/groups/me/reports/9876ebce-899c-4703-8d61-934335d7a425/977eac7558000db9950d?ctid=bf346810-9c7d-43de-a872-24a2ef3995a8&experience=power-bi" target="_blank" rel="noopener noreferrer">
+        <a class="app-tools-list__item" href="https://app.powerbi.com/groups/me/reports/9876ebce-899c-4703-8d61-934335d7a425/977eac7558000db9950d" target="_blank" rel="noopener noreferrer">
           <h3 class="govuk-heading-s app-tools-list__item__heading">Overview</h3>
           <p class="govuk-body">Platform overview report in Power BI.</p>
         </a>

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -33,7 +33,7 @@
         "html": 'This is a new service – your <a class="govuk-link govuk-link--inverse" href="/feedback">feedback</a> will help us to improve it.',
         "classes": "app-masthead__phase-banner app-masthead__phase-banner--inverse"
       }) }}
-      <div class="govuk-grid-row">
+      <div class="govuk-grid-row" style="margin-top: 30px;">
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Manage Service</h1>
           <p class="govuk-body-l">A service to help manage the Planning Data Platform's configuration data and processing pipelines</p>

--- a/tests/unit/blueprints/datamanager/services/test_doc_crawler.py
+++ b/tests/unit/blueprints/datamanager/services/test_doc_crawler.py
@@ -1,0 +1,204 @@
+from unittest.mock import patch, Mock
+
+import requests as requests_lib
+
+from application.blueprints.datamanager.services.doc_crawler import (
+    _hrefs_match,
+    check_endpoint_in_doc,
+    is_gov_uk_url,
+)
+
+# Use unique (doc_url, endpoint_url) pairs per test to avoid @cache.memoize
+# collisions across tests (app fixture is session-scoped, so cache persists).
+DOC_URL = "https://www.example.gov.uk/data/"
+NON_GOV_DOC_URL = "https://www.council.org.uk/data/"
+ENDPOINT_URL = "https://maps.example.gov.uk/server/rest/services/data.geojson"
+
+
+class TestIsGovUkUrl:
+    def test_gov_uk_apex(self):
+        assert is_gov_uk_url("https://gov.uk/data") is True
+
+    def test_subdomain_of_gov_uk(self):
+        assert is_gov_uk_url("https://www.example.gov.uk/page") is True
+
+    def test_non_gov_uk_domain(self):
+        assert is_gov_uk_url("https://www.council.org.uk/page") is False
+
+    def test_empty_string(self):
+        assert is_gov_uk_url("") is False
+
+    def test_none(self):
+        assert is_gov_uk_url(None) is False
+
+    def test_gov_uk_in_path_not_hostname(self):
+        # hostname is arcgis.com, not gov.uk
+        assert is_gov_uk_url("https://arcgis.com/gov.uk/stuff") is False
+
+
+class TestHrefsMatch:
+    def test_exact_match(self):
+        assert _hrefs_match(ENDPOINT_URL, ENDPOINT_URL, DOC_URL) is True
+
+    def test_relative_href_resolves_to_endpoint(self):
+        # relative path resolved against DOC_URL gives ENDPOINT_URL
+        relative = "/server/rest/services/data.geojson"
+        resolved_endpoint = (
+            "https://www.example.gov.uk/server/rest/services/data.geojson"
+        )
+        assert _hrefs_match(relative, resolved_endpoint, DOC_URL) is True
+
+    def test_path_only_match(self):
+        endpoint = "https://maps.example.gov.uk/downloads/file/3149/data.csv"
+        assert _hrefs_match("/downloads/file/3149/data.csv", endpoint, DOC_URL) is True
+
+    def test_absolute_href_path_matches_endpoint_path(self):
+        href = "https://other.example.gov.uk/server/rest/services/data.geojson"
+        assert _hrefs_match(href, ENDPOINT_URL, DOC_URL) is True
+
+    def test_no_match(self):
+        assert (
+            _hrefs_match("https://unrelated.com/other", ENDPOINT_URL, DOC_URL) is False
+        )
+
+
+def _mock_response(text="", status_code=200, raise_for=None):
+    resp = Mock()
+    resp.text = text
+    resp.status_code = status_code
+    if raise_for:
+        resp.raise_for_status.side_effect = raise_for
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestCheckEndpointInDoc:
+    """
+    Covers the five accordion colour-logic scenarios:
+
+    | Doc gov.uk? | Found? | Access error? | Endpoint gov.uk? | Colour |
+    |-------------|--------|---------------|------------------|--------|
+    | any         | any    | any           | —  (no URL)      | —      |  → Missing URL error
+    | ✗           | any    | any           | any              | Red    |  → found/not-found, non-gov.uk doc
+    | ✓           | ✓      | —             | —                | Green  |  → found
+    | ✓           | ✗      | ✓             | —                | Orange |  → access error
+    | ✓           | ✗      | ✗             | ✓                | Orange |  → not found, gov.uk endpoint
+    | ✓           | ✗      | ✗             | ✗                | Red    |  → not found, non-gov.uk endpoint
+    """
+
+    def test_missing_documentation_url_returns_error(self, app):
+        with app.app_context():
+            result = check_endpoint_in_doc("", ENDPOINT_URL)
+        assert result["found"] is False
+        assert result["error"] == "Missing URL"
+
+    def test_missing_endpoint_url_returns_error(self, app):
+        with app.app_context():
+            result = check_endpoint_in_doc(DOC_URL, "")
+        assert result["found"] is False
+        assert result["error"] == "Missing URL"
+
+    def test_endpoint_found_in_doc_green(self, app):
+        """doc gov.uk + endpoint found → Green"""
+        doc = "https://www.example.gov.uk/data/found/"
+        ep = "https://maps.example.gov.uk/layer-found.geojson"
+        html = f'<html><body><a href="{ep}">link</a></body></html>'
+        with patch(
+            "application.blueprints.datamanager.services.doc_crawler.requests.get",
+            return_value=_mock_response(html),
+        ):
+            with app.app_context():
+                result = check_endpoint_in_doc(doc, ep)
+        assert result["found"] is True
+        assert result["matched_href"] == ep
+        assert result["error"] is None
+
+    def test_access_error_returns_error_string_orange(self, app):
+        """doc gov.uk + HTTP error → Orange (access error)"""
+        doc = "https://www.example.gov.uk/data/access-error/"
+        ep = "https://maps.example.gov.uk/layer-access-error.geojson"
+        exc = requests_lib.exceptions.RequestException("403 Forbidden")
+        with patch(
+            "application.blueprints.datamanager.services.doc_crawler.requests.get",
+            side_effect=exc,
+        ):
+            with app.app_context():
+                result = check_endpoint_in_doc(doc, ep)
+        assert result["found"] is False
+        assert result["error"] is not None
+        assert "403" in result["error"]
+
+    def test_timeout_returns_error_string_orange(self, app):
+        """doc gov.uk + timeout → Orange (access error)"""
+        doc = "https://www.example.gov.uk/data/timeout/"
+        ep = "https://maps.example.gov.uk/layer-timeout.geojson"
+        with patch(
+            "application.blueprints.datamanager.services.doc_crawler.requests.get",
+            side_effect=requests_lib.exceptions.Timeout(),
+        ):
+            with app.app_context():
+                result = check_endpoint_in_doc(doc, ep)
+        assert result["found"] is False
+        assert result["error"] is not None
+
+    def test_endpoint_not_found_gov_uk_endpoint_orange(self, app):
+        """doc gov.uk + not found + endpoint gov.uk → Orange"""
+        doc = "https://www.example.gov.uk/data/not-found-govuk/"
+        ep = "https://maps.example.gov.uk/layer-govuk-notfound.geojson"
+        html = "<html><body><a href='https://other.example.gov.uk/unrelated'>x</a></body></html>"
+        with patch(
+            "application.blueprints.datamanager.services.doc_crawler.requests.get",
+            return_value=_mock_response(html),
+        ):
+            with app.app_context():
+                result = check_endpoint_in_doc(doc, ep)
+        assert result["found"] is False
+        assert result["error"] is None
+        # Caller checks is_gov_uk_url(endpoint_url) to determine Orange vs Red
+        assert is_gov_uk_url(ep) is True
+
+    def test_endpoint_not_found_non_gov_uk_endpoint_red(self, app):
+        """doc gov.uk + not found + non-gov.uk endpoint → Red"""
+        doc = "https://www.example.gov.uk/data/not-found-nongov/"
+        ep = "https://services.arcgis.com/data/layer-nongov.geojson"
+        html = "<html><body><a href='https://other.example.gov.uk/unrelated'>x</a></body></html>"
+        with patch(
+            "application.blueprints.datamanager.services.doc_crawler.requests.get",
+            return_value=_mock_response(html),
+        ):
+            with app.app_context():
+                result = check_endpoint_in_doc(doc, ep)
+        assert result["found"] is False
+        assert result["error"] is None
+        assert is_gov_uk_url(ep) is False
+
+    def test_non_gov_uk_doc_url_endpoint_found_still_red(self, app):
+        """non-gov.uk doc + found → Red (caller checks is_gov_uk_url(doc_url))"""
+        doc = "https://www.council.org.uk/data/found/"
+        ep = "https://maps.example.gov.uk/layer-nongov-doc-found.geojson"
+        html = f'<html><body><a href="{ep}">link</a></body></html>'
+        with patch(
+            "application.blueprints.datamanager.services.doc_crawler.requests.get",
+            return_value=_mock_response(html),
+        ):
+            with app.app_context():
+                result = check_endpoint_in_doc(doc, ep)
+        assert result["found"] is True
+        # Caller checks is_gov_uk_url(doc_url) to determine the Red override
+        assert is_gov_uk_url(doc) is False
+
+    def test_non_gov_uk_doc_url_endpoint_not_found_red(self, app):
+        """non-gov.uk doc + not found → Red"""
+        doc = "https://www.council.org.uk/data/not-found/"
+        ep = "https://maps.example.gov.uk/layer-nongov-doc-notfound.geojson"
+        html = "<html><body><a href='https://unrelated.org.uk/page'>x</a></body></html>"
+        with patch(
+            "application.blueprints.datamanager.services.doc_crawler.requests.get",
+            return_value=_mock_response(html),
+        ):
+            with app.app_context():
+                result = check_endpoint_in_doc(doc, ep)
+        assert result["found"] is False
+        assert result["error"] is None
+        assert is_gov_uk_url(doc) is False


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Few things added here:

1. No longer use error summary or column field log from the async as these are set to be removed in the near future.
2. Endpoint URL's now will show if they are retired and can't be selected.

<img width="1117" height="668" alt="image" src="https://github.com/user-attachments/assets/7251b38c-72f6-44a2-a478-b1ec69ddd2b0" />

3. Check in the data submission page if the endpoint URL exists in the documentation URL as a safety check 

<img width="1117" height="367" alt="image" src="https://github.com/user-attachments/assets/b0eced50-2f7e-41cb-bf47-faec28119ded" />

4. Also added a link to the demo planning data flow app.

<img width="494" height="392" alt="image" src="https://github.com/user-attachments/assets/97af9a2a-f3ae-4671-ae37-565f29914bd9" />

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=178524033&issue=digital-land%7Casync-request-backend%7C105
- Ticket Link https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=189060433&issue=digital-land%7Cconfig%7C2610

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Endpoint documentation validation added (checks if an endpoint URL appears in its docs, with gov.uk detection) and a new “Endpoint URL in Doc” panel showing status, matched link and domain tags.
  * Coloured action legend added to transform pages.
  * New “Data Explore” section and updated Reporting area on the landing page (external report cards).

* **Bug Fixes / Improvements**
  * Check results and column-mapping displays revised for clearer must-fix / fixable / passed checks.
  * Transformed tables now include additional detected columns.
  * Endpoint retirement dates shown with disabled controls and “Already retired” status.

* **Other**
  * CSV preview now supports injecting/overriding pipeline values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digital-land/config-manager/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->