### PR TITLE
2629 column mapping   swap around columns to bring in line with new design

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,5 +9,6 @@ exclude =
     node_modules
 		.venv
 		migrations
+		.history
 
 ; vim: ft=dosini

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+.history
 # C extensions
 *.so
 

--- a/application/blueprints/datamanager/controllers/check.py
+++ b/application/blueprints/datamanager/controllers/check.py
@@ -175,15 +175,15 @@ def handle_check_results(request_id, result):
 
     # Build column mapping rows for inline configure UI
     unmapped_columns = converted_table.get("unmapped_columns", set())
-    user_column_mapping = result.get("params", {}).get("column_mapping") or {}
-    mapping_rows = build_column_mapping_rows(
-        column_mapping, unmapped_columns, user_column_mapping
-    )
     # Merge spec fields with all dataset fields so the mapping dropdown includes
     # fields that aren't present in this check's column-mapping
     spec_fields = (spec_fields | set(get_field_names_for_dataset(dataset_id))) - {
         "IGNORE"
     }
+    user_column_mapping = result.get("params", {}).get("column_mapping") or {}
+    mapping_rows = build_column_mapping_rows(
+        column_mapping, unmapped_columns, user_column_mapping, spec_fields
+    )
 
     # must_fix: task-log entries flagged as missing columns (task-source == "column-field")
     # fixable: all other task-log issues (value errors, etc.)
@@ -202,6 +202,9 @@ def handle_check_results(request_id, result):
         f"Column mapped: {entry['field']}"
         for entry in column_mapping
         if entry.get("field")
+        and entry.get("column")
+        and entry.get("field") != "IGNORE"
+        and entry.get("column") != "IGNORE"
     ]
     allow_add_data = len(must_fix) == 0
 
@@ -256,6 +259,14 @@ def handle_check_resubmit(request_id):
     # Start from any mappings already stored on this request, then merge new ones on top
     column_mapping = dict(params.get("column_mapping") or {})
     form = request.form.to_dict()
+
+    for key, value in form.items():
+        if key.startswith("field_map[") and key.endswith("]"):
+            field_name = key[10:-1]
+            col_name = value.strip()
+            if field_name and col_name:
+                column_mapping[col_name] = field_name
+
     for key, value in form.items():
         if key.startswith("map[") and key.endswith("]"):
             col_name = key[4:-1]
@@ -268,6 +279,9 @@ def handle_check_resubmit(request_id):
         if key.startswith("unmap[") and key.endswith("]") and value == "yes":
             col_name = key[6:-1]
             column_mapping.pop(col_name, None)
+        if key.startswith("ignore[") and key.endswith("]") and value == "yes":
+            col_name = key[7:-1]
+            column_mapping[col_name] = "IGNORE"
 
     # Submit new check with updated config
     payload_params = {

--- a/application/blueprints/datamanager/controllers/check.py
+++ b/application/blueprints/datamanager/controllers/check.py
@@ -39,6 +39,13 @@ logger = logging.getLogger(__name__)
 _ROWS_PER_PAGE = 500
 
 
+def _assign_column_mapping(column_mapping, col_name, field_name):
+    for existing_col, existing_field in list(column_mapping.items()):
+        if existing_col != col_name and existing_field == field_name:
+            del column_mapping[existing_col]
+    column_mapping[col_name] = field_name
+
+
 def handle_check_results(request_id, result):
     # Extract org code
     organisation_code = result.get("params", {}).get("organisationName")
@@ -265,14 +272,14 @@ def handle_check_resubmit(request_id):
             field_name = key[10:-1]
             col_name = value.strip()
             if field_name and col_name:
-                column_mapping[col_name] = field_name
+                _assign_column_mapping(column_mapping, col_name, field_name)
 
     for key, value in form.items():
         if key.startswith("map[") and key.endswith("]"):
             col_name = key[4:-1]
             field_value = value.strip()
             if field_value:
-                column_mapping[col_name] = field_value
+                _assign_column_mapping(column_mapping, col_name, field_value)
 
     # Remove any mappings the user has chosen to unmap
     for key, value in form.items():

--- a/application/blueprints/datamanager/utils/configure.py
+++ b/application/blueprints/datamanager/utils/configure.py
@@ -14,8 +14,8 @@ def build_column_mapping_rows(
     user_column_mapping = user_column_mapping or {}
     field_names = set(spec_fields or [])
 
-    # Currently column-mapping returns IGNORE for fields that have been unmapped. This is a bug in async service that needs to be fixed.
-    # For now we need to check for IGNORE and exclude these from the field names, otherwise they will be included as unmapped fields in the UI which is confusing for users.
+    # The async service currently returns IGNORE for fields that have been unmapped.
+    # Exclude these to avoid showing IGNORE as an unmapped field in the UI.
     field_names.update(
         entry.get("field")
         for entry in column_field_log

--- a/application/blueprints/datamanager/utils/configure.py
+++ b/application/blueprints/datamanager/utils/configure.py
@@ -1,42 +1,72 @@
 def build_column_mapping_rows(
-    column_field_log, unmapped_columns, user_column_mapping=None
+    column_field_log, unmapped_columns, user_column_mapping=None, spec_fields=None
 ):
     """Build rows for the inline column mapping UI.
 
     Returns a list of dicts, each with:
-      - column: the CSV column name
-      - field: the mapped spec field (or empty string for unmapped)
-      - is_mapped: True if the column already has a mapping from the pipeline
+      - field: the system field
+      - column: the mapped CSV column name (or empty string for unmapped)
+      - is_mapped: True if the field already has a column mapping
       - user_defined: True if the mapping was set by the user (i.e. in user_column_mapping)
 
-    Mapped rows come first (from column_field_log), then unmapped rows
-    (discovered in the converted data but absent from the log).
+    Rows are keyed by system field so users choose a source column for each field.
     """
     user_column_mapping = user_column_mapping or {}
-    rows = []
+    field_names = set(spec_fields or [])
+
+    # Currently column-mapping returns IGNORE for fields that have been unmapped. This is a bug in async service that needs to be fixed.
+    # For now we need to check for IGNORE and exclude these from the field names, otherwise they will be included as unmapped fields in the UI which is confusing for users.
+    field_names.update(
+        entry.get("field")
+        for entry in column_field_log
+        if entry.get("field") and entry.get("field") != "IGNORE"
+    )
+
+    active_mapping = {}
+    ignored_columns = set()
+
     for entry in column_field_log:
         col = entry.get("column")
         field = entry.get("field", "")
-        if col:
-            user_ignored = user_column_mapping.get(col) == "IGNORE"
-            rows.append(
-                {
-                    "column": col,
-                    "field": field,
-                    "is_mapped": not user_ignored,
-                    "user_defined": col in user_column_mapping and not user_ignored,
-                    "user_ignored": user_ignored,
-                }
-            )
+        if not col or not field:
+            continue
+        if user_column_mapping.get(col) == "IGNORE":
+            ignored_columns.add(col)
+            continue
+        if field == "IGNORE":
+            continue
+        active_mapping[field] = col
 
-    for col in sorted(unmapped_columns):
+    for col, field in user_column_mapping.items():
+        if field == "IGNORE":
+            ignored_columns.add(col)
+            continue
+        if field:
+            field_names.add(field)
+            active_mapping[field] = col
+
+    mapped_columns = set(active_mapping.values())
+    available_columns = sorted(
+        (set(unmapped_columns) | ignored_columns) - mapped_columns
+    )
+
+    mapped_fields = sorted(field for field in field_names if active_mapping.get(field))
+    unmapped_fields = sorted(
+        field for field in field_names if not active_mapping.get(field)
+    )
+
+    rows = []
+    for field in mapped_fields + unmapped_fields:
+        column = active_mapping.get(field, "")
         rows.append(
             {
-                "column": col,
-                "field": "",
-                "is_mapped": False,
-                "user_defined": False,
+                "field": field,
+                "column": column,
+                "is_mapped": bool(column),
+                "user_defined": bool(column)
+                and user_column_mapping.get(column) == field,
                 "user_ignored": False,
+                "available_columns": available_columns,
             }
         )
 

--- a/application/blueprints/datamanager/utils/configure.py
+++ b/application/blueprints/datamanager/utils/configure.py
@@ -24,6 +24,7 @@ def build_column_mapping_rows(
 
     active_mapping = {}
     ignored_columns = set()
+    ignored_fields = set()
 
     for entry in column_field_log:
         col = entry.get("column")
@@ -32,6 +33,7 @@ def build_column_mapping_rows(
             continue
         if user_column_mapping.get(col) == "IGNORE":
             ignored_columns.add(col)
+            ignored_fields.add(field)
             continue
         if field == "IGNORE":
             continue
@@ -65,7 +67,7 @@ def build_column_mapping_rows(
                 "is_mapped": bool(column),
                 "user_defined": bool(column)
                 and user_column_mapping.get(column) == field,
-                "user_ignored": False,
+                "user_ignored": field in ignored_fields,
                 "available_columns": available_columns,
             }
         )

--- a/application/templates/datamanager/components/column-mapping.html
+++ b/application/templates/datamanager/components/column-mapping.html
@@ -10,8 +10,8 @@
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Column</th>
             <th scope="col" class="govuk-table__header">Field</th>
+            <th scope="col" class="govuk-table__header">Column</th>
             <th scope="col" class="govuk-table__header">Status</th>
           </tr>
         </thead>
@@ -19,18 +19,20 @@
           {% for row in mapping_rows %}
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              <strong>{{ row.column }}</strong>
+              <strong>{{ row.field }}</strong>
             </td>
             <td class="govuk-table__cell">
               {% if row.is_mapped %}
-              {{ row.field }}
-              {% else %}
-              <select class="govuk-select" name="map[{{ row.column }}]">
-                <option value="">-- select a field --</option>
-                {% for field in spec_fields %}
-                <option value="{{ field }}">{{ field }}</option>
+              {{ row.column }}
+              {% elif row.available_columns %}
+              <select class="govuk-select" name="field_map[{{ row.field }}]">
+                <option value="">-- select a column --</option>
+                {% for column in row.available_columns %}
+                <option value="{{ column }}">{{ column }}</option>
                 {% endfor %}
               </select>
+              {% else %}
+              <span class="govuk-hint">No unmapped columns available</span>
               {% endif %}
             </td>
             <td class="govuk-table__cell">
@@ -43,9 +45,9 @@
                 <option value="yes">Un-Map</option>
               </select>
               {% elif row.is_mapped %}
-              <select name="map[{{ row.column }}]" style="background-color: #00703c; color: #ffffff; font-weight: 700; font-size: 0.875rem; padding: 2px 8px; border: none; border-radius: 0; cursor: pointer; appearance: auto;">
+              <select name="ignore[{{ row.column }}]" style="background-color: #00703c; color: #ffffff; font-weight: 700; font-size: 0.875rem; padding: 2px 8px; border: none; border-radius: 0; cursor: pointer; appearance: auto;">
                 <option value="">Mapped</option>
-                <option value="IGNORE">Un-Map</option>
+                <option value="yes">Un-Map</option>
               </select>
               {% else %}
               <strong class="govuk-tag govuk-tag--red">Unmapped</strong>

--- a/tests/acceptance/blueprints/datamanager/test_add_data_journey.py
+++ b/tests/acceptance/blueprints/datamanager/test_add_data_journey.py
@@ -256,12 +256,14 @@ class TestAddDataJourney:
             ):
                 with patch(
                     "application.blueprints.datamanager.controllers.check.get_field_names_for_dataset",
-                    return_value=[],
+                    return_value=["geometry"],
                 ):
                     response = client.get("/datamanager/check-results/check-id-1")
         assert response.status_code == 200
         assert b"geom" in response.data
-        assert b"map[geom]" in response.data  # column mapping select input name
+        assert b"field_map[geometry]" in response.data
+        assert b'<option value="geom">geom</option>' in response.data
+        assert b"field_map[reference]" not in response.data
 
     # --- Step 4: Resubmit with column mapping geom → geometry ---
 
@@ -273,7 +275,7 @@ class TestAddDataJourney:
         rsps.add(rsps.POST, ASYNC_BASE, json={"id": "check-id-2"}, status=202)
         response = client.post(
             "/datamanager/check-results/check-id-1",
-            data={"map[geom]": "geometry"},
+            data={"field_map[geometry]": "geom"},
         )
         assert response.status_code == 302
         assert "check-results/check-id-2" in response.headers["Location"]

--- a/tests/unit/blueprints/datamanager/controllers/test_check.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_check.py
@@ -39,17 +39,25 @@ class TestCheckResultsRoute:
         assert b"govuk-error-summary" in response.data
 
     def test_resubmit_redirects_to_new_check(self, client):
+        result = {
+            **PENDING_RESULT,
+            "params": {
+                **PENDING_RESULT["params"],
+                "column_mapping": {"OldColumn": "name"},
+            },
+        }
         with patch(
             "application.blueprints.datamanager.controllers.check.fetch_request",
-            return_value=PENDING_RESULT,
-        ):
-            with patch(
-                "application.blueprints.datamanager.controllers.check.submit_request",
-                return_value="new-check-id",
-            ):
-                response = client.post(
-                    "/datamanager/check-results/test-id",
-                    data={"field_map[name]": "MyColumn"},
-                )
+            return_value=result,
+        ), patch(
+            "application.blueprints.datamanager.controllers.check.submit_request",
+            return_value="new-check-id",
+        ) as submit_request:
+            response = client.post(
+                "/datamanager/check-results/test-id",
+                data={"field_map[name]": "MyColumn"},
+            )
         assert response.status_code == 302
         assert "new-check-id" in response.headers["Location"]
+        submitted_params = submit_request.call_args.args[0]
+        assert submitted_params["column_mapping"] == {"MyColumn": "name"}

--- a/tests/unit/blueprints/datamanager/controllers/test_check.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_check.py
@@ -49,7 +49,7 @@ class TestCheckResultsRoute:
             ):
                 response = client.post(
                     "/datamanager/check-results/test-id",
-                    data={"map[MyColumn]": "name"},
+                    data={"field_map[name]": "MyColumn"},
                 )
         assert response.status_code == 302
         assert "new-check-id" in response.headers["Location"]

--- a/tests/unit/blueprints/datamanager/utils/test_configure.py
+++ b/tests/unit/blueprints/datamanager/utils/test_configure.py
@@ -1,0 +1,29 @@
+from application.blueprints.datamanager.utils.configure import build_column_mapping_rows
+
+
+def test_build_column_mapping_rows_orders_mapped_then_unmapped_by_field():
+    rows = build_column_mapping_rows(
+        column_field_log=[
+            {"column": "user_name", "field": "name"},
+            {"column": "user_ref", "field": "reference"},
+        ],
+        unmapped_columns={"z_col", "a_col"},
+        spec_fields={"geometry", "entry-date", "name", "reference"},
+    )
+
+    assert [row["field"] for row in rows] == [
+        "name",
+        "reference",
+        "entry-date",
+        "geometry",
+    ]
+
+
+def test_build_column_mapping_rows_sorts_dropdown_columns_alphabetically():
+    rows = build_column_mapping_rows(
+        column_field_log=[],
+        unmapped_columns={"z_col", "a_col", "middle_col"},
+        spec_fields={"geometry"},
+    )
+
+    assert rows[0]["available_columns"] == ["a_col", "middle_col", "z_col"]

--- a/tests/unit/blueprints/datamanager/utils/test_configure.py
+++ b/tests/unit/blueprints/datamanager/utils/test_configure.py
@@ -27,3 +27,21 @@ def test_build_column_mapping_rows_sorts_dropdown_columns_alphabetically():
     )
 
     assert rows[0]["available_columns"] == ["a_col", "middle_col", "z_col"]
+
+
+def test_build_column_mapping_rows_flags_user_ignored_fields():
+    rows = build_column_mapping_rows(
+        column_field_log=[
+            {"column": "geom", "field": "geometry"},
+            {"column": "ref", "field": "reference"},
+        ],
+        unmapped_columns=set(),
+        user_column_mapping={"geom": "IGNORE"},
+        spec_fields={"geometry", "reference"},
+    )
+
+    geometry_row = next(row for row in rows if row["field"] == "geometry")
+
+    assert geometry_row["user_ignored"] is True
+    assert geometry_row["is_mapped"] is False
+    assert geometry_row["available_columns"] == ["geom"]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Updates the manage service mapping UI so mappings are selected against system fields, with available source columns in the dropdown. Mapped fields are shown first, then unmapped fields, with both groups sorted alphabetically. Dropdown column options are also sorted alphabetically and exclude already mapped columns.

## Related Tickets & Documents

- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Run the datamanager check flow and open the column mapping section on check results. Confirm fields appear on the left, source columns appear in the dropdown, mapped columns are not selectable, and ordering is mapped fields first then unmapped fields.

Tested with automated tests.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why:
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

None.

## [optional] Are there any dependencies on other PRs or Work?

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reworked the Configure Columns interface for clearer field/column presentation and improved dropdown options.
  * Resubmission form updated: unmapped fields use a field-centric selector and ignore handling now marks fields as ignored.
  * Mapping enforcement tightened to prevent duplicate field assignments and provide more accurate validation feedback.

* **Tests**
  * Acceptance and unit tests updated to reflect the new form naming and ignore behaviours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->