### PR TITLE
Feat/magic link support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,8 @@ ignore = W291, E203, W503
 exclude =
     __pycache__
     node_modules
-		.venv
-		migrations
+    .venv
+    migrations
+    .history
 
 ; vim: ft=dosini

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+.history/
 # C extensions
 *.so
 

--- a/application/blueprints/datamanager/controllers/form.py
+++ b/application/blueprints/datamanager/controllers/form.py
@@ -42,6 +42,7 @@ def _is_admin():
     current_user = (session.get("user") or {}).get("login", "")
     return current_user.lower() in get_allowed_override_users()
 
+
 def _organisation_display_name(org_code: str, org_values: list) -> str:
     for org in org_values:
         if org.get("code") == org_code:

--- a/application/blueprints/datamanager/controllers/form.py
+++ b/application/blueprints/datamanager/controllers/form.py
@@ -64,15 +64,12 @@ def handle_dashboard_get():
         return jsonify(org_values)
 
     # Pre-fill form from request parameters.
-    if (
-        request.args.get("import_data") != "true"
-        and (
-            request.args.get("requestId")
-            or request.args.get("dataset")
-            or request.args.get("organisationId")
-            or request.args.get("geometryType")
-            or request.args.get("geom_type")
-        )
+    if request.args.get("import_data") != "true" and (
+        request.args.get("requestId")
+        or request.args.get("dataset")
+        or request.args.get("organisationId")
+        or request.args.get("geometryType")
+        or request.args.get("geom_type")
     ):
         request_id = request.args.get("requestId", "")
         dataset_param = request.args.get("dataset", "")

--- a/application/blueprints/datamanager/controllers/form.py
+++ b/application/blueprints/datamanager/controllers/form.py
@@ -63,13 +63,16 @@ def handle_dashboard_get():
             return jsonify([])
         return jsonify(org_values)
 
-    # Pre-fill form from request parameters (requestId, dataset, organisationId, endpointUrl, documentationUrl, jiraIssueId, geometryType)
+    # Pre-fill form from request parameters.
     if (
-        request.args.get("requestId")
-        or request.args.get("dataset")
-        or request.args.get("organisationId")
-        or request.args.get("geometryType")
-        or request.args.get("geom_type")
+        request.args.get("import_data") != "true"
+        and (
+            request.args.get("requestId")
+            or request.args.get("dataset")
+            or request.args.get("organisationId")
+            or request.args.get("geometryType")
+            or request.args.get("geom_type")
+        )
     ):
         request_id = request.args.get("requestId", "")
         dataset_param = request.args.get("dataset", "")

--- a/application/blueprints/datamanager/controllers/form.py
+++ b/application/blueprints/datamanager/controllers/form.py
@@ -80,7 +80,9 @@ def handle_dashboard_get():
         endpoint_url = request.args.get("endpointUrl", "")
         doc_url = request.args.get("documentationUrl", "")
         jira_issue_id = request.args.get("jiraIssueId", "")
-        geom_type = request.args.get("geometryType", request.args.get("geom_type", "")).strip()
+        geom_type = request.args.get(
+            "geometryType", request.args.get("geom_type", "")
+        ).strip()
 
         if dataset_id:
             org_codes = get_provision_orgs_for_dataset(dataset_id)
@@ -266,7 +268,9 @@ def handle_dashboard_add():
             )
 
             if params_unchanged:
-                logger.info(f"Reusing request ID: {original_request_id} (params unchanged)")
+                logger.info(
+                    f"Reusing request ID: {original_request_id} (params unchanged)"
+                )
                 request_id = original_request_id
             else:
                 request_id = submit_request(payload["params"])

--- a/application/blueprints/datamanager/controllers/form.py
+++ b/application/blueprints/datamanager/controllers/form.py
@@ -40,6 +40,8 @@ def handle_dashboard_get():
     errors = {}
     org_values = []
     dataset_input = ""
+    request_id = ""
+    prefilled_values = {}  # Track original prefilled values for change detection
 
     # Autocomplete dataset names for UI suggestions
     if request.args.get("autocomplete"):
@@ -61,8 +63,51 @@ def handle_dashboard_get():
             return jsonify([])
         return jsonify(org_values)
 
+    # Pre-fill form from request parameters (requestId, dataset, organisationId, endpointUrl, documentationUrl, jiraIssueId, geometryType)
+    if (
+        request.args.get("requestId")
+        or request.args.get("dataset")
+        or request.args.get("organisationId")
+        or request.args.get("geometryType")
+        or request.args.get("geom_type")
+    ):
+        request_id = request.args.get("requestId", "")
+        dataset_param = request.args.get("dataset", "")
+        dataset_input = get_dataset_name(dataset_param, default=dataset_param)
+        dataset_id = get_dataset_id(dataset_input) if dataset_input else ""
+
+        org_value = request.args.get("organisationId", "")
+        endpoint_url = request.args.get("endpointUrl", "")
+        doc_url = request.args.get("documentationUrl", "")
+        jira_issue_id = request.args.get("jiraIssueId", "")
+        geom_type = request.args.get("geometryType", request.args.get("geom_type", "")).strip()
+
+        if dataset_id:
+            org_codes = get_provision_orgs_for_dataset(dataset_id)
+            org_values = format_org_options(org_codes)
+
+        form = {
+            "dataset": dataset_input,
+            "organisation": org_value,
+            "endpoint_url": endpoint_url,
+            "documentation_url": doc_url,
+            "jira_issue_id": jira_issue_id,
+            "geom_type": geom_type,
+        }
+
+        # Store original prefilled values for comparison during submission
+        prefilled_values = {
+            "request_id": request_id,
+            "dataset": dataset_input,
+            "organisation": org_value,
+            "endpoint_url": endpoint_url,
+            "documentation_url": doc_url,
+            "jira_issue_id": jira_issue_id,
+            "geom_type": geom_type,
+        }
+
     # Pre-fill form from imported CSV data if available
-    if request.args.get("import_data") == "true":
+    elif request.args.get("import_data") == "true":
         csv_dataset_id = request.args.get("dataset", "")
         dataset_input = get_dataset_name(csv_dataset_id, default=csv_dataset_id)
         dataset_id = csv_dataset_id
@@ -108,6 +153,8 @@ def handle_dashboard_get():
         org_values=org_values,
         form=form,
         errors=errors,
+        request_id=request_id,
+        prefilled_values=prefilled_values,
     )
 
 
@@ -115,6 +162,14 @@ def handle_dashboard_get():
 def handle_dashboard_add():
     form = request.form.to_dict()
     errors = {}
+
+    # Check if this is a re-submission of prefilled params
+    original_request_id = form.get("original_request_id", "").strip()
+    original_dataset = form.get("original_dataset", "").strip()
+    original_organisation = form.get("original_organisation", "").strip()
+    original_endpoint_url = form.get("original_endpoint_url", "").strip()
+    original_documentation_url = form.get("original_documentation_url", "").strip()
+    original_jira_issue_id = form.get("original_jira_issue_id", "").strip()
 
     # Set the the dataset id and collection id.
     dataset_input = form.get("dataset", "").strip()
@@ -131,6 +186,7 @@ def handle_dashboard_add():
     org_code_input = form.get("organisation", "").strip()
     endpoint_url = form.get("endpoint_url", "").strip()
     doc_url = form.get("documentation_url", "").strip()
+    jira_issue_id = form.get("jira_issue_id", "").strip()
     licence = (form.get("licence") or "ogl3").strip().lower()
     authoritative = form.get("authoritative", "").strip().lower() or None
 
@@ -182,7 +238,9 @@ def handle_dashboard_add():
                 "url": endpoint_url,
                 "organisationName": org_code_input,
                 "geom_type": geom_type,
+                "geometryType": geom_type,
                 "column_mapping": column_mapping or None,
+                "jiraIssueId": jira_issue_id or None,
             }
         }
         session["add_data_fields"] = {
@@ -192,10 +250,26 @@ def handle_dashboard_add():
             "column_mapping": {},
             "authoritative": authoritative == "yes",
             "github_new": form.get("github_new", "true").strip() != "false",
+            "jira_issue_id": jira_issue_id,
         }
 
         try:
-            request_id = submit_request(payload["params"])
+            # Check if prefilled params have changed
+            params_unchanged = (
+                original_request_id
+                and dataset_input == original_dataset
+                and org_code_input == original_organisation
+                and endpoint_url == original_endpoint_url
+                and doc_url == original_documentation_url
+                and jira_issue_id == original_jira_issue_id
+                and geom_type == form.get("original_geom_type", "").strip()
+            )
+
+            if params_unchanged:
+                logger.info(f"Reusing request ID: {original_request_id} (params unchanged)")
+                request_id = original_request_id
+            else:
+                request_id = submit_request(payload["params"])
             return redirect(
                 url_for(
                     "datamanager.check_results",

--- a/application/blueprints/datamanager/controllers/form.py
+++ b/application/blueprints/datamanager/controllers/form.py
@@ -35,13 +35,21 @@ from ..services.organisation import (
 logger = logging.getLogger(__name__)
 
 
+def _organisation_display_name(org_code: str, org_values: list) -> str:
+    for org in org_values:
+        if org.get("code") == org_code:
+            return org.get("label", org_code)
+
+    return org_code
+
+
 def handle_dashboard_get():
     form = {}
     errors = {}
     org_values = []
     dataset_input = ""
     request_id = ""
-    prefilled_values = {}  # Track original prefilled values for change detection
+    prefilled_values = {}
 
     # Autocomplete dataset names for UI suggestions
     if request.args.get("autocomplete"):
@@ -63,15 +71,70 @@ def handle_dashboard_get():
             return jsonify([])
         return jsonify(org_values)
 
-    # Pre-fill form from request parameters.
-    if request.args.get("import_data") != "true" and (
-        request.args.get("requestId")
-        or request.args.get("dataset")
+    # Pre-fill form from request details when a request ID is provided.
+    if request.args.get("import_data") != "true" and request.args.get("requestId"):
+        request_id = request.args.get("requestId", "")
+        request_params = {}
+        try:
+            request_params = fetch_request(request_id).get("params", {})
+        except AsyncAPIError as e:
+            logger.warning(f"Could not fetch request details for {request_id}: {e}")
+            request_id = ""
+
+        if request_params:
+            dataset_param = request_params.get("dataset", "")
+            dataset_input = get_dataset_name(dataset_param, default=dataset_param)
+            dataset_id = get_dataset_id(dataset_input) if dataset_input else ""
+
+            org_value = (
+                request_params.get("organisationName")
+                or request_params.get("organisation")
+                or ""
+            )
+            endpoint_url = request_params.get("url", "")
+            doc_url = (
+                request_params.get("documentation_url")
+                or request_params.get("documentationUrl")
+                or request.args.get("documentationUrl", "")
+            )
+            geom_type = (
+                request_params.get("geom_type")
+                or request_params.get("geometryType")
+                or ""
+            ).strip()
+
+            if dataset_id:
+                org_codes = get_provision_orgs_for_dataset(dataset_id)
+                org_values = format_org_options(org_codes)
+
+            form = {
+                "dataset": dataset_input,
+                "organisation": org_value,
+                "organisation_display_name": _organisation_display_name(
+                    org_value, org_values
+                ),
+                "endpoint_url": endpoint_url,
+                "documentation_url": doc_url,
+                "geom_type": geom_type,
+            }
+
+            # Store original prefilled values for comparison during submission
+            prefilled_values = {
+                "request_id": request_id,
+                "dataset": dataset_input,
+                "organisation": org_value,
+                "endpoint_url": endpoint_url,
+                "documentation_url": doc_url,
+                "geom_type": geom_type,
+            }
+
+    # Pre-fill form from explicit request parameters.
+    elif request.args.get("import_data") != "true" and (
+        request.args.get("dataset")
         or request.args.get("organisationId")
         or request.args.get("geometryType")
         or request.args.get("geom_type")
     ):
-        request_id = request.args.get("requestId", "")
         dataset_param = request.args.get("dataset", "")
         dataset_input = get_dataset_name(dataset_param, default=dataset_param)
         dataset_id = get_dataset_id(dataset_input) if dataset_input else ""
@@ -79,9 +142,8 @@ def handle_dashboard_get():
         org_value = request.args.get("organisationId", "")
         endpoint_url = request.args.get("endpointUrl", "")
         doc_url = request.args.get("documentationUrl", "")
-        jira_issue_id = request.args.get("jiraIssueId", "")
-        geom_type = request.args.get(
-            "geometryType", request.args.get("geom_type", "")
+        geom_type = (
+            request.args.get("geometryType") or request.args.get("geom_type", "")
         ).strip()
 
         if dataset_id:
@@ -91,20 +153,21 @@ def handle_dashboard_get():
         form = {
             "dataset": dataset_input,
             "organisation": org_value,
+            "organisation_display_name": _organisation_display_name(
+                org_value, org_values
+            ),
             "endpoint_url": endpoint_url,
             "documentation_url": doc_url,
-            "jira_issue_id": jira_issue_id,
             "geom_type": geom_type,
         }
 
         # Store original prefilled values for comparison during submission
         prefilled_values = {
-            "request_id": request_id,
+            "request_id": "",
             "dataset": dataset_input,
             "organisation": org_value,
             "endpoint_url": endpoint_url,
             "documentation_url": doc_url,
-            "jira_issue_id": jira_issue_id,
             "geom_type": geom_type,
         }
 
@@ -156,6 +219,7 @@ def handle_dashboard_get():
         form=form,
         errors=errors,
         request_id=request_id,
+        is_magic_link_prefilled=bool(prefilled_values),
         prefilled_values=prefilled_values,
     )
 
@@ -164,14 +228,7 @@ def handle_dashboard_get():
 def handle_dashboard_add():
     form = request.form.to_dict()
     errors = {}
-
-    # Check if this is a re-submission of prefilled params
-    original_request_id = form.get("original_request_id", "").strip()
-    original_dataset = form.get("original_dataset", "").strip()
-    original_organisation = form.get("original_organisation", "").strip()
-    original_endpoint_url = form.get("original_endpoint_url", "").strip()
-    original_documentation_url = form.get("original_documentation_url", "").strip()
-    original_jira_issue_id = form.get("original_jira_issue_id", "").strip()
+    request_id = form.get("request_id", "").strip()
 
     # Set the the dataset id and collection id.
     dataset_input = form.get("dataset", "").strip()
@@ -188,7 +245,6 @@ def handle_dashboard_add():
     org_code_input = form.get("organisation", "").strip()
     endpoint_url = form.get("endpoint_url", "").strip()
     doc_url = form.get("documentation_url", "").strip()
-    jira_issue_id = form.get("jira_issue_id", "").strip()
     licence = (form.get("licence") or "ogl3").strip().lower()
     authoritative = form.get("authoritative", "").strip().lower() or None
 
@@ -242,7 +298,6 @@ def handle_dashboard_add():
                 "geom_type": geom_type,
                 "geometryType": geom_type,
                 "column_mapping": column_mapping or None,
-                "jiraIssueId": jira_issue_id or None,
             }
         }
         session["add_data_fields"] = {
@@ -252,26 +307,11 @@ def handle_dashboard_add():
             "column_mapping": {},
             "authoritative": authoritative == "yes",
             "github_new": form.get("github_new", "true").strip() != "false",
-            "jira_issue_id": jira_issue_id,
         }
 
         try:
-            # Check if prefilled params have changed
-            params_unchanged = (
-                original_request_id
-                and dataset_input == original_dataset
-                and org_code_input == original_organisation
-                and endpoint_url == original_endpoint_url
-                and doc_url == original_documentation_url
-                and jira_issue_id == original_jira_issue_id
-                and geom_type == form.get("original_geom_type", "").strip()
-            )
-
-            if params_unchanged:
-                logger.info(
-                    f"Reusing request ID: {original_request_id} (params unchanged)"
-                )
-                request_id = original_request_id
+            if request_id:
+                logger.info(f"Reusing request ID: {request_id}")
             else:
                 request_id = submit_request(payload["params"])
             return redirect(
@@ -290,6 +330,8 @@ def handle_dashboard_add():
         org_values=org_values,
         form=form,
         errors=errors,
+        is_magic_link_prefilled=False,
+        prefilled_values={},
     )
 
 

--- a/application/blueprints/datamanager/controllers/form.py
+++ b/application/blueprints/datamanager/controllers/form.py
@@ -49,7 +49,6 @@ def handle_dashboard_get():
     org_values = []
     dataset_input = ""
     request_id = ""
-    prefilled_values = {}
 
     # Autocomplete dataset names for UI suggestions
     if request.args.get("autocomplete"):
@@ -71,7 +70,7 @@ def handle_dashboard_get():
             return jsonify([])
         return jsonify(org_values)
 
-    # Pre-fill form from request details when a request ID is provided.
+    # Pre-fill form from async request details when a request ID is provided.
     if request.args.get("import_data") != "true" and request.args.get("requestId"):
         request_id = request.args.get("requestId", "")
         request_params = {}
@@ -86,22 +85,10 @@ def handle_dashboard_get():
             dataset_input = get_dataset_name(dataset_param, default=dataset_param)
             dataset_id = get_dataset_id(dataset_input) if dataset_input else ""
 
-            org_value = (
-                request_params.get("organisationName")
-                or request_params.get("organisation")
-                or ""
-            )
+            org_value = request_params.get("organisationName", "")
             endpoint_url = request_params.get("url", "")
-            doc_url = (
-                request_params.get("documentation_url")
-                or request_params.get("documentationUrl")
-                or request.args.get("documentationUrl", "")
-            )
-            geom_type = (
-                request_params.get("geom_type")
-                or request_params.get("geometryType")
-                or ""
-            ).strip()
+            doc_url = request.args.get("documentationUrl", "")
+            geom_type = (request_params.get("geom_type") or "").strip()
 
             if dataset_id:
                 org_codes = get_provision_orgs_for_dataset(dataset_id)
@@ -117,59 +104,6 @@ def handle_dashboard_get():
                 "documentation_url": doc_url,
                 "geom_type": geom_type,
             }
-
-            # Store original prefilled values for comparison during submission
-            prefilled_values = {
-                "request_id": request_id,
-                "dataset": dataset_input,
-                "organisation": org_value,
-                "endpoint_url": endpoint_url,
-                "documentation_url": doc_url,
-                "geom_type": geom_type,
-            }
-
-    # Pre-fill form from explicit request parameters.
-    elif request.args.get("import_data") != "true" and (
-        request.args.get("dataset")
-        or request.args.get("organisationId")
-        or request.args.get("geometryType")
-        or request.args.get("geom_type")
-    ):
-        dataset_param = request.args.get("dataset", "")
-        dataset_input = get_dataset_name(dataset_param, default=dataset_param)
-        dataset_id = get_dataset_id(dataset_input) if dataset_input else ""
-
-        org_value = request.args.get("organisationId", "")
-        endpoint_url = request.args.get("endpointUrl", "")
-        doc_url = request.args.get("documentationUrl", "")
-        geom_type = (
-            request.args.get("geometryType") or request.args.get("geom_type", "")
-        ).strip()
-
-        if dataset_id:
-            org_codes = get_provision_orgs_for_dataset(dataset_id)
-            org_values = format_org_options(org_codes)
-
-        form = {
-            "dataset": dataset_input,
-            "organisation": org_value,
-            "organisation_display_name": _organisation_display_name(
-                org_value, org_values
-            ),
-            "endpoint_url": endpoint_url,
-            "documentation_url": doc_url,
-            "geom_type": geom_type,
-        }
-
-        # Store original prefilled values for comparison during submission
-        prefilled_values = {
-            "request_id": "",
-            "dataset": dataset_input,
-            "organisation": org_value,
-            "endpoint_url": endpoint_url,
-            "documentation_url": doc_url,
-            "geom_type": geom_type,
-        }
 
     # Pre-fill form from imported CSV data if available
     elif request.args.get("import_data") == "true":
@@ -219,8 +153,7 @@ def handle_dashboard_get():
         form=form,
         errors=errors,
         request_id=request_id,
-        is_magic_link_prefilled=bool(prefilled_values),
-        prefilled_values=prefilled_values,
+        is_magic_link_prefilled=bool(request_id),
     )
 
 
@@ -331,7 +264,7 @@ def handle_dashboard_add():
         form=form,
         errors=errors,
         is_magic_link_prefilled=False,
-        prefilled_values={},
+        request_id="",
     )
 
 

--- a/application/blueprints/datamanager/controllers/form.py
+++ b/application/blueprints/datamanager/controllers/form.py
@@ -43,6 +43,15 @@ def _organisation_display_name(org_code: str, org_values: list) -> str:
     return org_code
 
 
+def _get_org_values_for_dataset(dataset_id: str) -> list:
+    try:
+        org_codes = get_provision_orgs_for_dataset(dataset_id)
+        return format_org_options(org_codes)
+    except Exception as e:
+        logger.warning(f"Failed to fetch organisations for {dataset_id}: {e}")
+        return []
+
+
 def handle_dashboard_get():
     form = {}
     errors = {}
@@ -91,8 +100,7 @@ def handle_dashboard_get():
             geom_type = (request_params.get("geom_type") or "").strip()
 
             if dataset_id:
-                org_codes = get_provision_orgs_for_dataset(dataset_id)
-                org_values = format_org_options(org_codes)
+                org_values = _get_org_values_for_dataset(dataset_id)
 
             form = {
                 "dataset": dataset_input,
@@ -113,8 +121,7 @@ def handle_dashboard_get():
 
         org_value = request.args.get("organisation", "")
         if dataset_id:
-            org_codes = get_provision_orgs_for_dataset(dataset_id)
-            org_values = format_org_options(org_codes)
+            org_values = _get_org_values_for_dataset(dataset_id)
 
         form = {
             "dataset": dataset_input,
@@ -169,13 +176,12 @@ def handle_dashboard_add():
     collection_id = get_collection_id(dataset_input)
 
     # Get list of orgs provisioned for this dataset in both code and display format.
-    org_codes = []
     org_values = []
     if dataset_id:
-        org_codes = get_provision_orgs_for_dataset(dataset_id)
-        org_values = format_org_options(org_codes)
+        org_values = _get_org_values_for_dataset(dataset_id)
 
-    org_code_input = form.get("organisation", "").strip()
+    submitted_org_code = form.get("organisation", "").strip()
+    org_code_input = submitted_org_code
     endpoint_url = form.get("endpoint_url", "").strip()
     doc_url = form.get("documentation_url", "").strip()
     licence = (form.get("licence") or "ogl3").strip().lower()
@@ -229,7 +235,6 @@ def handle_dashboard_add():
                 "url": endpoint_url,
                 "organisationName": org_code_input,
                 "geom_type": geom_type,
-                "geometryType": geom_type,
                 "column_mapping": column_mapping or None,
             }
         }
@@ -246,6 +251,7 @@ def handle_dashboard_add():
             if request_id:
                 logger.info(f"Reusing request ID: {request_id}")
             else:
+                logger.info("Creating a new check request")
                 request_id = submit_request(payload["params"])
             return redirect(
                 url_for(
@@ -257,14 +263,19 @@ def handle_dashboard_add():
             raise Exception(f"Check tool submission failed: {e.detail}") from e
 
     # Re-render form with errors
+    if request_id:
+        form["organisation_display_name"] = _organisation_display_name(
+            submitted_org_code, org_values
+        )
+
     return render_template(
         "datamanager/dashboard_add.html",
         dataset_input=dataset_input,
         org_values=org_values,
         form=form,
         errors=errors,
-        is_magic_link_prefilled=False,
-        request_id="",
+        is_magic_link_prefilled=bool(request_id),
+        request_id=request_id,
     )
 
 

--- a/application/templates/datamanager/dashboard_add.html
+++ b/application/templates/datamanager/dashboard_add.html
@@ -11,16 +11,11 @@ endblock %}
 
 {% block content %}
 {% set magic_link_hint = 'This value has been prefilled from the magic link and cannot be changed here.' %}
-{% set prefilled_dataset = prefilled_values.get('dataset') if prefilled_values else '' %}
-{% set prefilled_organisation = prefilled_values.get('organisation') if prefilled_values else '' %}
-{% set prefilled_endpoint_url = prefilled_values.get('endpoint_url') if prefilled_values else '' %}
-{% set prefilled_documentation_url = prefilled_values.get('documentation_url') if prefilled_values else '' %}
-{% set prefilled_geom_type = prefilled_values.get('geom_type') if prefilled_values else '' %}
-{% set is_magic_link_prefilled = prefilled_values %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Check and Add Planning data</h1>
+    {% if not is_magic_link_prefilled %}
     <div style="display:flex; gap: 1rem; align-items: center; margin-bottom: 1rem;">
       {% if is_magic_link_prefilled %}
       <a class="govuk-button govuk-button--disabled govuk-!-margin-bottom-0" role="link" aria-disabled="true" tabindex="-1" data-module="govuk-button">Import from CSV</a>
@@ -33,6 +28,7 @@ endblock %}
         <button type="button" class="govuk-button govuk-!-margin-bottom-0" onclick="document.getElementById('csv-file-upload').click()" {% if is_magic_link_prefilled %}disabled aria-disabled="true"{% endif %}>Upload CSV file</button>
       </form>
     </div>
+    {% endif %}
   </div>
 </div>
 
@@ -51,8 +47,8 @@ endblock %}
         <h2 class="govuk-error-summary__title">There is a problem</h2>
         <div class="govuk-error-summary__body">
           <ul class="govuk-list govuk-error-summary__list">
-            {% if dataset_error %}<li><a href="#dataset-autocomplete">Select a dataset</a></li>{% endif %}
-            {% if organisation_error %}<li><a href="#organisation">Enter your organisation</a></li>{% endif %}
+            {% if dataset_error %}<li><a href="#{% if is_magic_link_prefilled and form.dataset %}dataset-display{% else %}dataset-autocomplete{% endif %}">Select a dataset</a></li>{% endif %}
+            {% if organisation_error %}<li><a href="#{% if is_magic_link_prefilled and form.organisation %}organisation-display{% else %}organisation{% endif %}">Enter your organisation</a></li>{% endif %}
             {% if environment_error %}<li><a href="#endpoint-url">Enter a valid endpoint URL</a></li>{% endif %}
             {% if documentation_error %}<li><a href="#documentation-url">Enter a valid documentation URL</a></li>{%
             endif %}
@@ -65,15 +61,15 @@ endblock %}
 
       <!-- Dataset autocomplete -->
       <div class="govuk-form-group {% if dataset_error %}govuk-form-group--error{% endif %}">
-        <label class="govuk-label" for="{% if prefilled_dataset %}dataset-display{% else %}dataset-autocomplete{% endif %}">Dataset name <span class="govuk-required">*</span></label>
+        <label class="govuk-label" for="{% if is_magic_link_prefilled and form.dataset %}dataset-display{% else %}dataset-autocomplete{% endif %}">Dataset name <span class="govuk-required">*</span></label>
         {% if dataset_error %}
         <p class="govuk-error-message">
           <span class="govuk-visually-hidden">Error:</span> Select a dataset
         </p>
         {% endif %}
-        {% if prefilled_dataset %}
+        {% if is_magic_link_prefilled and form.dataset %}
         <div id="dataset-display-hint" class="govuk-hint">{{ magic_link_hint }}</div>
-        <input class="govuk-input app-text-input__readonly" id="dataset-display" name="dataset_display" type="text" value="{{ prefilled_dataset }}" readonly aria-describedby="dataset-display-hint">
+        <input class="govuk-input app-text-input__readonly" id="dataset-display" name="dataset_display" type="text" value="{{ form.dataset or dataset_input }}" readonly aria-describedby="dataset-display-hint">
         {% else %}
         <div id="autocomplete-container"></div>
         {% endif %}
@@ -82,15 +78,15 @@ endblock %}
 
       <!-- Organisation autocomplete -->
       <div class="govuk-form-group {% if organisation_error %}govuk-form-group--error{% endif %}">
-        <label class="govuk-label" for="{% if prefilled_organisation %}organisation-display{% else %}organisation{% endif %}">Organisation <span class="govuk-required">*</span></label>
+        <label class="govuk-label" for="{% if is_magic_link_prefilled and form.organisation %}organisation-display{% else %}organisation{% endif %}">Organisation <span class="govuk-required">*</span></label>
         {% if organisation_error %}
         <p class="govuk-error-message">
           <span class="govuk-visually-hidden">Error:</span> Enter a valid organisation
         </p>
         {% endif %}
-        {% if prefilled_organisation %}
+        {% if is_magic_link_prefilled and form.organisation %}
         <div id="organisation-display-hint" class="govuk-hint">{{ magic_link_hint }}</div>
-        <input class="govuk-input app-text-input__readonly" id="organisation-display" name="organisation_display" type="text" value="{{ prefilled_organisation }}" readonly aria-describedby="organisation-display-hint">
+        <input class="govuk-input app-text-input__readonly" id="organisation-display" name="organisation_display" type="text" value="{{ form.get('organisation_display_name', form.organisation) }}" readonly aria-describedby="organisation-display-hint">
         {% else %}
         <div id="org-autocomplete-container">
           <div id="org-autocomplete-wrapper"></div>
@@ -100,35 +96,29 @@ endblock %}
         <input type="hidden" name="org_warning" id="org-warning" value="false">
       </div>
 
-      <!-- Original prefilled values (for change detection) -->
-      {% if prefilled_values %}
-      <input type="hidden" name="original_request_id" value="{{ prefilled_values.get('request_id', '') }}">
-      <input type="hidden" name="original_dataset" value="{{ prefilled_values.get('dataset', '') }}">
-      <input type="hidden" name="original_organisation" value="{{ prefilled_values.get('organisation', '') }}">
-      <input type="hidden" name="original_endpoint_url" value="{{ prefilled_values.get('endpoint_url', '') }}">
-      <input type="hidden" name="original_documentation_url" value="{{ prefilled_values.get('documentation_url', '') }}">
-      <input type="hidden" name="original_jira_issue_id" value="{{ prefilled_values.get('jira_issue_id', '') }}">
-      <input type="hidden" name="original_geom_type" value="{{ prefilled_values.get('geom_type', '') }}">
+      <!-- Original request ID (for reusing the completed check) -->
+      {% if is_magic_link_prefilled %}
+      <input type="hidden" name="request_id" value="{{ prefilled_values.get('request_id', '') }}">
       {% endif %}
 
       <!-- Geometry type (tree dataset only) -->
-      {% if prefilled_geom_type %}
+      {% if is_magic_link_prefilled and form.get('geom_type') %}
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="geom-type-hint">
           <legend class="govuk-fieldset__legend">Geometry type</legend>
           <div id="geom-type-hint" class="govuk-hint">{{ magic_link_hint }}</div>
           <div class="govuk-radios govuk-radios--inline">
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="geom-type-point" name="geom_type_display" type="radio" value="point" {% if prefilled_geom_type != 'polygon' %}checked{% endif %} disabled>
+              <input class="govuk-radios__input" id="geom-type-point" name="geom_type_display" type="radio" value="point" {% if form.get('geom_type') != 'polygon' %}checked{% endif %} disabled>
               <label class="govuk-label govuk-radios__label" for="geom-type-point">Point</label>
             </div>
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="geom-type-polygon" name="geom_type_display" type="radio" value="polygon" {% if prefilled_geom_type == 'polygon' %}checked{% endif %} disabled>
+              <input class="govuk-radios__input" id="geom-type-polygon" name="geom_type_display" type="radio" value="polygon" {% if form.get('geom_type') == 'polygon' %}checked{% endif %} disabled>
               <label class="govuk-label govuk-radios__label" for="geom-type-polygon">Polygon</label>
             </div>
           </div>
         </fieldset>
-        <input type="hidden" name="geom_type" value="{{ prefilled_geom_type }}">
+        <input type="hidden" name="geom_type" value="{{ form.get('geom_type') }}">
       </div>
       {% else %}
       <div class="govuk-form-group" id="geom-type-group" style="display:none;">
@@ -150,7 +140,7 @@ endblock %}
 
       <!-- Endpoint URL -->
       <div class="govuk-form-group {% if environment_error %}govuk-form-group--error{% endif %}">
-        {% if prefilled_endpoint_url %}
+        {% if is_magic_link_prefilled and form.get('endpoint_url') %}
         {{ govukInput({
         'label': { 'html': 'Endpoint URL <span class="govuk-required">*</span>' },
         'id': 'endpoint-url',
@@ -173,7 +163,7 @@ endblock %}
 
       <!-- Documentation URL -->
       <div class="govuk-form-group {% if documentation_error %}govuk-form-group--error{% endif %}">
-        {% if prefilled_documentation_url %}
+        {% if is_magic_link_prefilled and form.get('documentation_url') %}
         {{ govukInput({
         'label': { 'text': 'Documentation URL' },
         'id': 'documentation-url',
@@ -253,8 +243,8 @@ endblock %}
         'name': 'authoritative',
         'label': { 'html': 'Is this the authoritative source? <span class="govuk-required">*</span>' },
         'items': [
-          { 'value': '', 'text': 'Select an option', 'selected': not form.get('authoritative') },
-          { 'value': 'yes', 'text': 'Yes', 'selected': form.get('authoritative') == 'yes' },
+          { 'value': '', 'text': 'Select an option', 'selected': False },
+          { 'value': 'yes', 'text': 'Yes', 'selected': form.get('authoritative', 'yes') != 'no' },
           { 'value': 'no', 'text': 'No', 'selected': form.get('authoritative') == 'no' }
         ],
         'errorMessage': ( { 'text': 'Select whether this is the authoritative source' } if errors.get('authoritative') else None )
@@ -287,8 +277,8 @@ endblock %}
     const datasetValue = datasetHidden.value || "";
     const orgValue = hiddenOrgInput.value && hiddenOrgInput.value !== "undefined" ? hiddenOrgInput.value : "";
     const orgList = JSON.parse(`{{ org_values | default([]) | tojson | safe }}`);
-    const datasetLocked = {{ 'true' if prefilled_dataset else 'false' }};
-    const geometryLocked = {{ 'true' if prefilled_geom_type else 'false' }};
+    const datasetLocked = {{ 'true' if is_magic_link_prefilled and form.dataset else 'false' }};
+    const geometryLocked = {{ 'true' if is_magic_link_prefilled and form.get('geom_type') else 'false' }};
 
     // Build lookup from display label to org code
     function buildOrgLookup(orgs) {

--- a/application/templates/datamanager/dashboard_add.html
+++ b/application/templates/datamanager/dashboard_add.html
@@ -10,15 +10,27 @@
 endblock %}
 
 {% block content %}
+{% set magic_link_hint = 'This value has been prefilled from the magic link and cannot be changed here.' %}
+{% set prefilled_dataset = prefilled_values.get('dataset') if prefilled_values else '' %}
+{% set prefilled_organisation = prefilled_values.get('organisation') if prefilled_values else '' %}
+{% set prefilled_endpoint_url = prefilled_values.get('endpoint_url') if prefilled_values else '' %}
+{% set prefilled_documentation_url = prefilled_values.get('documentation_url') if prefilled_values else '' %}
+{% set prefilled_geom_type = prefilled_values.get('geom_type') if prefilled_values else '' %}
+{% set is_magic_link_prefilled = prefilled_values %}
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Check and Add Planning data</h1>
     <div style="display:flex; gap: 1rem; align-items: center; margin-bottom: 1rem;">
+      {% if is_magic_link_prefilled %}
+      <a class="govuk-button govuk-button--disabled govuk-!-margin-bottom-0" role="link" aria-disabled="true" tabindex="-1" data-module="govuk-button">Import from CSV</a>
+      {% else %}
       <a href="{{ url_for('datamanager.dashboard_add_import') }}" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button">Import from CSV</a>
+      {% endif %}
       <form method="post" action="{{ url_for('datamanager.dashboard_add_import') }}" enctype="multipart/form-data" style="margin:0;">
         <input type="hidden" name="mode" value="parse">
-        <input type="file" name="csv_file" id="csv-file-upload" accept=".csv" style="display:none;">
-        <button type="button" class="govuk-button govuk-!-margin-bottom-0" onclick="document.getElementById('csv-file-upload').click()">Upload CSV file</button>
+        <input type="file" name="csv_file" id="csv-file-upload" accept=".csv" style="display:none;" {% if is_magic_link_prefilled %}disabled{% endif %}>
+        <button type="button" class="govuk-button govuk-!-margin-bottom-0" onclick="document.getElementById('csv-file-upload').click()" {% if is_magic_link_prefilled %}disabled aria-disabled="true"{% endif %}>Upload CSV file</button>
       </form>
     </div>
   </div>
@@ -53,32 +65,72 @@ endblock %}
 
       <!-- Dataset autocomplete -->
       <div class="govuk-form-group {% if dataset_error %}govuk-form-group--error{% endif %}">
-        <label class="govuk-label" for="dataset-autocomplete">Dataset name <span class="govuk-required">*</span></label>
+        <label class="govuk-label" for="{% if prefilled_dataset %}dataset-display{% else %}dataset-autocomplete{% endif %}">Dataset name <span class="govuk-required">*</span></label>
         {% if dataset_error %}
         <p class="govuk-error-message">
           <span class="govuk-visually-hidden">Error:</span> Select a dataset
         </p>
         {% endif %}
+        {% if prefilled_dataset %}
+        <div id="dataset-display-hint" class="govuk-hint">{{ magic_link_hint }}</div>
+        <input class="govuk-input app-text-input__readonly" id="dataset-display" name="dataset_display" type="text" value="{{ prefilled_dataset }}" readonly aria-describedby="dataset-display-hint">
+        {% else %}
         <div id="autocomplete-container"></div>
+        {% endif %}
         <input type="hidden" name="dataset" id="dataset" value="{{ form.dataset or dataset_input }}">
       </div>
 
       <!-- Organisation autocomplete -->
       <div class="govuk-form-group {% if organisation_error %}govuk-form-group--error{% endif %}">
-        <label class="govuk-label" for="organisation">Organisation <span class="govuk-required">*</span></label>
+        <label class="govuk-label" for="{% if prefilled_organisation %}organisation-display{% else %}organisation{% endif %}">Organisation <span class="govuk-required">*</span></label>
         {% if organisation_error %}
         <p class="govuk-error-message">
           <span class="govuk-visually-hidden">Error:</span> Enter a valid organisation
         </p>
         {% endif %}
+        {% if prefilled_organisation %}
+        <div id="organisation-display-hint" class="govuk-hint">{{ magic_link_hint }}</div>
+        <input class="govuk-input app-text-input__readonly" id="organisation-display" name="organisation_display" type="text" value="{{ prefilled_organisation }}" readonly aria-describedby="organisation-display-hint">
+        {% else %}
         <div id="org-autocomplete-container">
           <div id="org-autocomplete-wrapper"></div>
         </div>
+        {% endif %}
         <input type="hidden" name="organisation" id="organisation" value="{{ form.organisation or '' }}">
         <input type="hidden" name="org_warning" id="org-warning" value="false">
       </div>
 
+      <!-- Original prefilled values (for change detection) -->
+      {% if prefilled_values %}
+      <input type="hidden" name="original_request_id" value="{{ prefilled_values.get('request_id', '') }}">
+      <input type="hidden" name="original_dataset" value="{{ prefilled_values.get('dataset', '') }}">
+      <input type="hidden" name="original_organisation" value="{{ prefilled_values.get('organisation', '') }}">
+      <input type="hidden" name="original_endpoint_url" value="{{ prefilled_values.get('endpoint_url', '') }}">
+      <input type="hidden" name="original_documentation_url" value="{{ prefilled_values.get('documentation_url', '') }}">
+      <input type="hidden" name="original_jira_issue_id" value="{{ prefilled_values.get('jira_issue_id', '') }}">
+      <input type="hidden" name="original_geom_type" value="{{ prefilled_values.get('geom_type', '') }}">
+      {% endif %}
+
       <!-- Geometry type (tree dataset only) -->
+      {% if prefilled_geom_type %}
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="geom-type-hint">
+          <legend class="govuk-fieldset__legend">Geometry type</legend>
+          <div id="geom-type-hint" class="govuk-hint">{{ magic_link_hint }}</div>
+          <div class="govuk-radios govuk-radios--inline">
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="geom-type-point" name="geom_type_display" type="radio" value="point" {% if prefilled_geom_type != 'polygon' %}checked{% endif %} disabled>
+              <label class="govuk-label govuk-radios__label" for="geom-type-point">Point</label>
+            </div>
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="geom-type-polygon" name="geom_type_display" type="radio" value="polygon" {% if prefilled_geom_type == 'polygon' %}checked{% endif %} disabled>
+              <label class="govuk-label govuk-radios__label" for="geom-type-polygon">Polygon</label>
+            </div>
+          </div>
+        </fieldset>
+        <input type="hidden" name="geom_type" value="{{ prefilled_geom_type }}">
+      </div>
+      {% else %}
       <div class="govuk-form-group" id="geom-type-group" style="display:none;">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend">Are the geometries points or polygons?</legend>
@@ -94,9 +146,21 @@ endblock %}
           </div>
         </fieldset>
       </div>
+      {% endif %}
 
       <!-- Endpoint URL -->
       <div class="govuk-form-group {% if environment_error %}govuk-form-group--error{% endif %}">
+        {% if prefilled_endpoint_url %}
+        {{ govukInput({
+        'label': { 'html': 'Endpoint URL <span class="govuk-required">*</span>' },
+        'id': 'endpoint-url',
+        'name': 'endpoint_url',
+        'value': form.get('endpoint_url', ''),
+        'classes': 'app-text-input__readonly',
+        'hint': { 'text': magic_link_hint },
+        'attributes': { 'required': 'required', 'type': 'url', 'readonly': 'readonly' }
+        }) }}
+        {% else %}
         {{ govukInput({
         'label': { 'html': 'Endpoint URL <span class="govuk-required">*</span>' },
         'id': 'endpoint-url',
@@ -104,10 +168,28 @@ endblock %}
         'value': form.get('endpoint_url', ''),
         'attributes': { 'required': 'required', 'type': 'url' }
         }) }}
+        {% endif %}
       </div>
 
       <!-- Documentation URL -->
       <div class="govuk-form-group {% if documentation_error %}govuk-form-group--error{% endif %}">
+        {% if prefilled_documentation_url %}
+        {{ govukInput({
+        'label': { 'text': 'Documentation URL' },
+        'id': 'documentation-url',
+        'name': 'documentation_url',
+        'value': form.get('documentation_url', ''),
+        'classes': 'app-text-input__readonly',
+        'hint': { 'text': magic_link_hint },
+        'attributes': {
+        'pattern': '(^$)|https?://.*\\.(gov\\.uk|org\\.uk)(/.*)?',
+        'title': 'Must be a valid URL ending in .gov.uk or .org.uk if provided',
+        'readonly': 'readonly'
+        },
+        'errorMessage': ( { 'text': 'Enter a valid documentation URL ending in .gov.uk or .org.uk' } if
+        documentation_error else None )
+        }) }}
+        {% else %}
         {{ govukInput({
         'label': { 'text': 'Documentation URL' },
         'id': 'documentation-url',
@@ -120,6 +202,7 @@ endblock %}
         'errorMessage': ( { 'text': 'Enter a valid documentation URL ending in .gov.uk or .org.uk' } if
         documentation_error else None )
         }) }}
+        {% endif %}
       </div>
 
       <div class="govuk-form-group govuk-!-margin-top-6">
@@ -200,9 +283,12 @@ endblock %}
     const orgWrapper = document.getElementById("org-autocomplete-wrapper");
     const hiddenOrgInput = document.getElementById("organisation");
     const orgWarningInput = document.getElementById("org-warning");
+    const geomTypeGroup = document.getElementById("geom-type-group");
     const datasetValue = datasetHidden.value || "";
     const orgValue = hiddenOrgInput.value && hiddenOrgInput.value !== "undefined" ? hiddenOrgInput.value : "";
     const orgList = JSON.parse(`{{ org_values | default([]) | tojson | safe }}`);
+    const datasetLocked = {{ 'true' if prefilled_dataset else 'false' }};
+    const geometryLocked = {{ 'true' if prefilled_geom_type else 'false' }};
 
     // Build lookup from display label to org code
     function buildOrgLookup(orgs) {
@@ -255,41 +341,45 @@ endblock %}
         }
       });
     }
-    // Dataset autocomplete
-    accessibleAutocomplete({
-      element: datasetContainer,
-      id: "dataset-autocomplete",
-      name: "dataset-autocomplete-visible",
-      defaultValue: datasetValue,
-      minLength: 2,
-      confirmOnBlur: false,
-      autoselect: true,
-      displayMenu: "overlay",
-      placeholder: "Type dataset name…",
-      source: function(query, populateResults) {
-        fetch(`{{ url_for('datamanager.dashboard_get') }}?autocomplete=${encodeURIComponent(query)}`)
-          .then((response) => response.json())
-          .then((data) => populateResults(data));
-      },
-      onConfirm: function(val) {
-        datasetHidden.value = val;
-        hiddenOrgInput.value = "";
-        document.getElementById('geom-type-group').style.display = (val.toLowerCase() === 'tree') ? 'block' : 'none';
-        fetch(`{{ url_for('datamanager.dashboard_get') }}?get_orgs_for=${encodeURIComponent(val)}`)
-          .then(res => res.json())
-          .then(orgs => {
-            updateOrgAutocomplete(orgs, "", "Type organisation name...");
-          });
+    if (!datasetLocked) {
+      // Dataset autocomplete
+      accessibleAutocomplete({
+        element: datasetContainer,
+        id: "dataset-autocomplete",
+        name: "dataset-autocomplete-visible",
+        defaultValue: datasetValue,
+        minLength: 2,
+        confirmOnBlur: false,
+        autoselect: true,
+        displayMenu: "overlay",
+        placeholder: "Type dataset name…",
+        source: function(query, populateResults) {
+          fetch(`{{ url_for('datamanager.dashboard_get') }}?autocomplete=${encodeURIComponent(query)}`)
+            .then((response) => response.json())
+            .then((data) => populateResults(data));
+        },
+        onConfirm: function(val) {
+          datasetHidden.value = val;
+          hiddenOrgInput.value = "";
+          if (geomTypeGroup) {
+            geomTypeGroup.style.display = (val.toLowerCase() === 'tree') ? 'block' : 'none';
+          }
+          fetch(`{{ url_for('datamanager.dashboard_get') }}?get_orgs_for=${encodeURIComponent(val)}`)
+            .then(res => res.json())
+            .then(orgs => {
+              updateOrgAutocomplete(orgs, "", "Type organisation name...");
+            });
+        }
+      });
+      if (datasetValue && orgList.length > 0) {
+        updateOrgAutocomplete(orgList, orgCodeToLabel(orgList, orgValue), "Type organisation name...");
+      } else {
+        updateOrgAutocomplete([], "", "Select a dataset first...");
       }
-    });
-    if (datasetValue && orgList.length > 0) {
-      updateOrgAutocomplete(orgList, orgCodeToLabel(orgList, orgValue), "Type organisation name...");
-    } else {
-      updateOrgAutocomplete([], "", "Select a dataset first...");
     }
 
-    if (datasetValue.toLowerCase() === 'tree') {
-      document.getElementById('geom-type-group').style.display = 'block';
+    if (geomTypeGroup && !geometryLocked && datasetValue.toLowerCase() === 'tree') {
+      geomTypeGroup.style.display = 'block';
     }
 
     document.getElementById('csv-file-upload').addEventListener('change', function() {

--- a/application/templates/datamanager/dashboard_add.html
+++ b/application/templates/datamanager/dashboard_add.html
@@ -139,60 +139,41 @@ endblock %}
       {% endif %}
 
       <!-- Endpoint URL -->
+      {% set is_endpoint_readonly = is_magic_link_prefilled and form.get('endpoint_url') %}
       <div class="govuk-form-group {% if environment_error %}govuk-form-group--error{% endif %}">
-        {% if is_magic_link_prefilled and form.get('endpoint_url') %}
         {{ govukInput({
         'label': { 'html': 'Endpoint URL <span class="govuk-required">*</span>' },
         'id': 'endpoint-url',
         'name': 'endpoint_url',
         'value': form.get('endpoint_url', ''),
-        'classes': 'app-text-input__readonly',
-        'hint': { 'text': magic_link_hint },
+        'classes': 'app-text-input__readonly' if is_endpoint_readonly else '',
+        'hint': { 'text': magic_link_hint } if is_endpoint_readonly else None,
         'attributes': { 'required': 'required', 'type': 'url', 'readonly': 'readonly' }
+        if is_endpoint_readonly else { 'required': 'required', 'type': 'url' }
         }) }}
-        {% else %}
-        {{ govukInput({
-        'label': { 'html': 'Endpoint URL <span class="govuk-required">*</span>' },
-        'id': 'endpoint-url',
-        'name': 'endpoint_url',
-        'value': form.get('endpoint_url', ''),
-        'attributes': { 'required': 'required', 'type': 'url' }
-        }) }}
-        {% endif %}
       </div>
 
       <!-- Documentation URL -->
+      {% set is_documentation_readonly = is_magic_link_prefilled and form.get('documentation_url') %}
       <div class="govuk-form-group {% if documentation_error %}govuk-form-group--error{% endif %}">
-        {% if is_magic_link_prefilled and form.get('documentation_url') %}
         {{ govukInput({
         'label': { 'text': 'Documentation URL' },
         'id': 'documentation-url',
         'name': 'documentation_url',
         'value': form.get('documentation_url', ''),
-        'classes': 'app-text-input__readonly',
-        'hint': { 'text': magic_link_hint },
+        'classes': 'app-text-input__readonly' if is_documentation_readonly else '',
+        'hint': { 'text': magic_link_hint } if is_documentation_readonly else None,
         'attributes': {
         'pattern': '(^$)|https?://.*\\.(gov\\.uk|org\\.uk)(/.*)?',
         'title': 'Must be a valid URL ending in .gov.uk or .org.uk if provided',
         'readonly': 'readonly'
-        },
-        'errorMessage': ( { 'text': 'Enter a valid documentation URL ending in .gov.uk or .org.uk' } if
-        documentation_error else None )
-        }) }}
-        {% else %}
-        {{ govukInput({
-        'label': { 'text': 'Documentation URL' },
-        'id': 'documentation-url',
-        'name': 'documentation_url',
-        'value': form.get('documentation_url', ''),
-        'attributes': {
+        } if is_documentation_readonly else {
         'pattern': '(^$)|https?://.*\\.(gov\\.uk|org\\.uk)(/.*)?',
         'title': 'Must be a valid URL ending in .gov.uk or .org.uk if provided'
         },
         'errorMessage': ( { 'text': 'Enter a valid documentation URL ending in .gov.uk or .org.uk' } if
         documentation_error else None )
         }) }}
-        {% endif %}
       </div>
 
       <div class="govuk-form-group govuk-!-margin-top-6">

--- a/application/templates/datamanager/dashboard_add.html
+++ b/application/templates/datamanager/dashboard_add.html
@@ -98,7 +98,7 @@ endblock %}
 
       <!-- Original request ID (for reusing the completed check) -->
       {% if is_magic_link_prefilled %}
-      <input type="hidden" name="request_id" value="{{ prefilled_values.get('request_id', '') }}">
+      <input type="hidden" name="request_id" value="{{ request_id }}">
       {% endif %}
 
       <!-- Geometry type (tree dataset only) -->

--- a/application/templates/datamanager/dashboard_add.html
+++ b/application/templates/datamanager/dashboard_add.html
@@ -353,11 +353,14 @@ endblock %}
       geomTypeGroup.style.display = 'block';
     }
 
-    document.getElementById('csv-file-upload').addEventListener('change', function() {
-      if (this.files.length > 0) {
-        this.closest('form').submit();
-      }
-    });
+    const upload = document.getElementById('csv-file-upload');
+    if (upload) {
+      upload.addEventListener('change', function() {
+        if (this.files.length > 0) {
+          this.closest('form').submit();
+        }
+      });
+    }
   });
 </script>
 {% endblock %}

--- a/application/templates/datamanager/dashboard_add.html
+++ b/application/templates/datamanager/dashboard_add.html
@@ -17,11 +17,7 @@ endblock %}
     <h1 class="govuk-heading-xl">Check and Add Planning data</h1>
     {% if not is_magic_link_prefilled %}
     <div style="display:flex; gap: 1rem; align-items: center; margin-bottom: 1rem;">
-      {% if is_magic_link_prefilled %}
-      <a class="govuk-button govuk-button--disabled govuk-!-margin-bottom-0" role="link" aria-disabled="true" tabindex="-1" data-module="govuk-button">Import from CSV</a>
-      {% else %}
       <a href="{{ url_for('datamanager.dashboard_add_import') }}" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button">Import from CSV</a>
-      {% endif %}
       <form method="post" action="{{ url_for('datamanager.dashboard_add_import') }}" enctype="multipart/form-data" style="margin:0;">
         <input type="hidden" name="mode" value="parse">
         <input type="file" name="csv_file" id="csv-file-upload" accept=".csv" style="display:none;" {% if is_magic_link_prefilled %}disabled{% endif %}>

--- a/config/allowed-users.md
+++ b/config/allowed-users.md
@@ -8,4 +8,5 @@ Add one GitHub username per line under the list below.
 - pooleycodes
 - Swati-Dash
 - Ben-Hodgkiss
+- gibahjoe
 

--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -8,4 +8,6 @@
 .app-text-input__readonly {
   border-color:  $govuk-border-colour;
   color: $govuk-secondary-text-colour;
+  background-color: govuk-colour("light-grey");
+  cursor: not-allowed;
 }

--- a/tests/unit/blueprints/datamanager/controllers/test_form.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_form.py
@@ -163,22 +163,20 @@ class TestDashboardGetMagicLinkData:
         assert b'id="geom-type-polygon"' in response.data
         assert b'name="geom_type" value="polygon"' in response.data
 
-    def test_request_id_fetch_failure_ignores_other_prefill_params(self, client):
+    def test_request_id_fetch_failure_does_not_prefill_magic_link_form(self, client):
         with patch(
             "application.blueprints.datamanager.controllers.form.fetch_request",
             side_effect=AsyncAPIError("not found", status_code=404),
         ):
             response = client.get(
                 "/datamanager/?requestId=req-123"
-                "&dataset=brownfield-land"
-                "&organisationId=local-authority:ABC"
-                "&endpointUrl=https://example.com/data.csv"
+                "&documentationUrl=https://example.gov.uk/docs"
             )
 
         assert response.status_code == 200
         assert b'id="dataset-display"' not in response.data
         assert b'id="organisation-display"' not in response.data
-        assert b'value="https://example.com/data.csv"' not in response.data
+        assert b'value="https://example.gov.uk/docs"' not in response.data
         assert b'name="request_id"' not in response.data
 
 

--- a/tests/unit/blueprints/datamanager/controllers/test_form.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_form.py
@@ -1,6 +1,8 @@
 import io
 from unittest.mock import patch
 
+from application.blueprints.datamanager.services.async_api import AsyncAPIError
+
 from application.blueprints.datamanager.controllers.form import (
     _has_all_add_data_fields,
     _parse_start_date,
@@ -105,6 +107,79 @@ class TestDashboardGetOrgsFor:
 
         assert response.status_code == 200
         assert response.get_json() == []
+
+
+class TestDashboardGetDefaults:
+    def test_authoritative_defaults_to_yes(self, client):
+        response = client.get("/datamanager/")
+
+        assert response.status_code == 200
+        assert b'<option value="yes" selected>Yes</option>' in response.data
+
+
+class TestDashboardGetMagicLinkData:
+    def test_fetches_request_details_and_prefills_magic_link_form(self, client):
+        with patch(
+            "application.blueprints.datamanager.controllers.form.fetch_request",
+            return_value={
+                "params": {
+                    "dataset": "brownfield-land",
+                    "url": "https://example.com/data.csv",
+                    "organisationName": "local-authority:ABC",
+                    "geom_type": "polygon",
+                }
+            },
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.get_dataset_name",
+            return_value="Brownfield Land",
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.get_dataset_id",
+            return_value="brownfield-land",
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.get_provision_orgs_for_dataset",
+            return_value=["local-authority:ABC"],
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.format_org_options",
+            return_value=[
+                {
+                    "code": "local-authority:ABC",
+                    "label": "ABC Council (local-authority:ABC)",
+                }
+            ],
+        ):
+            response = client.get(
+                "/datamanager/?requestId=req-123"
+                "&documentationUrl=https://example.gov.uk/docs"
+            )
+
+        assert response.status_code == 200
+        assert b'id="dataset-display"' in response.data
+        assert b'value="Brownfield Land"' in response.data
+        assert b'id="organisation-display"' in response.data
+        assert b'value="ABC Council (local-authority:ABC)"' in response.data
+        assert b'id="organisation" value="local-authority:ABC"' in response.data
+        assert b'value="https://example.com/data.csv"' in response.data
+        assert b'value="https://example.gov.uk/docs"' in response.data
+        assert b'id="geom-type-polygon"' in response.data
+        assert b'name="geom_type" value="polygon"' in response.data
+
+    def test_request_id_fetch_failure_ignores_other_prefill_params(self, client):
+        with patch(
+            "application.blueprints.datamanager.controllers.form.fetch_request",
+            side_effect=AsyncAPIError("not found", status_code=404),
+        ):
+            response = client.get(
+                "/datamanager/?requestId=req-123"
+                "&dataset=brownfield-land"
+                "&organisationId=local-authority:ABC"
+                "&endpointUrl=https://example.com/data.csv"
+            )
+
+        assert response.status_code == 200
+        assert b'id="dataset-display"' not in response.data
+        assert b'id="organisation-display"' not in response.data
+        assert b'value="https://example.com/data.csv"' not in response.data
+        assert b'name="request_id"' not in response.data
 
 
 class TestDashboardGetImportData:
@@ -240,6 +315,50 @@ class TestDashboardAddPost:
             response = client.post("/datamanager/", data={})
 
         assert response.status_code == 200
+
+    def test_post_with_request_id_reuses_existing_check_request(self, client):
+        with patch(
+            "application.blueprints.datamanager.controllers.form.get_dataset_id",
+            return_value="brownfield-land",
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.get_collection_id",
+            return_value="brownfield",
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.get_provision_orgs_for_dataset",
+            return_value=["local-authority:ABC"],
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.format_org_options",
+            return_value=[
+                {
+                    "code": "local-authority:ABC",
+                    "label": "ABC Council (local-authority:ABC)",
+                }
+            ],
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.is_valid_organisation",
+            return_value=True,
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.submit_request",
+            return_value="new-request-id",
+        ) as submit_request:
+            response = client.post(
+                "/datamanager/",
+                data={
+                    "request_id": "existing-request-id",
+                    "dataset": "Brownfield Land",
+                    "organisation": "local-authority:ABC",
+                    "endpoint_url": "https://example.com/data.csv",
+                    "documentation_url": "https://example.gov.uk/docs",
+                    "authoritative": "yes",
+                    "start_day": "1",
+                    "start_month": "6",
+                    "start_year": "2024",
+                },
+            )
+
+        assert response.status_code == 302
+        assert "existing-request-id" in response.headers["Location"]
+        submit_request.assert_not_called()
 
 
 class TestDashboardAddImportPost:

--- a/tests/unit/blueprints/datamanager/controllers/test_form.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_form.py
@@ -401,7 +401,7 @@ class TestDashboardAddPost:
         assert b'id="dataset-display"' in response.data
         assert b'id="organisation-display"' in response.data
         assert b'value="ABC Council (local-authority:ABC)"' in response.data
-        assert b'readonly' in response.data
+        assert b"readonly" in response.data
 
 
 class TestDashboardAddImportPost:

--- a/tests/unit/blueprints/datamanager/controllers/test_form.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_form.py
@@ -358,6 +358,51 @@ class TestDashboardAddPost:
         assert "existing-request-id" in response.headers["Location"]
         submit_request.assert_not_called()
 
+    def test_post_with_request_id_validation_error_preserves_magic_link_state(
+        self, client
+    ):
+        with patch(
+            "application.blueprints.datamanager.controllers.form.get_dataset_id",
+            return_value="brownfield-land",
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.get_collection_id",
+            return_value="brownfield",
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.get_provision_orgs_for_dataset",
+            return_value=["local-authority:ABC"],
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.format_org_options",
+            return_value=[
+                {
+                    "code": "local-authority:ABC",
+                    "label": "ABC Council (local-authority:ABC)",
+                }
+            ],
+        ), patch(
+            "application.blueprints.datamanager.controllers.form.is_valid_organisation",
+            return_value=True,
+        ):
+            response = client.post(
+                "/datamanager/",
+                data={
+                    "request_id": "existing-request-id",
+                    "dataset": "Brownfield Land",
+                    "organisation": "local-authority:ABC",
+                    "endpoint_url": "https://example.com/data.csv",
+                    "documentation_url": "https://example.gov.uk/docs",
+                    "start_day": "1",
+                    "start_month": "6",
+                    "start_year": "2024",
+                },
+            )
+
+        assert response.status_code == 200
+        assert b'name="request_id" value="existing-request-id"' in response.data
+        assert b'id="dataset-display"' in response.data
+        assert b'id="organisation-display"' in response.data
+        assert b'value="ABC Council (local-authority:ABC)"' in response.data
+        assert b'readonly' in response.data
+
 
 class TestDashboardAddImportPost:
     def test_file_upload_with_valid_single_row_csv_redirects(self, client):


### PR DESCRIPTION
Manage service now prefills the form using magic link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added magic-link request-id pre-filling for dashboard “add” flows, including dataset/organisation, endpoint and documentation URLs, and geometry type/value; state is preserved across submit and validation.
  * CSV import controls and related form sections now render as read-only/disabled when prefilled via magic link.
* **Style**
  * Improved styling for readonly inputs (light-grey background and non-interactive cursor).
* **Tests**
  * Added unit tests covering magic-link GET/POST success and failure paths.
* **Chores**
  * Updated ignore/config settings and extended the allowed users list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->