### PR TITLE
Preview & Confirm - Reduce content on summary page

### DIFF
--- a/application/blueprints/datamanager/controllers/preview.py
+++ b/application/blueprints/datamanager/controllers/preview.py
@@ -56,7 +56,7 @@ def handle_entities_preview(request_id, req):
     new_entities = pipeline_summary.get("new-entities") or []
 
     # Build lookup CSV preview
-    table_params, lookup_csv_text = build_lookup_csv_preview(new_entities)
+    table_params = build_lookup_csv_preview(new_entities)
 
     # Existing entities table
     ex_cols = ["reference", "entity"]
@@ -78,13 +78,12 @@ def handle_entities_preview(request_id, req):
         endpoint_already_exists,
         endpoint_url,
         endpoint_csv_table_params,
-        endpoint_csv_text,
     ) = build_endpoint_csv_preview(
         endpoint_summary, endpoint_parameters=endpoint_parameters
     )
 
     # Build source CSV preview
-    source_summary, source_csv_table_params, source_csv_text = build_source_csv_preview(
+    source_summary, source_csv_table_params = build_source_csv_preview(
         source_summary_data
     )
 
@@ -93,7 +92,6 @@ def handle_entities_preview(request_id, req):
     column_mapping = params.get("column_mapping", {})
     (
         column_csv_table_params,
-        column_csv_text,
         has_column_mapping,
     ) = build_column_csv_preview(column_mapping, dataset_id, endpoint_summary)
 
@@ -130,7 +128,6 @@ def handle_entities_preview(request_id, req):
     # Build entity-organisation CSV preview (only for authoritative data)
     authoritative = params.get("authoritative", False)
     entity_org_table_params = None
-    entity_org_csv_text = ""
     has_entity_org = False
     entity_org_warning = None
 
@@ -139,7 +136,6 @@ def handle_entities_preview(request_id, req):
         if entity_organisation_data:
             (
                 entity_org_table_params,
-                entity_org_csv_text,
                 has_entity_org,
             ) = build_entity_organisation_csv(entity_organisation_data)
         else:
@@ -159,18 +155,13 @@ def handle_entities_preview(request_id, req):
         endpoint_already_exists=endpoint_already_exists,
         endpoint_url=endpoint_url,
         table_params=table_params,
-        lookup_csv_text=lookup_csv_text,
         existing_table_params=existing_table_params,
         endpoint_csv_table_params=endpoint_csv_table_params,
-        endpoint_csv_text=endpoint_csv_text,
         source_csv_table_params=source_csv_table_params,
-        source_csv_text=source_csv_text,
         source_summary=source_summary,
         column_csv_table_params=column_csv_table_params,
-        column_csv_text=column_csv_text,
         has_column_mapping=has_column_mapping,
         entity_org_table_params=entity_org_table_params,
-        entity_org_csv_text=entity_org_csv_text,
         has_entity_org=has_entity_org,
         entity_org_warning=entity_org_warning,
     )

--- a/application/blueprints/datamanager/utils/csv_formats.py
+++ b/application/blueprints/datamanager/utils/csv_formats.py
@@ -137,17 +137,7 @@ def build_source_csv_preview(source_summary_data: dict) -> tuple:
 
     source_summary = {
         "already_exists": source_already_exists_text,
-        "source": src_source.get("source", ""),
-        "collection": src_source.get("collection", ""),
-        "organisation": src_source.get("organisation", ""),
-        "endpoint": src_source.get("endpoint", ""),
-        "licence": src_source.get("licence", ""),
-        "pipelines": src_source.get("pipelines", ""),
-        "entry_date": src_source.get("entry-date", ""),
-        "start_date": src_source.get("start-date", ""),
-        "end_date": src_source.get("end-date", ""),
         "documentation_url": src_source.get("documentation-url", ""),
-        "attribution": src_source.get("attribution", ""),
     }
 
     return source_summary, source_csv_table_params

--- a/application/blueprints/datamanager/utils/csv_formats.py
+++ b/application/blueprints/datamanager/utils/csv_formats.py
@@ -1,22 +1,13 @@
-import csv
-import io
 import json
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-def _row_to_csv(values: list) -> str:
-    """Serialise a list of values to a RFC 4180-compliant CSV row string."""
-    buf = io.StringIO()
-    csv.writer(buf).writerow(values)
-    return buf.getvalue().rstrip("\r\n")
-
-
-def build_lookup_csv_preview(new_entities: list) -> tuple:
+def build_lookup_csv_preview(new_entities: list) -> dict:
     """
     Build lookup CSV preview for new entities.
-    Returns (table_params, csv_text)
+    Returns table_params
     """
     cols = ["reference", "prefix", "organisation", "entity"]
     rows = [
@@ -31,24 +22,7 @@ def build_lookup_csv_preview(new_entities: list) -> tuple:
         "columnNameProcessing": "none",
     }
 
-    fields = [
-        "prefix",
-        "resource",
-        "endpoint",
-        "entry-number",
-        "organisation",
-        "reference",
-        "entity",
-        "entry-date",
-        "start-date",
-        "end-date",
-    ]
-
-    csv_text = "\n".join(
-        ",".join(item.get(field, "") for field in fields) for item in new_entities
-    )
-
-    return table_params, csv_text
+    return table_params
 
 
 def build_endpoint_csv_preview(
@@ -56,7 +30,7 @@ def build_endpoint_csv_preview(
 ) -> tuple:
     """
     Build endpoint CSV preview.
-    Returns (endpoint_already_exists, endpoint_url, table_params, csv_text)
+    Returns (endpoint_already_exists, endpoint_url, table_params)
     """
     ep_cols = [
         "endpoint",
@@ -72,7 +46,6 @@ def build_endpoint_csv_preview(
     )
     logger.info(f"Endpoint already exists: {endpoint_already_exists}")
 
-    endpoint_csv_text = ""
     if endpoint_summary.get("endpoint_url_in_endpoint_csv"):
         end_point_entry = endpoint_summary.get("existing_endpoint_entry", {})
         endpoint_url = end_point_entry.get("endpoint-url", "")
@@ -84,9 +57,6 @@ def build_endpoint_csv_preview(
                 **end_point_entry,
                 "parameters": json.dumps(endpoint_parameters),
             }
-        endpoint_csv_text = _row_to_csv(
-            [end_point_entry.get(col, "") for col in ep_cols]
-        )
 
     ep_row = [str(end_point_entry.get(col, "") or "") for col in ep_cols]
     endpoint_csv_table_params = {
@@ -100,20 +70,16 @@ def build_endpoint_csv_preview(
         endpoint_already_exists,
         endpoint_url,
         endpoint_csv_table_params,
-        endpoint_csv_text,
     )
 
 
-def build_source_csv_preview(
-    source_summary_data: dict, include_headers: bool = True
-) -> tuple:
+def build_source_csv_preview(source_summary_data: dict) -> tuple:
     """
     Build source CSV preview and summary.
-    Returns (source_summary, table_params, csv_text)
+    Returns (source_summary, table_params)
 
     Args:
         source_summary_data: Source summary data from API response
-        include_headers: If True, include CSV headers in csv_text. Default True.
     """
     src_cols = [
         "source",
@@ -134,7 +100,6 @@ def build_source_csv_preview(
 
     pipelines_append_required = source_summary_data.get("pipelines_append_required")
 
-    source_csv_text = ""
     if not source_present:
         src_source = source_summary_data.get("new_source_entry", {})
         if pipelines_append_required:
@@ -151,10 +116,6 @@ def build_source_csv_preview(
             "rows": [{"columns": {c: {"value": v} for c, v in zip(src_cols, src_row)}}],
             "columnNameProcessing": "none",
         }
-        if include_headers:
-            source_csv_text = _row_to_csv(src_cols) + "\n" + _row_to_csv(src_row)
-        else:
-            source_csv_text = _row_to_csv(src_row)
     else:
         src_source = source_summary_data.get("existing_source_entry", {})
         if pipelines_append_required:
@@ -189,27 +150,24 @@ def build_source_csv_preview(
         "attribution": src_source.get("attribution", ""),
     }
 
-    return source_summary, source_csv_table_params, source_csv_text
+    return source_summary, source_csv_table_params
 
 
 def build_column_csv_preview(
     column_mapping: dict,
     dataset_id: str,
     endpoint_summary: dict,
-    include_headers: bool = True,
 ) -> tuple:
     """
     Build column CSV preview from column mapping data.
-    Returns (column_csv_table_params, column_csv_text, has_column_mapping)
+    Returns (column_csv_table_params, has_column_mapping)
 
     Args:
         column_mapping: Column mapping dict from request params
         dataset_id: Dataset ID
         endpoint_summary: Endpoint summary data from API response
-        include_headers: If True, include CSV headers in csv_text. Default True.
     """
     column_csv_table_params = None
-    column_csv_text = ""
     has_column_mapping = False
 
     logger.info("Entities preview: Checking for column mapping")
@@ -258,37 +216,21 @@ def build_column_csv_preview(
             "columnNameProcessing": "none",
         }
 
-        if include_headers:
-            column_csv_text = ",".join(col_csv_cols) + "\n"
-            for row in col_csv_rows:
-                column_csv_text += (
-                    ",".join([row.get(c, "") for c in col_csv_cols]) + "\n"
-                )
-            column_csv_text = column_csv_text.strip()
-        else:
-            csv_rows = []
-            for row in col_csv_rows:
-                csv_rows.append(",".join([row.get(c, "") for c in col_csv_cols]))
-            column_csv_text = "\n".join(csv_rows)
-
-    return column_csv_table_params, column_csv_text, has_column_mapping
+    return column_csv_table_params, has_column_mapping
 
 
-def build_entity_organisation_csv(
-    entity_organisation_data: list, include_headers: bool = True
-) -> tuple:
+def build_entity_organisation_csv(entity_organisation_data: list) -> tuple:
     """
     Build entity-organisation CSV preview.
-    Returns (table_params, csv_text, has_data)
+    Returns (table_params, has_data)
 
     Args:
         entity_organisation_data: List of entity-organisation entries from pipeline-summary
-        include_headers: If True, include CSV headers in csv_text. Default True.
     """
     cols = ["dataset", "entity-minimum", "entity-maximum", "organisation"]
 
     if not entity_organisation_data:
-        return None, "", False
+        return None, False
 
     rows = []
     for entry in entity_organisation_data:
@@ -310,22 +252,4 @@ def build_entity_organisation_csv(
         "columnNameProcessing": "none",
     }
 
-    csv_lines = []
-    if include_headers:
-        csv_lines.append(",".join(cols))
-
-    for entry in entity_organisation_data:
-        csv_lines.append(
-            ",".join(
-                [
-                    str(entry.get("dataset", "")),
-                    str(entry.get("entity-minimum", "")),
-                    str(entry.get("entity-maximum", "")),
-                    str(entry.get("organisation", "")),
-                ]
-            )
-        )
-
-    csv_text = "\n".join(csv_lines)
-
-    return table_params, csv_text, True
+    return table_params, True

--- a/application/blueprints/datamanager/utils/csv_formats.py
+++ b/application/blueprints/datamanager/utils/csv_formats.py
@@ -96,7 +96,7 @@ def build_source_csv_preview(source_summary_data: dict) -> tuple:
     ]
 
     source_present = source_summary_data.get("documentation_url_in_source_csv")
-    will_create_source_text = "No" if source_present else "Yes"
+    source_already_exists_text = "Yes" if source_present else "No"
 
     pipelines_append_required = source_summary_data.get("pipelines_append_required")
 
@@ -133,10 +133,10 @@ def build_source_csv_preview(source_summary_data: dict) -> tuple:
             "columnNameProcessing": "none",
         }
 
-    logger.info(f"Will create source: {will_create_source_text}")
+    logger.info(f"Source already exists: {source_already_exists_text}")
 
     source_summary = {
-        "will_create": will_create_source_text,
+        "already_exists": source_already_exists_text,
         "source": src_source.get("source", ""),
         "collection": src_source.get("collection", ""),
         "organisation": src_source.get("organisation", ""),

--- a/application/templates/datamanager/entities_preview.html
+++ b/application/templates/datamanager/entities_preview.html
@@ -100,71 +100,9 @@
             </dd>
           </div>
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">source</dt>
-            <dd class="govuk-summary-list__value">
-              <code>{{ source_summary.source }}</code>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">collection</dt>
-            <dd class="govuk-summary-list__value">
-              {{ source_summary.collection }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">organisation</dt>
-            <dd class="govuk-summary-list__value">
-              {{ source_summary.organisation }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">endpoint</dt>
-            <dd class="govuk-summary-list__value">
-              <code>{{ source_summary.endpoint }}</code>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">licence</dt>
-            <dd class="govuk-summary-list__value">
-              {{ source_summary.licence }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">pipelines</dt>
-            <dd class="govuk-summary-list__value">
-              {{ source_summary.pipelines }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">documentation-url</dt>
+            <dt class="govuk-summary-list__key">Documentation URL</dt>
             <dd class="govuk-summary-list__value" style="word-break: break-all">
               {{ source_summary.documentation_url }}
-            </dd>
-          </div>
-          {% if source_summary.attribution %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">attribution</dt>
-            <dd class="govuk-summary-list__value">
-              {{ source_summary.attribution }}
-            </dd>
-          </div>
-          {% endif %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">entry-date</dt>
-            <dd class="govuk-summary-list__value">
-              {{ source_summary.entry_date }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">start-date</dt>
-            <dd class="govuk-summary-list__value">
-              {{ source_summary.start_date }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">end-date</dt>
-            <dd class="govuk-summary-list__value">
-              {{ source_summary.end_date }}
             </dd>
           </div>
         </dl>

--- a/application/templates/datamanager/entities_preview.html
+++ b/application/templates/datamanager/entities_preview.html
@@ -94,9 +94,9 @@
         <div style="background-color: #f3f2f1; padding: 10px 15px; margin-bottom: 30px;">
         <dl class="govuk-summary-list govuk-!-margin-bottom-0">
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Will create new source row</dt>
+            <dt class="govuk-summary-list__key">Source already in system</dt>
             <dd class="govuk-summary-list__value">
-              {{source_summary.will_create}}
+              {{source_summary.already_exists}}
             </dd>
           </div>
           <div class="govuk-summary-list__row">

--- a/application/templates/datamanager/entities_preview.html
+++ b/application/templates/datamanager/entities_preview.html
@@ -36,19 +36,6 @@
           {% if table_params and table_params.rows %}
           <div class="app-scrollable-container app-scrollable">{{ table(table_params) }}</div>
           {% endif %}
-          <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
-            <summary class="govuk-details__summary">
-              <span class="govuk-details__summary-text">Copy CSV for <code>lookup.csv</code></span>
-            </summary>
-            <div class="govuk-details__text">
-              {% set _ep_lines = (lookup_csv_text or '').splitlines() %}
-              <textarea class="govuk-textarea" rows="6" readonly>
-{{ _ep_lines[0:] | join('\n') }}</textarea>
-              <p class="govuk-hint govuk-!-margin-top-2">
-                Copy this line into your local <code>lookup.csv</code>.
-              </p>
-            </div>
-          </details>
         </section>
         {% endif %}
 
@@ -95,21 +82,6 @@
         <div class="app-scrollable-container app-scrollable govuk-!-margin-bottom-2">
           {{ table(endpoint_csv_table_params) }}
         </div>
-        {% if endpoint_csv_text != '' %}
-        <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">Copy CSV for <code>endpoint.csv</code></span>
-          </summary>
-          <div class="govuk-details__text">
-            {% set _ep_lines = (endpoint_csv_text or '').splitlines() %}
-            <textarea class="govuk-textarea" rows="2" readonly>
-{{ _ep_lines[0:] | join('\n') }}</textarea>
-            <p class="govuk-hint govuk-!-margin-top-2">
-              Copy this line into your local <code>endpoint.csv</code>.
-            </p>
-          </div>
-        </details>
-        {% endif %}
         {% endif %}
       </div>
     </div>
@@ -203,19 +175,6 @@
         <div class="app-scrollable-container app-scrollable govuk-!-margin-bottom-2">
           {{ table(source_csv_table_params) }}
         </div>
-        {% if source_csv_text != '' %}
-        <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">Copy CSV for <code>source.csv</code></span>
-          </summary>
-          <div class="govuk-details__text">
-            {# show CSV body only (drop header) #}
-            {% set _src_lines = (source_csv_text or '').splitlines() %}
-            <textarea class="govuk-textarea" rows="2" readonly>{{ _src_lines[1:] | join('\n') }}</textarea>
-            <p class="govuk-hint govuk-!-margin-top-2">Copy this line into your local <code>source.csv</code>.</p>
-          </div>
-        </details>
-        {% endif %}
         {% endif %}
       </div>
     </div>
@@ -230,19 +189,6 @@
         <div class="app-scrollable-container app-scrollable govuk-!-margin-bottom-2">
           {{ table(column_csv_table_params) }}
         </div>
-        {% if column_csv_text != '' %}
-        <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">Copy CSV for <code>column.csv</code></span>
-          </summary>
-          <div class="govuk-details__text">
-            {# show CSV body only (drop header) #}
-            {% set _col_lines = (column_csv_text or '').splitlines() %}
-            <textarea class="govuk-textarea" rows="{{ _col_lines[1:] | length }}" readonly>{{ _col_lines[1:] | join('\n') }}</textarea>
-            <p class="govuk-hint govuk-!-margin-top-2">Copy these lines into your local <code>column.csv</code>.</p>
-          </div>
-        </details>
-        {% endif %}
       </div>
     </div>
     {% endif %}
@@ -264,18 +210,6 @@
         <div class="app-scrollable-container app-scrollable govuk-!-margin-bottom-2">
           {{ table(entity_org_table_params) }}
         </div>
-        {% if entity_org_csv_text != '' %}
-        <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">Copy CSV for <code>entity-organisation.csv</code></span>
-          </summary>
-          <div class="govuk-details__text">
-            {% set _eo_lines = (entity_org_csv_text or '').splitlines() %}
-            <textarea class="govuk-textarea" rows="{{ [_eo_lines[1:] | length, 2] | max }}" readonly>{{ _eo_lines[1:] | join('\n') }}</textarea>
-            <p class="govuk-hint govuk-!-margin-top-2">Copy these lines into your local <code>entity-organisation.csv</code>.</p>
-          </div>
-        </details>
-        {% endif %}
         {% else %}
         <p class="govuk-body govuk-!-margin-bottom-0">No entity-organisation data found.</p>
         {% endif %}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description


The "Preview & Confirm" page in the Add Data flow has become harder to read
than necessary. Now that the GitHub Action is working, some content is
redundant.

This change removes all "Copy CSV for..." accordions in the page. These
were previously needed as a manual step but are no longer required now
the GitHub Action is in place.

The "Will create new source row" field in Source Summary has its logic inverted compared to the equivalent field in Endpoint Summary. This change also brings the wording and logic inline with the Endpoint Summary.

The Source Summary currently repeats information that already appears in the canonical row below it. This change also removes all fields that already exist in the canonical row, reducing duplication. 

The combination of these changes aim to help reduce the size of the page, avoid overwhelm, reduce cognitive load and confusion, and make for an improved experience for the user. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/config/issues/2548

## QA Instructions, Screenshots, Recordings

See ticket for list of changes. 

| Before | After |
|--------|--------|
| <img width="907" height="773" alt="Screenshot 2026-06-12 at 14 52 40" src="https://github.com/user-attachments/assets/fd8d5dfa-5922-4e44-8123-2cf3c892b210" /> | <img width="905" height="756" alt="Screenshot 2026-06-12 at 14 59 38" src="https://github.com/user-attachments/assets/2a32c59f-58c0-45bf-ac6f-6073474650f1" /> |
| <img width="912" height="530" alt="Screenshot 2026-06-12 at 14 52 47" src="https://github.com/user-attachments/assets/6705a620-0027-4c6a-995d-75b82da80fcf" /> | <img width="904" height="506" alt="Screenshot 2026-06-12 at 14 59 47" src="https://github.com/user-attachments/assets/bc6b9a1d-f3ce-4002-850c-0ae2e337cc01" /> |
| <img width="903" height="936" alt="Screenshot 2026-06-12 at 14 55 43" src="https://github.com/user-attachments/assets/d2a3c07b-0436-447f-9aa9-ef405bf175da" /> | <img width="912" height="481" alt="Screenshot 2026-06-12 at 14 59 53" src="https://github.com/user-attachments/assets/64b04314-ad49-422a-9870-5ef083beb036" /> |
| <img width="905" height="431" alt="Screenshot 2026-06-12 at 14 55 53" src="https://github.com/user-attachments/assets/086aca3d-822e-493a-b186-fd3666c9fa2a" /> | <img width="907" height="399" alt="Screenshot 2026-06-12 at 15 00 01" src="https://github.com/user-attachments/assets/f37671e1-c91e-4417-b03f-4c2f8e10152d" /> |
| <img width="908" height="325" alt="Screenshot 2026-06-12 at 14 56 02" src="https://github.com/user-attachments/assets/e6e96a7e-6fb7-49b2-8cae-4746dfecc53a" /> | <img width="900" height="294" alt="Screenshot 2026-06-12 at 15 00 08" src="https://github.com/user-attachments/assets/f86afb64-5b16-4133-b4cf-991a23aac163" /> | 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: This is mainly the removal of code. No tests needed.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface Updates**
  * Preview page now displays entity data in table format instead of expandable copy-able CSV text sections.
  * Source summary display simplified to show only system existence status and documentation URL, reducing information density.
  * Improved data presentation with consistent table-based layouts across all preview sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->