### PR TITLE
Add assign entities functionality and related templates

### DIFF
--- a/application/blueprints/base/views.py
+++ b/application/blueprints/base/views.py
@@ -50,7 +50,12 @@ def toggle_process_lock(process):
         return redirect(url_for("base.index"))
 
     user = session.get("user", {})
-    username = user.get("login", "unknown")
+    if current_app.config.get("AUTHENTICATION_ON", True):
+        if not user:
+            return redirect(url_for("auth.login", next=request.url))
+        username = user["login"]
+    else:
+        username = user.get("login", "development")
 
     lock = db.session.get(ServiceLock, process)
     if lock:

--- a/application/blueprints/base/views.py
+++ b/application/blueprints/base/views.py
@@ -15,7 +15,9 @@ from application.extensions import db
 
 base = Blueprint("base", __name__)
 
-ADD_DATA_LOCK = "add_data"
+ADD_DATA_LOCK = "add-data"
+ASSIGN_ENTITIES_LOCK = "assign-entities"
+PROCESS_LOCKS = [ADD_DATA_LOCK, ASSIGN_ENTITIES_LOCK]
 
 
 @base.route("/")
@@ -23,30 +25,42 @@ ADD_DATA_LOCK = "add_data"
 def index():
     authentication_on = current_app.config.get("AUTHENTICATION_ON", True)
     add_data_blocked_by = request.args.get("add_data_blocked_by")
+    assign_entities_blocked_by = request.args.get("assign_entities_blocked_by")
     try:
         add_data_lock = db.session.get(ServiceLock, ADD_DATA_LOCK)
     except Exception:
         add_data_lock = None
+    try:
+        assign_entities_lock = db.session.get(ServiceLock, ASSIGN_ENTITIES_LOCK)
+    except Exception:
+        assign_entities_lock = None
     return render_template(
         "index.html",
         authentication_on=authentication_on,
         add_data_lock=add_data_lock,
         add_data_blocked_by=add_data_blocked_by,
+        assign_entities_lock=assign_entities_lock,
+        assign_entities_blocked_by=assign_entities_blocked_by,
     )
 
 
-@base.route("/process-lock/add-data/toggle", methods=["POST"])
-def toggle_add_data_lock():
+@base.route("/process-lock/<process>/toggle", methods=["POST"])
+def toggle_process_lock(process):
+    if process not in PROCESS_LOCKS:
+        return redirect(url_for("base.index"))
+
     user = session.get("user", {})
     username = user.get("login", "unknown")
 
-    lock = db.session.get(ServiceLock, ADD_DATA_LOCK)
+    lock = db.session.get(ServiceLock, process)
     if lock:
         db.session.delete(lock)
     else:
         db.session.add(
             ServiceLock(
-                name=ADD_DATA_LOCK, locked_by=username, locked_at=datetime.utcnow()
+                name=process,
+                locked_by=username,
+                locked_at=datetime.utcnow(),
             )
         )
     db.session.commit()

--- a/application/blueprints/datamanager/controllers/flagged_resources.py
+++ b/application/blueprints/datamanager/controllers/flagged_resources.py
@@ -1,0 +1,470 @@
+import json
+import logging
+import tempfile
+import uuid
+from io import BytesIO, StringIO
+from pathlib import Path
+
+import pandas as pd
+from flask import redirect, render_template, request, session, url_for
+
+from application.data_access.overview.digital_land_queries import get_resource
+
+from . import ControllerError
+from .transform import handle_check_transform
+from ..services.async_api import AsyncAPIError, fetch_request, submit_request
+from ..services.dataset import get_collection_id, get_dataset_id, get_dataset_name
+
+
+REQUIRED_COLUMNS = [
+    "dataset",
+    "resource",
+    "organisation",
+    "reference",
+    "status",
+    "entities_created",
+    "error_code",
+    "message",
+]
+
+_CACHE_DIR = Path(tempfile.gettempdir()) / "config-manager-flagged-resources"
+logger = logging.getLogger(__name__)
+
+ERROR_ABBREVIATIONS = {
+    "current_resource_empty": {
+        "abbreviation": "CRE",
+        "description": "Resource empty",
+    },
+    "current_resource_no_new_entities": {
+        "abbreviation": "NNE",
+        "description": "No new entities",
+    },
+    "duplicate_entity_all_fields": {
+        "abbreviation": "DEAF",
+        "description": "Resource contains duplicates with existing entities (all fields)",
+    },
+    "duplicate_reference_organisation_in_new_resource": {
+        "abbreviation": "DRON",
+        "description": (
+            "Resource contains duplicate entities (organisation and reference)"
+        ),
+    },
+    "duplicate_reference_organisation": {
+        "abbreviation": "DRO",
+        "description": (
+            "Resource contains duplicates with existing entities "
+            "(Reference and organisation only)"
+        ),
+    },
+    "missing_organisation": {
+        "abbreviation": "MO",
+        "description": (
+            "Resource contain entities with missing organisation value"
+        ),
+    },
+    "missing_reference": {
+        "abbreviation": "MR",
+        "description": "Resource contain entities with missing reference values",
+    },
+    "invalid_uri_issue": {
+        "abbreviation": "IUI",
+        "description": (
+            "Resource has known issues with invalid URIs that require manual review."
+        ),
+    },
+    "large_number_of_new_entities": {
+        "abbreviation": "EG",
+        "description": "Entity growth is above threshold",
+    },
+    "previous_resource_not_found": {
+        "abbreviation": "PRNF",
+        "description": "Previous resource not found",
+    },
+    "previous_resource_empty": {
+        "abbreviation": "PRE",
+        "description": "Previous resource is empty",
+    },
+}
+
+ERROR_SORT_ORDER = {
+    "EG": 0,
+    "CRE": 1,
+    "NNE": 2,
+    "DEAF": 3,
+    "DRON": 4,
+    "DRO": 5,
+    "MO": 6,
+    "MR": 7,
+    "IUI": 8,
+    "PRE": 9,
+    "PRNF": 10,
+}
+
+
+def _normalise_frame(df):
+    df = df.fillna("")
+    for column in REQUIRED_COLUMNS:
+        df[column] = df[column].astype(str).str.strip()
+    return df
+
+
+def _validate_error_codes(df):
+    error_rows = df["status"].str.lower().eq("error")
+    missing_codes = error_rows & df["error_code"].eq("")
+    if missing_codes.any():
+        raise ValueError("Rows with status 'error' must include an error_code")
+
+
+def _read_csv_upload(uploaded_file):
+    contents = uploaded_file.read()
+    if not contents:
+        raise ValueError("Upload a CSV file")
+
+    df = pd.read_csv(BytesIO(contents), dtype=str, keep_default_na=False)
+    missing = [column for column in REQUIRED_COLUMNS if column not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {', '.join(missing)}")
+
+    df = _normalise_frame(df[REQUIRED_COLUMNS])
+    if df.empty:
+        raise ValueError("No data found in CSV")
+    _validate_error_codes(df)
+    return df
+
+
+def _read_csv_text(csv_data):
+    csv_data = (csv_data or "").strip()
+    if not csv_data:
+        raise ValueError("Enter CSV data")
+
+    df = pd.read_csv(StringIO(csv_data), dtype=str, keep_default_na=False)
+    missing = [column for column in REQUIRED_COLUMNS if column not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {', '.join(missing)}")
+
+    df = _normalise_frame(df[REQUIRED_COLUMNS])
+    if df.empty:
+        raise ValueError("No data found in CSV")
+    _validate_error_codes(df)
+    return df
+
+
+def _serialise_rows(df):
+    return df.to_dict(orient="records")
+
+
+def _store_rows(df):
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cache_key = uuid.uuid4().hex
+    cache_path = _CACHE_DIR / f"{cache_key}.json"
+    cache_path.write_text(json.dumps(_serialise_rows(df)), encoding="utf-8")
+    session["flagged_resource_cache_key"] = cache_key
+    session.pop("flagged_resource_rows", None)
+
+
+def _frame_from_session():
+    cache_key = session.get("flagged_resource_cache_key")
+    rows = []
+    if cache_key:
+        cache_path = _CACHE_DIR / f"{cache_key}.json"
+        if cache_path.exists():
+            try:
+                rows = json.loads(cache_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                rows = []
+    if not rows:
+        rows = session.get("flagged_resource_rows") or []
+    if not rows:
+        return pd.DataFrame(columns=REQUIRED_COLUMNS)
+    return _normalise_frame(pd.DataFrame(rows, columns=REQUIRED_COLUMNS))
+
+
+def _has_error(row):
+    return str(row.get("status", "")).strip().lower() == "error"
+
+
+def _error_abbreviation(error_code):
+    mapped_error = ERROR_ABBREVIATIONS.get(str(error_code).strip().lower())
+    if mapped_error:
+        return mapped_error["abbreviation"]
+    return error_code.upper()
+
+
+def _error_description(error_code, message):
+    mapped_error = ERROR_ABBREVIATIONS.get(str(error_code).strip().lower())
+    if mapped_error:
+        return mapped_error["description"]
+    return message
+
+
+def _summarise_errors(rows):
+    errors = []
+    seen = set()
+    for row in rows:
+        if not _has_error(row):
+            continue
+
+        error_code = row.get("error_code", "")
+        if error_code and error_code not in seen:
+            errors.append(
+                {
+                    "code": error_code,
+                    "abbreviation": _error_abbreviation(error_code),
+                    "message": _error_description(
+                        error_code, row.get("message", "")
+                    ),
+                }
+            )
+            seen.add(error_code)
+
+    return errors
+
+
+def _build_error_key(resources):
+    error_key = []
+    seen = set()
+    for resource in resources:
+        for error in resource["errors"]:
+            key = error["abbreviation"]
+            if key in seen:
+                continue
+            error_key.append(error)
+            seen.add(key)
+    return sorted(
+        error_key,
+        key=lambda error: (
+            ERROR_SORT_ORDER.get(error["abbreviation"], 99),
+            error["abbreviation"],
+        ),
+    )
+
+
+def _resource_error_sort_key(resource):
+    error_order = min(
+        (
+            ERROR_SORT_ORDER.get(error["abbreviation"], 99)
+            for error in resource["errors"]
+        ),
+        default=99,
+    )
+    row_order = {"entity_growth": 0, "orange": 1, "red": 2}.get(
+        resource["row_type"], 3
+    )
+    return (
+        row_order,
+        error_order,
+        resource["dataset"],
+        resource["organisation"],
+        resource["resource"],
+    )
+
+
+def _group_resources(df):
+    if df.empty:
+        return []
+
+    resources = []
+    grouped = df.groupby(["resource", "dataset", "organisation"], dropna=False)
+    for (resource, dataset, organisation), group in grouped:
+        rows = group.to_dict(orient="records")
+        errors = _summarise_errors(rows)
+        if not any(_has_error(row) for row in rows):
+            continue
+
+        error_abbreviations = {error["abbreviation"] for error in errors}
+        if error_abbreviations == {"EG"}:
+            row_type = "entity_growth"
+            row_colour = ""
+        elif "EG" in error_abbreviations:
+            row_type = "orange"
+            row_colour = "orange"
+        else:
+            row_type = "red"
+            row_colour = "red"
+
+        resources.append(
+            {
+                "resource": resource,
+                "dataset": dataset,
+                "organisation": organisation,
+                "errors": errors,
+                "row_type": row_type,
+                "row_colour": row_colour,
+                "is_entity_growth_only": row_type == "entity_growth",
+                "rows": len(rows),
+            }
+        )
+
+    return sorted(resources, key=_resource_error_sort_key)
+
+
+def _resolve_dataset_and_collection(dataset_input):
+    dataset_id = get_dataset_id(dataset_input) or dataset_input
+    dataset_name = get_dataset_name(dataset_id, default=dataset_input)
+    collection_id = (
+        get_collection_id(dataset_input)
+        or get_collection_id(dataset_name)
+        or dataset_id
+    )
+    return dataset_id, collection_id
+
+
+def _organisation_from_cached_rows(resource, dataset_id):
+    df = _frame_from_session()
+    if df.empty:
+        return None
+
+    matches = df[df["resource"] == resource]
+    if dataset_id:
+        dataset_matches = matches[matches["dataset"] == dataset_id]
+        if not dataset_matches.empty:
+            matches = dataset_matches
+
+    if matches.empty:
+        return None
+
+    organisation = matches.iloc[0].get("organisation", "")
+    return organisation or None
+
+
+def _get_resource_organisation(resource, dataset_id):
+    try:
+        resource_rows = get_resource(resource) or []
+    except Exception as e:
+        logger.warning("Could not fetch resource details for %s: %s", resource, e)
+        resource_rows = []
+
+    matching_rows = resource_rows
+    if dataset_id:
+        matching_rows = [
+            row
+            for row in resource_rows
+            if dataset_id in (row.get("pipeline", "") or "").split(";")
+        ] or resource_rows
+
+    for row in matching_rows:
+        organisation = row.get("organisation")
+        if organisation:
+            return organisation
+
+    return _organisation_from_cached_rows(resource, dataset_id)
+
+
+def _submit_assign_entities_request(dataset_input, resource):
+    dataset_id, collection_id = _resolve_dataset_and_collection(dataset_input)
+    organisation = _get_resource_organisation(resource, dataset_id)
+    params = {
+        "type": 'add_data',
+        "resource": resource,
+        "dataset": dataset_id,
+        "collection": collection_id,
+        "authoritative": True
+    }
+    if organisation:
+        params["organisationName"] = organisation
+        params["organisation"] = organisation
+    return submit_request(params)
+
+
+def handle_flagged_resources_start():
+    errors = {}
+    form = {
+        "dataset": request.form.get("dataset", "").strip(),
+        "resource": request.form.get("resource", "").strip(),
+    }
+
+    if request.method == "POST":
+        has_direct_input = bool(form["dataset"] or form["resource"])
+
+        if has_direct_input:
+            if not form["dataset"]:
+                errors["dataset"] = "Enter a dataset"
+            if not form["resource"]:
+                errors["resource"] = "Enter a resource"
+            if not errors:
+                try:
+                    request_id = _submit_assign_entities_request(
+                        form["dataset"], form["resource"]
+                    )
+                except AsyncAPIError as e:
+                    raise Exception(
+                        f"Assign entities submission failed: {e.detail}"
+                    ) from e
+                return redirect(
+                    url_for("assign_entities.flagged_resource_detail", request_id=request_id)
+                )
+        else:
+            errors["form"] = "Enter a dataset and resource"
+
+    return render_template(
+        "datamanager/flagged-resources-start.html",
+        errors=errors,
+        form=form,
+    )
+
+
+def handle_flagged_resources_import():
+    errors = {}
+    csv_data = request.form.get("csv_data", "").strip()
+
+    if request.method == "POST":
+        uploaded_file = request.files.get("csv_file")
+        has_upload = bool(uploaded_file and uploaded_file.filename)
+
+        try:
+            df = (
+                _read_csv_upload(uploaded_file)
+                if has_upload
+                else _read_csv_text(csv_data)
+            )
+        except ValueError as e:
+            errors["csv_data"] = str(e)
+        else:
+            _store_rows(df)
+            return redirect(url_for("assign_entities.flagged_resources_summary"))
+
+    return render_template(
+        "datamanager/flagged-resources-import.html",
+        csv_data=csv_data,
+        errors=errors,
+        required_columns=REQUIRED_COLUMNS,
+    )
+
+
+def handle_flagged_resources_summary():
+    df = _frame_from_session()
+    if df.empty:
+        return redirect(url_for("assign_entities.flagged_resources_start"))
+
+    resources = _group_resources(df)
+    return render_template(
+        "datamanager/flagged-resources-summary.html",
+        resources=resources,
+        error_key=_build_error_key(resources),
+        resource_count=len(resources),
+    )
+
+
+def handle_flagged_resource_submit():
+    dataset = request.args.get("dataset", "").strip()
+    resource = request.args.get("resource", "").strip()
+    if not dataset or not resource:
+        raise ControllerError("Dataset and resource are required")
+
+    try:
+        request_id = _submit_assign_entities_request(dataset, resource)
+    except AsyncAPIError as e:
+        raise Exception(f"Assign entities submission failed: {e.detail}") from e
+
+    return redirect(
+        url_for("assign_entities.flagged_resource_detail", request_id=request_id)
+    )
+
+
+def handle_flagged_resource_detail(request_id):
+    req = fetch_request(request_id)
+    return handle_check_transform(
+        request_id,
+        req,
+        transform_endpoint="assign_entities.flagged_resource_detail",
+    )

--- a/application/blueprints/datamanager/controllers/flagged_resources.py
+++ b/application/blueprints/datamanager/controllers/flagged_resources.py
@@ -346,7 +346,9 @@ def _get_resource_organisation(resource, dataset_id):
     return _organisation_from_cached_rows(resource, dataset_id)
 
 
-def _submit_assign_entities_request(dataset_input, resource, organisation=None):
+def _submit_assign_entities_request(
+    dataset_input, resource, organisation=None, return_endpoint=None
+):
     dataset_id, collection_id = _resolve_dataset_and_collection(dataset_input)
     organisation = organisation or _get_resource_organisation(resource, dataset_id)
     params = {
@@ -360,6 +362,8 @@ def _submit_assign_entities_request(dataset_input, resource, organisation=None):
     if organisation:
         params["organisationName"] = organisation
         params["organisation"] = organisation
+    if return_endpoint:
+        params["return_endpoint"] = return_endpoint
     return submit_request(params)
 
 
@@ -381,7 +385,9 @@ def handle_flagged_resources_start():
             if not errors:
                 try:
                     request_id = _submit_assign_entities_request(
-                        form["dataset"], form["resource"]
+                        form["dataset"],
+                        form["resource"],
+                        return_endpoint="assign_entities.flagged_resources_start",
                     )
                 except AsyncAPIError as e:
                     raise ControllerError(
@@ -455,7 +461,12 @@ def handle_flagged_resource_submit():
         raise ControllerError("Dataset and resource are required")
 
     try:
-        request_id = _submit_assign_entities_request(dataset, resource, organisation)
+        request_id = _submit_assign_entities_request(
+            dataset,
+            resource,
+            organisation,
+            return_endpoint="assign_entities.flagged_resources_summary",
+        )
     except AsyncAPIError as e:
         raise ControllerError(f"Assign entities submission failed: {e.detail}") from e
 

--- a/application/blueprints/datamanager/controllers/flagged_resources.py
+++ b/application/blueprints/datamanager/controllers/flagged_resources.py
@@ -447,6 +447,9 @@ def handle_flagged_resource_submit():
     dataset = request.form.get("dataset", "").strip()
     resource = request.form.get("resource", "").strip()
     organisation = request.form.get("organisation", "").strip() or None
+    errors = [
+        error for error in request.form.get("errors", "").strip().split(",") if error
+    ]
     if not dataset or not resource:
         raise ControllerError("Dataset and resource are required")
 
@@ -456,15 +459,25 @@ def handle_flagged_resource_submit():
         raise ControllerError(f"Assign entities submission failed: {e.detail}") from e
 
     return redirect(
-        url_for("assign_entities.flagged_resource_detail", request_id=request_id)
+        url_for(
+            "assign_entities.flagged_resource_detail",
+            request_id=request_id,
+            errors=",".join(errors),
+        )
     )
 
 
 def handle_flagged_resource_detail(request_id):
     req = fetch_request(request_id)
+    flagged_errors = [
+        error for error in request.args.get("errors", "").strip().split(",") if error
+    ]
+    flagged_error_messages = [_error_description(error, "") for error in flagged_errors]
     return handle_check_transform(
         request_id,
         req,
         transform_endpoint="assign_entities.flagged_resource_detail",
         template_name="datamanager/assign-entities-check-results.html",
+        flagged_errors=flagged_errors,
+        flagged_error_messages=flagged_error_messages,
     )

--- a/application/blueprints/datamanager/controllers/flagged_resources.py
+++ b/application/blueprints/datamanager/controllers/flagged_resources.py
@@ -15,7 +15,6 @@ from .transform import handle_check_transform
 from ..services.async_api import AsyncAPIError, fetch_request, submit_request
 from ..services.dataset import get_collection_id, get_dataset_id, get_dataset_name
 
-
 REQUIRED_COLUMNS = [
     "dataset",
     "resource",
@@ -58,9 +57,7 @@ ERROR_ABBREVIATIONS = {
     },
     "missing_organisation": {
         "abbreviation": "MO",
-        "description": (
-            "Resource contain entities with missing organisation value"
-        ),
+        "description": ("Resource contain entities with missing organisation value"),
     },
     "missing_reference": {
         "abbreviation": "MR",
@@ -155,11 +152,16 @@ def _serialise_rows(df):
 
 def _store_rows(df):
     _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    previous_cache_key = session.get("flagged_resource_cache_key")
+    if previous_cache_key:
+        previous_cache_path = _CACHE_DIR / f"{previous_cache_key}.json"
+        if previous_cache_path.exists():
+            previous_cache_path.unlink()
+
     cache_key = uuid.uuid4().hex
     cache_path = _CACHE_DIR / f"{cache_key}.json"
     cache_path.write_text(json.dumps(_serialise_rows(df)), encoding="utf-8")
     session["flagged_resource_cache_key"] = cache_key
-    session.pop("flagged_resource_rows", None)
 
 
 def _frame_from_session():
@@ -172,8 +174,6 @@ def _frame_from_session():
                 rows = json.loads(cache_path.read_text(encoding="utf-8"))
             except json.JSONDecodeError:
                 rows = []
-    if not rows:
-        rows = session.get("flagged_resource_rows") or []
     if not rows:
         return pd.DataFrame(columns=REQUIRED_COLUMNS)
     return _normalise_frame(pd.DataFrame(rows, columns=REQUIRED_COLUMNS))
@@ -210,9 +210,7 @@ def _summarise_errors(rows):
                 {
                     "code": error_code,
                     "abbreviation": _error_abbreviation(error_code),
-                    "message": _error_description(
-                        error_code, row.get("message", "")
-                    ),
+                    "message": _error_description(error_code, row.get("message", "")),
                 }
             )
             seen.add(error_code)
@@ -247,9 +245,7 @@ def _resource_error_sort_key(resource):
         ),
         default=99,
     )
-    row_order = {"entity_growth": 0, "orange": 1, "red": 2}.get(
-        resource["row_type"], 3
-    )
+    row_order = {"entity_growth": 0, "orange": 1, "red": 2}.get(resource["row_type"], 3)
     return (
         row_order,
         error_order,
@@ -350,15 +346,15 @@ def _get_resource_organisation(resource, dataset_id):
     return _organisation_from_cached_rows(resource, dataset_id)
 
 
-def _submit_assign_entities_request(dataset_input, resource):
+def _submit_assign_entities_request(dataset_input, resource, organisation=None):
     dataset_id, collection_id = _resolve_dataset_and_collection(dataset_input)
-    organisation = _get_resource_organisation(resource, dataset_id)
+    organisation = organisation or _get_resource_organisation(resource, dataset_id)
     params = {
-        "type": 'add_data',
+        "type": "add_data",
         "resource": resource,
         "dataset": dataset_id,
         "collection": collection_id,
-        "authoritative": True
+        "authoritative": True,
     }
     if organisation:
         params["organisationName"] = organisation
@@ -387,11 +383,13 @@ def handle_flagged_resources_start():
                         form["dataset"], form["resource"]
                     )
                 except AsyncAPIError as e:
-                    raise Exception(
+                    raise ControllerError(
                         f"Assign entities submission failed: {e.detail}"
                     ) from e
                 return redirect(
-                    url_for("assign_entities.flagged_resource_detail", request_id=request_id)
+                    url_for(
+                        "assign_entities.flagged_resource_detail", request_id=request_id
+                    )
                 )
         else:
             errors["form"] = "Enter a dataset and resource"
@@ -446,15 +444,16 @@ def handle_flagged_resources_summary():
 
 
 def handle_flagged_resource_submit():
-    dataset = request.args.get("dataset", "").strip()
-    resource = request.args.get("resource", "").strip()
+    dataset = request.form.get("dataset", "").strip()
+    resource = request.form.get("resource", "").strip()
+    organisation = request.form.get("organisation", "").strip() or None
     if not dataset or not resource:
         raise ControllerError("Dataset and resource are required")
 
     try:
-        request_id = _submit_assign_entities_request(dataset, resource)
+        request_id = _submit_assign_entities_request(dataset, resource, organisation)
     except AsyncAPIError as e:
-        raise Exception(f"Assign entities submission failed: {e.detail}") from e
+        raise ControllerError(f"Assign entities submission failed: {e.detail}") from e
 
     return redirect(
         url_for("assign_entities.flagged_resource_detail", request_id=request_id)

--- a/application/blueprints/datamanager/controllers/flagged_resources.py
+++ b/application/blueprints/datamanager/controllers/flagged_resources.py
@@ -6,7 +6,7 @@ from io import BytesIO, StringIO
 from pathlib import Path
 
 import pandas as pd
-from flask import redirect, render_template, request, session, url_for
+from flask import current_app, redirect, render_template, request, session, url_for
 
 from application.data_access.overview.digital_land_queries import get_resource
 
@@ -355,6 +355,7 @@ def _submit_assign_entities_request(dataset_input, resource, organisation=None):
         "dataset": dataset_id,
         "collection": collection_id,
         "authoritative": True,
+        "github_branch": current_app.config.get("CONFIG_REPO_BRANCH") or None,
     }
     if organisation:
         params["organisationName"] = organisation

--- a/application/blueprints/datamanager/controllers/flagged_resources.py
+++ b/application/blueprints/datamanager/controllers/flagged_resources.py
@@ -466,4 +466,5 @@ def handle_flagged_resource_detail(request_id):
         request_id,
         req,
         transform_endpoint="assign_entities.flagged_resource_detail",
+        template_name="datamanager/assign-entities-check-results.html",
     )

--- a/application/blueprints/datamanager/controllers/preview.py
+++ b/application/blueprints/datamanager/controllers/preview.py
@@ -96,6 +96,11 @@ def handle_entities_preview(request_id, req):
     ) = build_column_csv_preview(column_mapping, dataset_id, endpoint_summary)
 
     github_branch = params.get("github_branch") or None
+    source_flow = (
+        "assign_entities"
+        if params.get("resource") and not params.get("url")
+        else "add_data"
+    )
 
     # Retire endpoint details
     request_meta = db.session.get(RequestMeta, request_id)
@@ -149,6 +154,7 @@ def handle_entities_preview(request_id, req):
         "datamanager/entities_preview.html",
         request_id=request_id,
         github_branch=github_branch,
+        source_flow=source_flow,
         retire_summary=retire_summary,
         new_count=int(pipeline_summary.get("new-in-resource") or 0),
         existing_count=int(pipeline_summary.get("existing-in-resource") or 0),
@@ -167,7 +173,9 @@ def handle_entities_preview(request_id, req):
     )
 
 
-def handle_add_data_confirm(request_id, github_branch: str | None = None):
+def handle_add_data_confirm(
+    request_id, github_branch: str | None = None, source_flow: str = "add_data"
+):
     request_meta = db.session.get(RequestMeta, request_id)
     endpoints_to_retire = (
         json.loads(request_meta.endpoints_to_retire or "[]") if request_meta else []
@@ -192,4 +200,5 @@ def handle_add_data_confirm(request_id, github_branch: str | None = None):
         "datamanager/add-data-success.html",
         message=result["message"],
         github_branch=github_branch,
+        source_flow=source_flow,
     )

--- a/application/blueprints/datamanager/controllers/preview.py
+++ b/application/blueprints/datamanager/controllers/preview.py
@@ -4,6 +4,7 @@ import logging
 from flask import (
     render_template,
     session,
+    url_for,
 )
 
 from application.db.models import RequestMeta
@@ -101,6 +102,13 @@ def handle_entities_preview(request_id, req):
         if params.get("resource") and not params.get("url")
         else "add_data"
     )
+    return_endpoint = params.get("return_endpoint")
+    if return_endpoint:
+        return_url = url_for(return_endpoint)
+    elif source_flow == "assign_entities":
+        return_url = url_for("assign_entities.flagged_resources_start")
+    else:
+        return_url = url_for("datamanager.dashboard_get")
 
     # Retire endpoint details
     request_meta = db.session.get(RequestMeta, request_id)
@@ -155,6 +163,7 @@ def handle_entities_preview(request_id, req):
         request_id=request_id,
         github_branch=github_branch,
         source_flow=source_flow,
+        return_url=return_url,
         retire_summary=retire_summary,
         new_count=int(pipeline_summary.get("new-in-resource") or 0),
         existing_count=int(pipeline_summary.get("existing-in-resource") or 0),
@@ -174,7 +183,10 @@ def handle_entities_preview(request_id, req):
 
 
 def handle_add_data_confirm(
-    request_id, github_branch: str | None = None, source_flow: str = "add_data"
+    request_id,
+    github_branch: str | None = None,
+    source_flow: str = "add_data",
+    return_url: str | None = None,
 ):
     request_meta = db.session.get(RequestMeta, request_id)
     endpoints_to_retire = (
@@ -195,10 +207,16 @@ def handle_add_data_confirm(
         logger.error(f"Failed to trigger async workflow: {result['message']}")
         raise ControllerError(f"Failed to trigger async workflow: {result['message']}")
 
+    fallback_return_url = (
+        url_for("assign_entities.flagged_resources_start")
+        if source_flow == "assign_entities"
+        else url_for("datamanager.dashboard_get")
+    )
     logger.info(f"Successfully triggered async workflow for request_id: {request_id}")
     return render_template(
         "datamanager/add-data-success.html",
         message=result["message"],
         github_branch=github_branch,
         source_flow=source_flow,
+        return_url=return_url or fallback_return_url,
     )

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -109,6 +109,15 @@ def build_entities_data(resp_details: list, platform_entities: list) -> dict:
     return {"columns": columns, "rows": rows}
 
 
+def _entity_row_matches_search(row: dict, search_query: str) -> bool:
+    if not search_query:
+        return True
+
+    fields = row.get("fields") or {}
+    row_text = " ".join(str(value) for value in fields.values()).lower()
+    return search_query.lower() in row_text
+
+
 def handle_check_transform(
     request_id,
     req,
@@ -161,6 +170,7 @@ def handle_check_transform(
     has_next_page = len(all_resp_details) > start_offset + _ROWS_PER_PAGE
 
     entity_page = max(1, int(flask_request.args.get("entity_page", 1)))
+    entity_search = flask_request.args.get("entity_search", "").strip()
     entity_start_offset = (entity_page - 1) * _ROWS_PER_PAGE
 
     response_payload = req.get("response") or {}
@@ -221,6 +231,12 @@ def handle_check_transform(
     # Build combined transformed entity data with platform entities and resp details entities, and paginate
 
     entities_data_full = build_entities_data(all_resp_details, platform_entities)
+    if entity_search:
+        entities_data_full["rows"] = [
+            row
+            for row in entities_data_full["rows"]
+            if _entity_row_matches_search(row, entity_search)
+        ]
     has_next_entity_page = (
         len(entities_data_full["rows"]) > entity_start_offset + _ROWS_PER_PAGE
     )
@@ -316,6 +332,7 @@ def handle_check_transform(
         page_start=page_start,
         page_end=page_end,
         entity_page=entity_page,
+        entity_search=entity_search,
         has_next_entity_page=has_next_entity_page,
         entity_page_start=entity_page_start,
         entity_page_end=entity_page_end,

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -123,6 +123,9 @@ def handle_check_transform(
     req,
     transform_endpoint="datamanager.check_transform",
     template_name="datamanager/check-transform.html",
+    flagged_errors=None,
+    flagged_error_abbreviations=None,
+    flagged_error_messages=None,
 ):
     """Display transformed facts and issue logs from response-details for a request.
 
@@ -132,6 +135,7 @@ def handle_check_transform(
     params = req.get("params") or {}
     organisation_code = params.get("organisationName") or params.get("organisation", "")
     dataset_id = params.get("dataset", "")
+    resource_hash = params.get("resource", "")
     organisation_display = get_organisation_name(organisation_code)
     dataset_display = get_dataset_name(dataset_id, default=dataset_id)
 
@@ -341,4 +345,8 @@ def handle_check_transform(
         endpoint_is_gov_uk=endpoint_is_gov_uk,
         endpoint_url=endpoint_url,
         documentation_url=documentation_url,
+        resource_hash=resource_hash,
+        flagged_errors=flagged_errors or [],
+        flagged_error_abbreviations=flagged_error_abbreviations or [],
+        flagged_error_messages=flagged_error_messages or [],
     )

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -109,7 +109,11 @@ def build_entities_data(resp_details: list, platform_entities: list) -> dict:
     return {"columns": columns, "rows": rows}
 
 
-def handle_check_transform(request_id, req):
+def handle_check_transform(
+    request_id,
+    req,
+    transform_endpoint="datamanager.check_transform",
+):
     """Display transformed facts and issue logs from response-details for a request.
 
     Shows a loading page while the async job is still running, and the full
@@ -144,6 +148,7 @@ def handle_check_transform(request_id, req):
             request_id=request_id,
             organisation_display=organisation_display,
             dataset_display=dataset_display,
+            transform_endpoint=transform_endpoint,
         )
 
     all_resp_details = fetch_response_details(request_id)
@@ -294,6 +299,7 @@ def handle_check_transform(request_id, req):
     return render_template(
         "datamanager/check-transform.html",
         request_id=request_id,
+        transform_endpoint=transform_endpoint,
         organisation_display=organisation_display,
         dataset_display=dataset_display,
         transformed_table=transformed_table,

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -113,6 +113,7 @@ def handle_check_transform(
     request_id,
     req,
     transform_endpoint="datamanager.check_transform",
+    template_name="datamanager/check-transform.html",
 ):
     """Display transformed facts and issue logs from response-details for a request.
 
@@ -297,7 +298,7 @@ def handle_check_transform(
     endpoint_is_gov_uk = is_gov_uk_url(endpoint_url)
 
     return render_template(
-        "datamanager/check-transform.html",
+        template_name,
         request_id=request_id,
         transform_endpoint=transform_endpoint,
         organisation_display=organisation_display,

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -238,19 +238,6 @@ def flagged_resource_submit():
 
 
 def flagged_resource_detail(request_id):
-    if request.method == "POST":
-        hashes = request.form.getlist("retire_endpoints")
-        meta = db.session.get(RequestMeta, request_id)
-        if meta is None:
-            meta = RequestMeta(
-                request_id=request_id, endpoints_to_retire=json.dumps(hashes)
-            )
-            db.session.add(meta)
-        else:
-            meta.endpoints_to_retire = json.dumps(hashes)
-        db.session.commit()
-        return redirect(url_for("datamanager.entities_preview", request_id=request_id))
-
     try:
         return handle_flagged_resource_detail(request_id)
     except AsyncAPIError:
@@ -319,5 +306,5 @@ assign_entities_bp.add_url_rule(
 assign_entities_bp.add_url_rule(
     "/check-results/<request_id>",
     view_func=flagged_resource_detail,
-    methods=["GET", "POST"],
+    methods=["GET"],
 )

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -88,11 +88,22 @@ def _require_login():
 
 def _require_add_data_unlocked():
     try:
-        lock = db.session.get(ServiceLock, "add_data")
+        lock = db.session.get(ServiceLock, "add-data")
     except Exception:
         lock = None
     if lock:
         return redirect(url_for("base.index", add_data_blocked_by=lock.locked_by))
+
+
+def _require_assign_entities_unlocked():
+    try:
+        lock = db.session.get(ServiceLock, "assign-entities")
+    except Exception:
+        lock = None
+    if lock:
+        return redirect(
+            url_for("base.index", assign_entities_blocked_by=lock.locked_by)
+        )
 
 
 @datamanager_bp.before_request
@@ -112,7 +123,7 @@ def assign_entities_require_login():
     if login_response:
         return login_response
 
-    return _require_add_data_unlocked()
+    return _require_assign_entities_unlocked()
 
 
 # TODO: remove these view functions and move logic entirely into controllers

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -314,7 +314,7 @@ assign_entities_bp.add_url_rule(
 assign_entities_bp.add_url_rule(
     "/resource",
     view_func=flagged_resource_submit,
-    methods=["GET"],
+    methods=["POST"],
 )
 assign_entities_bp.add_url_rule(
     "/check-results/<request_id>",

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -50,7 +50,7 @@ from .utils import (
 
 datamanager_bp = Blueprint("datamanager", __name__, url_prefix="/datamanager")
 assign_entities_bp = Blueprint(
-    "assign_entities", __name__, url_prefix="/asign-entities"
+    "assign_entities", __name__, url_prefix="/assign-entities"
 )
 logger = logging.getLogger(__name__)
 

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -12,6 +12,7 @@ from flask import (
 )
 from werkzeug.exceptions import RequestEntityTooLarge
 
+from application.blueprints.base.views import ADD_DATA_LOCK, ASSIGN_ENTITIES_LOCK
 from application.db.models import RequestMeta, ServiceLock
 from application.extensions import db
 
@@ -88,7 +89,7 @@ def _require_login():
 
 def _require_add_data_unlocked():
     try:
-        lock = db.session.get(ServiceLock, "add-data")
+        lock = db.session.get(ServiceLock, ADD_DATA_LOCK)
     except Exception:
         lock = None
     if lock:
@@ -97,7 +98,7 @@ def _require_add_data_unlocked():
 
 def _require_assign_entities_unlocked():
     try:
-        lock = db.session.get(ServiceLock, "assign-entities")
+        lock = db.session.get(ServiceLock, ASSIGN_ENTITIES_LOCK)
     except Exception:
         lock = None
     if lock:

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -10,6 +10,7 @@ from flask import (
     url_for,
     session,
 )
+from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
 from application.blueprints.base.views import ADD_DATA_LOCK, ASSIGN_ENTITIES_LOCK
@@ -64,15 +65,17 @@ assign_entities_bp.context_processor(inject_now)
 @assign_entities_bp.errorhandler(RequestEntityTooLarge)
 def handle_assign_entities_request_entity_too_large(e):
     if request.endpoint == "assign_entities.flagged_resources_import":
+        is_upload = (request.content_type or "").startswith("multipart/form-data")
+        message = (
+            "The uploaded CSV is too large. Upload a file smaller than 10MB."
+            if is_upload
+            else "The pasted CSV is too large. Upload the CSV file instead."
+        )
         return (
             render_template(
                 "datamanager/flagged-resources-import.html",
                 csv_data="",
-                errors={
-                    "csv_data": (
-                        "The pasted CSV is too large. Upload the CSV file instead."
-                    )
-                },
+                errors={"csv_data": message},
                 required_columns=REQUIRED_COLUMNS,
             ),
             413,
@@ -90,8 +93,14 @@ def _require_login():
 def _require_add_data_unlocked():
     try:
         lock = db.session.get(ServiceLock, ADD_DATA_LOCK)
-    except Exception:
-        lock = None
+    except SQLAlchemyError:
+        return (
+            render_template(
+                "datamanager/error.html",
+                message="The Add Data lock state is unavailable. Try again later.",
+            ),
+            503,
+        )
     if lock:
         return redirect(url_for("base.index", add_data_blocked_by=lock.locked_by))
 
@@ -99,8 +108,16 @@ def _require_add_data_unlocked():
 def _require_assign_entities_unlocked():
     try:
         lock = db.session.get(ServiceLock, ASSIGN_ENTITIES_LOCK)
-    except Exception:
-        lock = None
+    except SQLAlchemyError:
+        return (
+            render_template(
+                "datamanager/error.html",
+                message=(
+                    "The Assign Entities lock state is unavailable. Try again later."
+                ),
+            ),
+            503,
+        )
     if lock:
         return redirect(
             url_for("base.index", assign_entities_blocked_by=lock.locked_by)
@@ -246,10 +263,14 @@ def add_data_confirm_async(request_id):
     logger.info(f"Triggering async GitHub workflow for request_id: {request_id}")
     github_branch = request.form.get("github_branch") or None
     source_flow = request.form.get("source_flow") or "add_data"
+    return_url = request.form.get("return_url") or None
 
     try:
         return handle_add_data_confirm(
-            request_id, github_branch=github_branch, source_flow=source_flow
+            request_id,
+            github_branch=github_branch,
+            source_flow=source_flow,
+            return_url=return_url,
         )
     except ControllerError as e:
         return render_template("datamanager/error.html", message=e.message)

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -10,6 +10,7 @@ from flask import (
     url_for,
     session,
 )
+from werkzeug.exceptions import RequestEntityTooLarge
 
 from application.db.models import RequestMeta, ServiceLock
 from application.extensions import db
@@ -21,6 +22,7 @@ from .controllers.form import (
     handle_add_data,
 )
 from .controllers.flagged_resources import (
+    REQUIRED_COLUMNS,
     handle_flagged_resource_detail,
     handle_flagged_resource_submit,
     handle_flagged_resources_import,
@@ -56,6 +58,26 @@ datamanager_bp.errorhandler(Exception)(handle_error)
 datamanager_bp.context_processor(inject_now)
 assign_entities_bp.errorhandler(Exception)(handle_error)
 assign_entities_bp.context_processor(inject_now)
+
+
+@assign_entities_bp.errorhandler(RequestEntityTooLarge)
+def handle_assign_entities_request_entity_too_large(e):
+    if request.endpoint == "assign_entities.flagged_resources_import":
+        return (
+            render_template(
+                "datamanager/flagged-resources-import.html",
+                csv_data="",
+                errors={
+                    "csv_data": (
+                        "The pasted CSV is too large. Upload the CSV file instead."
+                    )
+                },
+                required_columns=REQUIRED_COLUMNS,
+            ),
+            413,
+        )
+
+    return render_template("datamanager/error.html", message=str(e)), 413
 
 
 def _require_login():

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -233,9 +233,12 @@ def check_transform_post(request_id):
 def add_data_confirm_async(request_id):
     logger.info(f"Triggering async GitHub workflow for request_id: {request_id}")
     github_branch = request.form.get("github_branch") or None
+    source_flow = request.form.get("source_flow") or "add_data"
 
     try:
-        return handle_add_data_confirm(request_id, github_branch=github_branch)
+        return handle_add_data_confirm(
+            request_id, github_branch=github_branch, source_flow=source_flow
+        )
     except ControllerError as e:
         return render_template("datamanager/error.html", message=e.message)
 

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -20,6 +20,13 @@ from .controllers.form import (
     handle_dashboard_add_import,
     handle_add_data,
 )
+from .controllers.flagged_resources import (
+    handle_flagged_resource_detail,
+    handle_flagged_resource_submit,
+    handle_flagged_resources_import,
+    handle_flagged_resources_start,
+    handle_flagged_resources_summary,
+)
 from .controllers import ControllerError
 from .controllers.check import (
     handle_check_results,
@@ -40,25 +47,50 @@ from .utils import (
 )
 
 datamanager_bp = Blueprint("datamanager", __name__, url_prefix="/datamanager")
+assign_entities_bp = Blueprint(
+    "assign_entities", __name__, url_prefix="/asign-entities"
+)
 logger = logging.getLogger(__name__)
 
 datamanager_bp.errorhandler(Exception)(handle_error)
 datamanager_bp.context_processor(inject_now)
+assign_entities_bp.errorhandler(Exception)(handle_error)
+assign_entities_bp.context_processor(inject_now)
 
 
-@datamanager_bp.before_request
-def require_login():
-    """Require login for all datamanager routes"""
+def _require_login():
     if current_app.config.get("AUTHENTICATION_ON", True):
         if session.get("user") is None:
             return redirect(url_for("auth.login", next=request.url))
 
+
+def _require_add_data_unlocked():
     try:
         lock = db.session.get(ServiceLock, "add_data")
     except Exception:
         lock = None
     if lock:
         return redirect(url_for("base.index", add_data_blocked_by=lock.locked_by))
+
+
+@datamanager_bp.before_request
+def require_login():
+    """Require login for all datamanager routes"""
+    login_response = _require_login()
+    if login_response:
+        return login_response
+
+    return _require_add_data_unlocked()
+
+
+@assign_entities_bp.before_request
+def assign_entities_require_login():
+    """Require login for assign entities routes."""
+    login_response = _require_login()
+    if login_response:
+        return login_response
+
+    return _require_add_data_unlocked()
 
 
 # TODO: remove these view functions and move logic entirely into controllers
@@ -186,6 +218,53 @@ def add_data_confirm_async(request_id):
         return render_template("datamanager/error.html", message=e.message)
 
 
+def flagged_resources_start():
+    return handle_flagged_resources_start()
+
+
+def flagged_resources_import():
+    return handle_flagged_resources_import()
+
+
+def flagged_resources_summary():
+    return handle_flagged_resources_summary()
+
+
+def flagged_resource_submit():
+    try:
+        return handle_flagged_resource_submit()
+    except ControllerError as e:
+        return render_template("datamanager/error.html", message=e.message)
+
+
+def flagged_resource_detail(request_id):
+    if request.method == "POST":
+        hashes = request.form.getlist("retire_endpoints")
+        meta = db.session.get(RequestMeta, request_id)
+        if meta is None:
+            meta = RequestMeta(
+                request_id=request_id, endpoints_to_retire=json.dumps(hashes)
+            )
+            db.session.add(meta)
+        else:
+            meta.endpoints_to_retire = json.dumps(hashes)
+        db.session.commit()
+        return redirect(url_for("datamanager.entities_preview", request_id=request_id))
+
+    try:
+        return handle_flagged_resource_detail(request_id)
+    except AsyncAPIError:
+        return (
+            render_template(
+                "datamanager/error.html",
+                message="Assign entities request not found",
+            ),
+            404,
+        )
+    except ControllerError as e:
+        return render_template("datamanager/error.html", message=e.message)
+
+
 datamanager_bp.add_url_rule("/", view_func=dashboard_get, methods=["GET"])
 datamanager_bp.add_url_rule("/", view_func=dashboard_add, methods=["POST"])
 datamanager_bp.add_url_rule(
@@ -215,4 +294,30 @@ datamanager_bp.add_url_rule(
     "/add-data/<request_id>/confirm-async",
     view_func=add_data_confirm_async,
     methods=["POST"],
+)
+assign_entities_bp.add_url_rule(
+    "/",
+    view_func=flagged_resources_start,
+    methods=["GET", "POST"],
+    strict_slashes=False,
+)
+assign_entities_bp.add_url_rule(
+    "/import",
+    view_func=flagged_resources_import,
+    methods=["GET", "POST"],
+)
+assign_entities_bp.add_url_rule(
+    "/resources",
+    view_func=flagged_resources_summary,
+    methods=["GET"],
+)
+assign_entities_bp.add_url_rule(
+    "/resource",
+    view_func=flagged_resource_submit,
+    methods=["GET"],
+)
+assign_entities_bp.add_url_rule(
+    "/check-results/<request_id>",
+    view_func=flagged_resource_detail,
+    methods=["GET", "POST"],
 )

--- a/application/factory.py
+++ b/application/factory.py
@@ -97,9 +97,13 @@ def register_blueprints(app):
 
     app.register_blueprint(dataset_bp)
 
-    from application.blueprints.datamanager.router import datamanager_bp
+    from application.blueprints.datamanager.router import (
+        assign_entities_bp,
+        datamanager_bp,
+    )
 
     app.register_blueprint(datamanager_bp)
+    app.register_blueprint(assign_entities_bp)
 
     from application.blueprints.schema.views import schema_bp
 

--- a/application/templates/datamanager/add-data-success.html
+++ b/application/templates/datamanager/add-data-success.html
@@ -40,7 +40,7 @@
     </p>
 
     <div class="govuk-button-group govuk-!-margin-top-6">
-      <a href="{{ url_for('assign_entities.flagged_resources_summary') if source_flow == 'assign_entities' else url_for('datamanager.dashboard_get') }}" class="govuk-button" data-module="govuk-button">
+      <a href="{{ return_url or url_for('datamanager.dashboard_get') }}" class="govuk-button" data-module="govuk-button">
         {% if source_flow == 'assign_entities' %}Assign more entities{% else %}Add more data{% endif %}
       </a>
       <a href="{{ url_for('base.index') }}" class="govuk-link">

--- a/application/templates/datamanager/add-data-success.html
+++ b/application/templates/datamanager/add-data-success.html
@@ -40,8 +40,8 @@
     </p>
 
     <div class="govuk-button-group govuk-!-margin-top-6">
-      <a href="{{ url_for('datamanager.dashboard_get') }}" class="govuk-button" data-module="govuk-button">
-        Add more data
+      <a href="{{ url_for('assign_entities.flagged_resources_summary') if source_flow == 'assign_entities' else url_for('datamanager.dashboard_get') }}" class="govuk-button" data-module="govuk-button">
+        {% if source_flow == 'assign_entities' %}Assign more entities{% else %}Add more data{% endif %}
       </a>
       <a href="{{ url_for('base.index') }}" class="govuk-link">
         Return to home

--- a/application/templates/datamanager/assign-entities-check-results.html
+++ b/application/templates/datamanager/assign-entities-check-results.html
@@ -1,0 +1,325 @@
+{% extends 'layouts/base.html' %}
+{% from "components/table.html" import table %}
+{% from "govuk_frontend_jinja/components/pagination/macro.html" import govukPagination %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    {% set _transform_endpoint = transform_endpoint or 'datamanager.check_transform' %}
+    <span class="govuk-caption-xl">{{ organisation_display }}</span>
+    <span class="govuk-body-l" style="display: block; color: #505a5f; margin-bottom: 10px;">{{ dataset_display }}</span>
+    <hr style="border: none; border-top: 2px solid #b1b4b6; margin: 10px 0 10px;">
+    <h1 class="govuk-heading-xl" style="margin-bottom: 10px;">Data Submission Assessment</h1>
+    <hr style="border: none; border-top: 2px solid #b1b4b6; margin: 0 0 20px;">
+    <p id="tab-desc-entities" class="govuk-hint govuk-!-margin-top-8 govuk-!-margin-bottom-4">All entities for this dataset and organisation, with new additions highlighted in <span style="color: #00703c; font-weight: bold;">green</span> and existing entities also present in this resource highlighted in <span style="color: #d4692a; font-weight: bold;">orange</span>.</p>
+    <p id="tab-desc-transformed" class="govuk-hint govuk-!-margin-top-8 govuk-!-margin-bottom-4" style="display:none;">The individual facts extracted from the submitted data by the pipeline <b>with entity lookup enabled</b>.</p>
+    <p id="tab-desc-issue-log" class="govuk-hint govuk-!-margin-top-8 govuk-!-margin-bottom-4" style="display:none;">Any issues the pipeline raised while processing the data.</p>
+
+    {% set window_start = [page_number - 2, 1] | max %}
+    {% set pagination_items = [] %}
+    {% if window_start > 1 %}
+      {% set _ = pagination_items.append({"number": 1, "href": url_for(_transform_endpoint, request_id=request_id, page_number=1)}) %}
+      {% if window_start > 2 %}
+        {% set _ = pagination_items.append({"ellipsis": true}) %}
+      {% endif %}
+    {% endif %}
+    {% for p in range(window_start, page_number + 1) %}
+      {% set _ = pagination_items.append({"number": p, "current": p == page_number, "href": url_for(_transform_endpoint, request_id=request_id, page_number=p)}) %}
+    {% endfor %}
+    {% if has_next_page %}
+      {% set _ = pagination_items.append({"number": page_number + 1, "href": url_for(_transform_endpoint, request_id=request_id, page_number=page_number + 1)}) %}
+    {% endif %}
+    {% set pagination_params = {
+      "previous": {"href": url_for(_transform_endpoint, request_id=request_id, page_number=page_number - 1)} if page_number > 1 else none,
+      "next": {"href": url_for(_transform_endpoint, request_id=request_id, page_number=page_number + 1)} if has_next_page else none,
+      "items": pagination_items
+    } %}
+
+    {% set entity_window_start = [entity_page - 2, 1] | max %}
+    {% set entity_pagination_items = [] %}
+    {% if entity_window_start > 1 %}
+      {% set _ = entity_pagination_items.append({"number": 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=1)}) %}
+      {% if entity_window_start > 2 %}
+        {% set _ = entity_pagination_items.append({"ellipsis": true}) %}
+      {% endif %}
+    {% endif %}
+    {% for p in range(entity_window_start, entity_page + 1) %}
+      {% set _ = entity_pagination_items.append({"number": p, "current": p == entity_page, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=p)}) %}
+    {% endfor %}
+    {% if has_next_entity_page %}
+      {% set _ = entity_pagination_items.append({"number": entity_page + 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1)}) %}
+    {% endif %}
+    {% set entity_pagination_params = {
+      "previous": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page - 1)} if entity_page > 1 else none,
+      "next": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1)} if has_next_entity_page else none,
+      "items": entity_pagination_items
+    } %}
+
+    <div class="govuk-tabs" data-module="govuk-tabs">
+      <ul class="govuk-tabs__list">
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <a class="govuk-tabs__tab" href="#entities-table">Entities</a>
+        </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#transformed-table">Transformed</a>
+        </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#issue-log-table">Issue logs</a>
+        </li>
+      </ul>
+
+      <div class="govuk-tabs__panel" id="entities-table">
+        {% if platform_too_large %}
+        <div class="govuk-inset-text">
+          <p class="govuk-body">There are {{ existing_count | commanum }} existing entities on the platform for this dataset. Comparison between the resource and platform is disabled for datasets this large.</p>
+        </div>
+        {% elif entities_data and entities_data.rows %}
+        <div class="app-scrollable-container app-scrollable">
+          <table class="govuk-table dl-table app-table">
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                {% for col in entities_data.columns %}
+                <th scope="col" class="govuk-table__header">{{ col }}</th>
+                {% endfor %}
+              </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+              {% for row in entities_data.rows %}
+              <tr class="govuk-table__row" {% if row.is_in_both %}style="background-color: #ffd8b0;"{% elif row.is_new %}style="background-color: #d4edda;"{% endif %}>
+                {% for col in entities_data.columns %}
+                <td class="govuk-table__cell app-wrap">
+                  {% set val = row.fields[col] %}
+                  {% if val | length > 50 %}{{ val[:50] }}...{% else %}{{ val }}{% endif %}
+                </td>
+                {% endfor %}
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        {% else %}
+        <p class="govuk-body">No entities to display.</p>
+        {% endif %}
+        {% if not platform_too_large %}
+        <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-1">Showing entities {{ entity_page_start }} to {{ entity_page_end }}</p>
+        {{ govukPagination(entity_pagination_params) }}
+        {% endif %}
+      </div>
+
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="transformed-table">
+        {% if transformed_table.rows %}
+        <div class="app-scrollable-container app-scrollable">
+          {{ table(transformed_table) }}
+        </div>
+        {% else %}
+        <p class="govuk-body">No transformed rows to display.</p>
+        {% endif %}
+        <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-1">Showing entries {{ page_start }} to {{ page_end }}</p>
+        {{ govukPagination(pagination_params) }}
+      </div>
+
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="issue-log-table">
+        {% if issue_log_table and issue_log_table.rows %}
+        <div class="app-scrollable-container app-scrollable">
+          {{ table(issue_log_table) }}
+        </div>
+        {% else %}
+        <p class="govuk-body">No issues on this page.</p>
+        {% endif %}
+        <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-1">Showing entries {{ page_start }} to {{ page_end }}</p>
+        {{ govukPagination(pagination_params) }}
+      </div>
+    </div>
+
+    <ul class="govuk-list govuk-body-s govuk-!-margin-top-4 govuk-!-margin-bottom-2" style="color: #505a5f;">
+      <li><strong style="color: #00703c;">&#9679;</strong> <strong>Green</strong> — No action needed</li>
+      <li><strong style="color: #f47738;">&#9679;</strong> <strong>Orange</strong> — Manual check needed</li>
+      <li><strong style="color: #d4351c;">&#9679;</strong> <strong>Red</strong> — Sign off needed</li>
+      <li><strong style="color: #1d70b8;">&#9679;</strong> <strong>Blue</strong> — Optional action</li>
+    </ul>
+
+    {% set _is_error = entity_growth_check.error %}
+    <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-6" style="background-color: #f3f2f1; padding: 15px 20px; border-left: 4px solid {{ '#d4351c' if _is_error else '#00703c' }};">
+      <details data-module="govuk-details" style="margin: 0;">
+        <summary style="cursor: pointer; list-style: none; display: flex; align-items: center; justify-content: space-between;">
+          <span class="govuk-heading-m" style="display: inline; margin: 0; color: {{ '#d4351c' if _is_error else '#00703c' }};">
+            Entity Growth Detection
+            <strong class="govuk-tag {{ 'govuk-tag--red' if _is_error else 'govuk-tag--green' }}" style="margin-left: 10px; vertical-align: middle;">
+              {{ 'Warning' if _is_error else 'Passed' }}
+            </strong>
+          </span>
+          <span class="govuk-body" style="margin: 0; font-size: 1.2em; color: {{ '#d4351c' if _is_error else '#00703c' }};">&#9660;</span>
+        </summary>
+        <div class="govuk-!-margin-top-4">
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Existing entities</dt>
+              <dd class="govuk-summary-list__value">{{ entity_growth_check.existing_count }}</dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">New entities</dt>
+              <dd class="govuk-summary-list__value">{{ entity_growth_check.new_count }}</dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Growth</dt>
+              <dd class="govuk-summary-list__value">
+                {% if entity_growth_check.growth_pct is not none %}{{ entity_growth_check.growth_pct }}%{% else %}N/A (no existing entities){% endif %}
+              </dd>
+            </div>
+          </dl>
+          {% if _is_error %}
+          <div class="govuk-warning-text govuk-!-margin-bottom-0">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-visually-hidden">Warning</span>
+              New entities exceed 10% of existing entities. Please review before continuing.
+            </strong>
+          </div>
+          {% else %}
+          <p class="govuk-body govuk-!-margin-bottom-0">New entity count is within the expected threshold.</p>
+          {% endif %}
+        </div>
+      </details>
+    </div>
+
+    {% if endpoint_url and documentation_url %}
+    {% set _doc_found = endpoint_in_doc.found %}
+    {% set _access_error = endpoint_in_doc.error %}
+    {# Red: doc URL not gov.uk (always). Green: doc gov.uk + found. Orange: doc gov.uk + (access error or endpoint gov.uk but not found). Red: doc gov.uk + not found + endpoint not gov.uk. #}
+    {% if not doc_is_gov_uk %}
+      {% set _border_colour = '#d4351c' %}
+    {% elif _doc_found %}
+      {% set _border_colour = '#00703c' %}
+    {% elif _access_error or endpoint_is_gov_uk %}
+      {% set _border_colour = '#f47738' %}
+    {% else %}
+      {% set _border_colour = '#d4351c' %}
+    {% endif %}
+    <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-6" style="background-color: #f3f2f1; padding: 15px 20px; border-left: 4px solid {{ _border_colour }};">
+      <details data-module="govuk-details" style="margin: 0;">
+        <summary style="cursor: pointer; list-style: none; display: flex; align-items: center; justify-content: space-between;">
+          <span class="govuk-heading-m" style="display: inline; margin: 0; color: {{ _border_colour }};">
+            Endpoint URL in Source URL (documentation-url) Check
+            {% if not doc_is_gov_uk %}
+            <strong class="govuk-tag govuk-tag--red" style="margin-left: 10px; vertical-align: middle;">Non-gov.uk domain</strong>
+            {% endif %}
+            {% if not doc_is_gov_uk %}
+            <strong class="govuk-tag govuk-tag--red" style="margin-left: 6px; vertical-align: middle;">{{ 'Found' if _doc_found else ('Unable to access' if _access_error else 'Not found') }}</strong>
+            {% elif _doc_found %}
+            <strong class="govuk-tag govuk-tag--green" style="margin-left: 6px; vertical-align: middle;">Found</strong>
+            {% elif _access_error or endpoint_is_gov_uk %}
+            <strong class="govuk-tag govuk-tag--orange" style="margin-left: 6px; vertical-align: middle;">{{ 'Unable to access' if _access_error else 'Not found' }}</strong>
+            {% if not _access_error and endpoint_is_gov_uk %}
+            <strong class="govuk-tag govuk-tag--green" style="margin-left: 6px; vertical-align: middle;">gov.uk domain</strong>
+            {% endif %}
+            {% else %}
+            <strong class="govuk-tag govuk-tag--red" style="margin-left: 6px; vertical-align: middle;">Not found</strong>
+            {% endif %}
+          </span>
+          <span class="govuk-body" style="margin: 0; font-size: 1.2em; color: {{ _border_colour }};">&#9660;</span>
+        </summary>
+        <div class="govuk-!-margin-top-4">
+          {% if not doc_is_gov_uk %}
+          <div class="govuk-warning-text govuk-!-margin-bottom-4">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-visually-hidden">Warning</span>
+              The documentation URL is not on a gov.uk domain. Please confirm this is the correct page for this dataset.
+            </strong>
+          </div>
+          {% endif %}
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Documentation URL</dt>
+              <dd class="govuk-summary-list__value">
+                <a class="govuk-link" href="{{ documentation_url }}" target="_blank" rel="noopener noreferrer" style="word-break: break-all;">{{ documentation_url }}</a>
+                <strong class="govuk-tag {{ 'govuk-tag--green' if doc_is_gov_uk else 'govuk-tag--red' }}" style="margin-left: 6px; vertical-align: middle; font-size: 0.75rem;">{{ 'gov.uk' if doc_is_gov_uk else 'non-gov.uk' }}</strong>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Endpoint URL</dt>
+              <dd class="govuk-summary-list__value">
+                <code style="word-break: break-all;">{{ endpoint_url }}</code>
+                <strong class="govuk-tag {{ 'govuk-tag--green' if endpoint_is_gov_uk else 'govuk-tag--grey' }}" style="margin-left: 6px; vertical-align: middle; font-size: 0.75rem;">{{ 'gov.uk' if endpoint_is_gov_uk else 'non-gov.uk' }}</strong>
+              </dd>
+            </div>
+            {% if _doc_found %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Matched link</dt>
+              <dd class="govuk-summary-list__value"><code style="word-break: break-all;">{{ endpoint_in_doc.matched_href }}</code></dd>
+            </div>
+            {% endif %}
+          </dl>
+          {% if _doc_found %}
+          <p class="govuk-body govuk-!-margin-bottom-0">The endpoint URL was found as a link on the documentation page.</p>
+          {% elif _access_error %}
+          <p class="govuk-body govuk-!-margin-bottom-1"><strong>The documentation URL could not be accessed.</strong></p>
+          <p class="govuk-body govuk-!-margin-bottom-1">Reason: {{ _access_error }}</p>
+          <p class="govuk-body govuk-!-margin-bottom-0">The page may require authentication or be temporarily unavailable. Please open the documentation URL manually to verify it is correct and publicly accessible.</p>
+          {% elif endpoint_is_gov_uk %}
+          <p class="govuk-body govuk-!-margin-bottom-1"><strong>The endpoint URL was not found as a direct link on this page.</strong></p>
+          <p class="govuk-body govuk-!-margin-bottom-0">The endpoint URL is on a gov.uk domain so this may be expected — some endpoint types such as ArcGIS or other map service URLs do not appear as clickable links even on the correct documentation page. Please open the documentation URL and confirm it refers to this dataset and endpoint.</p>
+          {% else %}
+          <p class="govuk-body govuk-!-margin-bottom-1"><strong>The endpoint URL was not found as a link on the documentation page and is not on a gov.uk domain.</strong></p>
+          <p class="govuk-body govuk-!-margin-bottom-0">This needs a manual check — please verify the documentation URL is the correct page for this dataset and that the endpoint URL is accurate. If the endpoint is an ArcGIS or other external map service, confirm it is still accessible and correctly referenced.</p>
+          {% endif %}
+        </div>
+      </details>
+    </div>
+    {% endif %}
+
+    {% if pipelines_append_required %}
+    <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-6" style="background-color: #f3f2f1; padding: 15px 20px; border-left: 4px solid #f47738;">
+      <details data-module="govuk-details" style="margin: 0;">
+        <summary style="cursor: pointer; list-style: none; display: flex; align-items: center; justify-content: space-between;">
+          <span class="govuk-heading-m" style="display: inline; margin: 0; color: #f47738;">
+            Source CSV pipelines field update required
+            <strong class="govuk-tag govuk-tag--orange" style="margin-left: 10px; vertical-align: middle;">Warning</strong>
+          </span>
+          <span class="govuk-body" style="margin: 0; font-size: 1.2em; color: #f47738;">&#9660;</span>
+        </summary>
+        <div class="govuk-!-margin-top-4">
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Current pipelines value</dt>
+              <dd class="govuk-summary-list__value"><code>{{ pipelines_append_required.current }}</code></dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Updated pipelines value</dt>
+              <dd class="govuk-summary-list__value"><code>{{ pipelines_append_required.updated }}</code></dd>
+            </div>
+          </dl>
+          <div class="govuk-warning-text govuk-!-margin-bottom-0">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-visually-hidden">Warning</span>
+              This source and endpoint already exist but are being assigned to another dataset. If you confirm and add to GitHub, the pipelines value will be updated to reflect this.
+            </strong>
+          </div>
+        </div>
+      </details>
+    </div>
+    {% endif %}
+
+    <div class="govuk-button-group govuk-!-margin-top-6">
+      <a href="{{ url_for('datamanager.entities_preview', request_id=request_id) }}" class="govuk-button">
+        Continue to preview
+      </a>
+      <a href="{{ url_for('datamanager.dashboard_get') }}" class="govuk-link">
+        Cancel
+      </a>
+    </div>
+  </div>
+</div>
+<script>
+  document.querySelectorAll('.govuk-tabs__tab').forEach(function(tab) {
+    tab.addEventListener('click', function() {
+      var target = this.getAttribute('href').replace('#', '').replace('-table', '');
+      document.querySelectorAll('[id^="tab-desc-"]').forEach(function(el) { el.style.display = 'none'; });
+      var desc = document.getElementById('tab-desc-' + target);
+      if (desc) desc.style.display = '';
+    });
+  });
+</script>
+
+{% endblock %}

--- a/application/templates/datamanager/assign-entities-check-results.html
+++ b/application/templates/datamanager/assign-entities-check-results.html
@@ -38,20 +38,20 @@
     {% set entity_window_start = [entity_page - 2, 1] | max %}
     {% set entity_pagination_items = [] %}
     {% if entity_window_start > 1 %}
-      {% set _ = entity_pagination_items.append({"number": 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=1)}) %}
+      {% set _ = entity_pagination_items.append({"number": 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=1, entity_search=entity_search)}) %}
       {% if entity_window_start > 2 %}
         {% set _ = entity_pagination_items.append({"ellipsis": true}) %}
       {% endif %}
     {% endif %}
     {% for p in range(entity_window_start, entity_page + 1) %}
-      {% set _ = entity_pagination_items.append({"number": p, "current": p == entity_page, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=p)}) %}
+      {% set _ = entity_pagination_items.append({"number": p, "current": p == entity_page, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=p, entity_search=entity_search)}) %}
     {% endfor %}
     {% if has_next_entity_page %}
-      {% set _ = entity_pagination_items.append({"number": entity_page + 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1)}) %}
+      {% set _ = entity_pagination_items.append({"number": entity_page + 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1, entity_search=entity_search)}) %}
     {% endif %}
     {% set entity_pagination_params = {
-      "previous": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page - 1)} if entity_page > 1 else none,
-      "next": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1)} if has_next_entity_page else none,
+      "previous": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page - 1, entity_search=entity_search)} if entity_page > 1 else none,
+      "next": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1, entity_search=entity_search)} if has_next_entity_page else none,
       "items": entity_pagination_items
     } %}
 
@@ -73,7 +73,20 @@
         <div class="govuk-inset-text">
           <p class="govuk-body">There are {{ existing_count | commanum }} existing entities on the platform for this dataset. Comparison between the resource and platform is disabled for datasets this large.</p>
         </div>
-        {% elif entities_data and entities_data.rows %}
+        {% elif entities_data %}
+        <form method="get" action="{{ url_for(_transform_endpoint, request_id=request_id) }}" class="govuk-!-margin-bottom-4">
+          <div class="govuk-form-group govuk-!-margin-bottom-2">
+            <label class="govuk-label" for="entity-search">
+              Search entities
+            </label>
+            <input class="govuk-input govuk-input--width-20" id="entity-search" name="entity_search" type="search" autocomplete="off" value="{{ entity_search }}">
+          </div>
+          <button type="submit" class="govuk-button govuk-!-margin-bottom-0">Search</button>
+          {% if entity_search %}
+          <a class="govuk-link govuk-!-margin-left-2" href="{{ url_for(_transform_endpoint, request_id=request_id) }}">Clear search</a>
+          {% endif %}
+        </form>
+        {% if entities_data.rows %}
         <div class="app-scrollable-container app-scrollable">
           <table class="govuk-table dl-table app-table">
             <thead class="govuk-table__head">
@@ -97,6 +110,11 @@
             </tbody>
           </table>
         </div>
+        {% elif entity_search %}
+        <p class="govuk-body">No entities match your search.</p>
+        {% else %}
+        <p class="govuk-body">No entities to display.</p>
+        {% endif %}
         {% else %}
         <p class="govuk-body">No entities to display.</p>
         {% endif %}

--- a/application/templates/datamanager/assign-entities-check-results.html
+++ b/application/templates/datamanager/assign-entities-check-results.html
@@ -32,7 +32,7 @@
           {% if existing_endpoints %}
             {% for endpoint in existing_endpoints %}
               {% if endpoint["endpoint-url"] %}
-              <div><a href="{{ endpoint["endpoint-url"] }}" target="_blank" style="word-break: break-all;">{{ endpoint["endpoint-url"] }}</a></div>
+              <div><a href="{{ endpoint["endpoint-url"] }}" target="_blank" rel="noopener noreferrer" style="word-break: break-all;">{{ endpoint["endpoint-url"] }}</a></div>
               {% endif %}
               {% if endpoint["endpoint"] %}
               <div class="govuk-hint govuk-!-margin-bottom-2" style="font-size: 0.8rem; word-break: break-all;">{{ endpoint["endpoint"] }}</div>

--- a/application/templates/datamanager/assign-entities-check-results.html
+++ b/application/templates/datamanager/assign-entities-check-results.html
@@ -118,7 +118,7 @@
         {% else %}
         <p class="govuk-body">No entities to display.</p>
         {% endif %}
-        {% if not platform_too_large %}
+        {% if not platform_too_large and entities_data and entities_data.rows %}
         <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-1">Showing entities {{ entity_page_start }} to {{ entity_page_end }}</p>
         {{ govukPagination(entity_pagination_params) }}
         {% endif %}

--- a/application/templates/datamanager/assign-entities-check-results.html
+++ b/application/templates/datamanager/assign-entities-check-results.html
@@ -2,15 +2,59 @@
 {% from "components/table.html" import table %}
 {% from "govuk_frontend_jinja/components/pagination/macro.html" import govukPagination %}
 
+{% block pageTitle %}Assign Entities - Resource Details: {{ organisation_display }} - {{ dataset_display }}{% endblock %}
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     {% set _transform_endpoint = transform_endpoint or 'datamanager.check_transform' %}
+    {% set _flagged_errors_query = flagged_errors | join(',') %}
     <span class="govuk-caption-xl">{{ organisation_display }}</span>
     <span class="govuk-body-l" style="display: block; color: #505a5f; margin-bottom: 10px;">{{ dataset_display }}</span>
     <hr style="border: none; border-top: 2px solid #b1b4b6; margin: 10px 0 10px;">
-    <h1 class="govuk-heading-xl" style="margin-bottom: 10px;">Data Submission Assessment</h1>
+    <h1 class="govuk-heading-xl" style="margin-bottom: 10px;">Assign Entities - Resource Details</h1>
     <hr style="border: none; border-top: 2px solid #b1b4b6; margin: 0 0 20px;">
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-6">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Resource hash</dt>
+        <dd class="govuk-summary-list__value">
+          {% if resource_hash %}
+          <span style="word-break: break-all;">{{ resource_hash }}</span>
+          {% else %}
+          Not available
+          {% endif %}
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Endpoints</dt>
+        <dd class="govuk-summary-list__value">
+          {% if existing_endpoints %}
+            {% for endpoint in existing_endpoints %}
+              {% if endpoint["endpoint-url"] %}
+              <div><a href="{{ endpoint["endpoint-url"] }}" target="_blank" style="word-break: break-all;">{{ endpoint["endpoint-url"] }}</a></div>
+              {% endif %}
+              {% if endpoint["endpoint"] %}
+              <div class="govuk-hint govuk-!-margin-bottom-2" style="font-size: 0.8rem; word-break: break-all;">{{ endpoint["endpoint"] }}</div>
+              {% endif %}
+            {% endfor %}
+          {% else %}
+          None
+          {% endif %}
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Errors</dt>
+        <dd class="govuk-summary-list__value">
+          {% if flagged_error_messages %}
+          <span style="word-break: break-all;">{{ flagged_error_messages | join(', ') }}</span>
+          {% else %}
+          None
+          {% endif %}
+        </dd>
+      </div>
+    </dl>
+
     <p id="tab-desc-entities" class="govuk-hint govuk-!-margin-top-8 govuk-!-margin-bottom-4">All entities for this dataset and organisation, with new additions highlighted in <span style="color: #00703c; font-weight: bold;">green</span> and existing entities also present in this resource highlighted in <span style="color: #d4692a; font-weight: bold;">orange</span>.</p>
     <p id="tab-desc-transformed" class="govuk-hint govuk-!-margin-top-8 govuk-!-margin-bottom-4" style="display:none;">The individual facts extracted from the submitted data by the pipeline <b>with entity lookup enabled</b>.</p>
     <p id="tab-desc-issue-log" class="govuk-hint govuk-!-margin-top-8 govuk-!-margin-bottom-4" style="display:none;">Any issues the pipeline raised while processing the data.</p>
@@ -18,40 +62,40 @@
     {% set window_start = [page_number - 2, 1] | max %}
     {% set pagination_items = [] %}
     {% if window_start > 1 %}
-      {% set _ = pagination_items.append({"number": 1, "href": url_for(_transform_endpoint, request_id=request_id, page_number=1)}) %}
+      {% set _ = pagination_items.append({"number": 1, "href": url_for(_transform_endpoint, request_id=request_id, page_number=1, errors=_flagged_errors_query)}) %}
       {% if window_start > 2 %}
         {% set _ = pagination_items.append({"ellipsis": true}) %}
       {% endif %}
     {% endif %}
     {% for p in range(window_start, page_number + 1) %}
-      {% set _ = pagination_items.append({"number": p, "current": p == page_number, "href": url_for(_transform_endpoint, request_id=request_id, page_number=p)}) %}
+      {% set _ = pagination_items.append({"number": p, "current": p == page_number, "href": url_for(_transform_endpoint, request_id=request_id, page_number=p, errors=_flagged_errors_query)}) %}
     {% endfor %}
     {% if has_next_page %}
-      {% set _ = pagination_items.append({"number": page_number + 1, "href": url_for(_transform_endpoint, request_id=request_id, page_number=page_number + 1)}) %}
+      {% set _ = pagination_items.append({"number": page_number + 1, "href": url_for(_transform_endpoint, request_id=request_id, page_number=page_number + 1, errors=_flagged_errors_query)}) %}
     {% endif %}
     {% set pagination_params = {
-      "previous": {"href": url_for(_transform_endpoint, request_id=request_id, page_number=page_number - 1)} if page_number > 1 else none,
-      "next": {"href": url_for(_transform_endpoint, request_id=request_id, page_number=page_number + 1)} if has_next_page else none,
+      "previous": {"href": url_for(_transform_endpoint, request_id=request_id, page_number=page_number - 1, errors=_flagged_errors_query)} if page_number > 1 else none,
+      "next": {"href": url_for(_transform_endpoint, request_id=request_id, page_number=page_number + 1, errors=_flagged_errors_query)} if has_next_page else none,
       "items": pagination_items
     } %}
 
     {% set entity_window_start = [entity_page - 2, 1] | max %}
     {% set entity_pagination_items = [] %}
     {% if entity_window_start > 1 %}
-      {% set _ = entity_pagination_items.append({"number": 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=1, entity_search=entity_search)}) %}
+      {% set _ = entity_pagination_items.append({"number": 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=1, entity_search=entity_search, errors=_flagged_errors_query)}) %}
       {% if entity_window_start > 2 %}
         {% set _ = entity_pagination_items.append({"ellipsis": true}) %}
       {% endif %}
     {% endif %}
     {% for p in range(entity_window_start, entity_page + 1) %}
-      {% set _ = entity_pagination_items.append({"number": p, "current": p == entity_page, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=p, entity_search=entity_search)}) %}
+      {% set _ = entity_pagination_items.append({"number": p, "current": p == entity_page, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=p, entity_search=entity_search, errors=_flagged_errors_query)}) %}
     {% endfor %}
     {% if has_next_entity_page %}
-      {% set _ = entity_pagination_items.append({"number": entity_page + 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1, entity_search=entity_search)}) %}
+      {% set _ = entity_pagination_items.append({"number": entity_page + 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1, entity_search=entity_search, errors=_flagged_errors_query)}) %}
     {% endif %}
     {% set entity_pagination_params = {
-      "previous": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page - 1, entity_search=entity_search)} if entity_page > 1 else none,
-      "next": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1, entity_search=entity_search)} if has_next_entity_page else none,
+      "previous": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page - 1, entity_search=entity_search, errors=_flagged_errors_query)} if entity_page > 1 else none,
+      "next": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1, entity_search=entity_search, errors=_flagged_errors_query)} if has_next_entity_page else none,
       "items": entity_pagination_items
     } %}
 
@@ -75,6 +119,7 @@
         </div>
         {% elif entities_data %}
         <form method="get" action="{{ url_for(_transform_endpoint, request_id=request_id) }}" class="govuk-!-margin-bottom-4">
+          <input type="hidden" name="errors" value="{{ _flagged_errors_query }}">
           <div class="govuk-form-group govuk-!-margin-bottom-2">
             <label class="govuk-label" for="entity-search">
               Search entities
@@ -83,7 +128,7 @@
           </div>
           <button type="submit" class="govuk-button govuk-!-margin-bottom-0">Search</button>
           {% if entity_search %}
-          <a class="govuk-link govuk-!-margin-left-2" href="{{ url_for(_transform_endpoint, request_id=request_id) }}">Clear search</a>
+          <a class="govuk-link govuk-!-margin-left-2" href="{{ url_for(_transform_endpoint, request_id=request_id, errors=_flagged_errors_query) }}">Clear search</a>
           {% endif %}
         </form>
         {% if entities_data.rows %}

--- a/application/templates/datamanager/check-transform-loading.html
+++ b/application/templates/datamanager/check-transform-loading.html
@@ -9,7 +9,7 @@
     <p class="govuk-body">We're running the pipeline transform for your request. This should only take a moment.</p>
     <p class="govuk-body">This page will refresh automatically.</p>
     <p class="govuk-body">
-      If nothing happens, you can <a class="govuk-link" href="{{ url_for('datamanager.check_transform', request_id=request_id) }}">refresh manually</a>.
+      If nothing happens, you can <a class="govuk-link" href="{{ url_for(transform_endpoint or 'datamanager.check_transform', request_id=request_id) }}">refresh manually</a>.
     </p>
   </div>
 </div>

--- a/application/templates/datamanager/check-transform.html
+++ b/application/templates/datamanager/check-transform.html
@@ -38,20 +38,20 @@
     {% set entity_window_start = [entity_page - 2, 1] | max %}
     {% set entity_pagination_items = [] %}
     {% if entity_window_start > 1 %}
-      {% set _ = entity_pagination_items.append({"number": 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=1)}) %}
+      {% set _ = entity_pagination_items.append({"number": 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=1, entity_search=entity_search)}) %}
       {% if entity_window_start > 2 %}
         {% set _ = entity_pagination_items.append({"ellipsis": true}) %}
       {% endif %}
     {% endif %}
     {% for p in range(entity_window_start, entity_page + 1) %}
-      {% set _ = entity_pagination_items.append({"number": p, "current": p == entity_page, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=p)}) %}
+      {% set _ = entity_pagination_items.append({"number": p, "current": p == entity_page, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=p, entity_search=entity_search)}) %}
     {% endfor %}
     {% if has_next_entity_page %}
-      {% set _ = entity_pagination_items.append({"number": entity_page + 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1)}) %}
+      {% set _ = entity_pagination_items.append({"number": entity_page + 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1, entity_search=entity_search)}) %}
     {% endif %}
     {% set entity_pagination_params = {
-      "previous": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page - 1)} if entity_page > 1 else none,
-      "next": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1)} if has_next_entity_page else none,
+      "previous": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page - 1, entity_search=entity_search)} if entity_page > 1 else none,
+      "next": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1, entity_search=entity_search)} if has_next_entity_page else none,
       "items": entity_pagination_items
     } %}
 
@@ -73,7 +73,20 @@
         <div class="govuk-inset-text">
           <p class="govuk-body">There are {{ existing_count | commanum }} existing entities on the platform for this dataset. Comparison between the resource and platform is disabled for datasets this large.</p>
         </div>
-        {% elif entities_data and entities_data.rows %}
+        {% elif entities_data %}
+        <form method="get" action="{{ url_for(_transform_endpoint, request_id=request_id) }}" class="govuk-!-margin-bottom-4">
+          <div class="govuk-form-group govuk-!-margin-bottom-2">
+            <label class="govuk-label" for="entity-search">
+              Search entities
+            </label>
+            <input class="govuk-input govuk-input--width-20" id="entity-search" name="entity_search" type="search" autocomplete="off" value="{{ entity_search }}">
+          </div>
+          <button type="submit" class="govuk-button govuk-!-margin-bottom-0">Search</button>
+          {% if entity_search %}
+          <a class="govuk-link govuk-!-margin-left-2" href="{{ url_for(_transform_endpoint, request_id=request_id) }}">Clear search</a>
+          {% endif %}
+        </form>
+        {% if entities_data.rows %}
         <div class="app-scrollable-container app-scrollable">
           <table class="govuk-table dl-table app-table">
             <thead class="govuk-table__head">
@@ -97,6 +110,11 @@
             </tbody>
           </table>
         </div>
+        {% elif entity_search %}
+        <p class="govuk-body">No entities match your search.</p>
+        {% else %}
+        <p class="govuk-body">No entities to display.</p>
+        {% endif %}
         {% else %}
         <p class="govuk-body">No entities to display.</p>
         {% endif %}

--- a/application/templates/datamanager/check-transform.html
+++ b/application/templates/datamanager/check-transform.html
@@ -2,6 +2,8 @@
 {% from "components/table.html" import table %}
 {% from "govuk_frontend_jinja/components/pagination/macro.html" import govukPagination %}
 
+{% block pageTitle %}Data Submission Assessment - {{ organisation_display }} - {{ dataset_display }}{% endblock %}
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/application/templates/datamanager/check-transform.html
+++ b/application/templates/datamanager/check-transform.html
@@ -5,6 +5,7 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    {% set _transform_endpoint = transform_endpoint or 'datamanager.check_transform' %}
     <span class="govuk-caption-xl">{{ organisation_display }}</span>
     <span class="govuk-body-l" style="display: block; color: #505a5f; margin-bottom: 10px;">{{ dataset_display }}</span>
     <hr style="border: none; border-top: 2px solid #b1b4b6; margin: 10px 0 10px;">
@@ -17,40 +18,40 @@
     {% set window_start = [page_number - 2, 1] | max %}
     {% set pagination_items = [] %}
     {% if window_start > 1 %}
-      {% set _ = pagination_items.append({"number": 1, "href": url_for('datamanager.check_transform', request_id=request_id, page_number=1)}) %}
+      {% set _ = pagination_items.append({"number": 1, "href": url_for(_transform_endpoint, request_id=request_id, page_number=1)}) %}
       {% if window_start > 2 %}
         {% set _ = pagination_items.append({"ellipsis": true}) %}
       {% endif %}
     {% endif %}
     {% for p in range(window_start, page_number + 1) %}
-      {% set _ = pagination_items.append({"number": p, "current": p == page_number, "href": url_for('datamanager.check_transform', request_id=request_id, page_number=p)}) %}
+      {% set _ = pagination_items.append({"number": p, "current": p == page_number, "href": url_for(_transform_endpoint, request_id=request_id, page_number=p)}) %}
     {% endfor %}
     {% if has_next_page %}
-      {% set _ = pagination_items.append({"number": page_number + 1, "href": url_for('datamanager.check_transform', request_id=request_id, page_number=page_number + 1)}) %}
+      {% set _ = pagination_items.append({"number": page_number + 1, "href": url_for(_transform_endpoint, request_id=request_id, page_number=page_number + 1)}) %}
     {% endif %}
     {% set pagination_params = {
-      "previous": {"href": url_for('datamanager.check_transform', request_id=request_id, page_number=page_number - 1)} if page_number > 1 else none,
-      "next": {"href": url_for('datamanager.check_transform', request_id=request_id, page_number=page_number + 1)} if has_next_page else none,
+      "previous": {"href": url_for(_transform_endpoint, request_id=request_id, page_number=page_number - 1)} if page_number > 1 else none,
+      "next": {"href": url_for(_transform_endpoint, request_id=request_id, page_number=page_number + 1)} if has_next_page else none,
       "items": pagination_items
     } %}
 
     {% set entity_window_start = [entity_page - 2, 1] | max %}
     {% set entity_pagination_items = [] %}
     {% if entity_window_start > 1 %}
-      {% set _ = entity_pagination_items.append({"number": 1, "href": url_for('datamanager.check_transform', request_id=request_id, entity_page=1)}) %}
+      {% set _ = entity_pagination_items.append({"number": 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=1)}) %}
       {% if entity_window_start > 2 %}
         {% set _ = entity_pagination_items.append({"ellipsis": true}) %}
       {% endif %}
     {% endif %}
     {% for p in range(entity_window_start, entity_page + 1) %}
-      {% set _ = entity_pagination_items.append({"number": p, "current": p == entity_page, "href": url_for('datamanager.check_transform', request_id=request_id, entity_page=p)}) %}
+      {% set _ = entity_pagination_items.append({"number": p, "current": p == entity_page, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=p)}) %}
     {% endfor %}
     {% if has_next_entity_page %}
-      {% set _ = entity_pagination_items.append({"number": entity_page + 1, "href": url_for('datamanager.check_transform', request_id=request_id, entity_page=entity_page + 1)}) %}
+      {% set _ = entity_pagination_items.append({"number": entity_page + 1, "href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1)}) %}
     {% endif %}
     {% set entity_pagination_params = {
-      "previous": {"href": url_for('datamanager.check_transform', request_id=request_id, entity_page=entity_page - 1)} if entity_page > 1 else none,
-      "next": {"href": url_for('datamanager.check_transform', request_id=request_id, entity_page=entity_page + 1)} if has_next_entity_page else none,
+      "previous": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page - 1)} if entity_page > 1 else none,
+      "next": {"href": url_for(_transform_endpoint, request_id=request_id, entity_page=entity_page + 1)} if has_next_entity_page else none,
       "items": entity_pagination_items
     } %}
 
@@ -301,7 +302,7 @@
     {% endif %}
 
     {% if existing_endpoints %}
-    <form method="post" action="{{ url_for('datamanager.check_transform', request_id=request_id) }}">
+    <form method="post" action="{{ url_for(_transform_endpoint, request_id=request_id) }}">
     <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-6" style="background-color: #f3f2f1; padding: 15px 20px; border-left: 4px solid #1d70b8;">
       <details data-module="govuk-details" style="margin: 0;">
         <summary style="cursor: pointer; list-style: none; display: flex; align-items: center; justify-content: space-between;">

--- a/application/templates/datamanager/entities_preview.html
+++ b/application/templates/datamanager/entities_preview.html
@@ -1,6 +1,9 @@
 {% extends 'layouts/base.html' %}
 {% from "components/table.html" import table %}
 
+
+{% block pageTitle %}Add Data - Preview {% endblock %}
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/application/templates/datamanager/entities_preview.html
+++ b/application/templates/datamanager/entities_preview.html
@@ -187,6 +187,7 @@
     <div class="govuk-button-group">
       <form method="post" action="{{ url_for('datamanager.add_data_confirm_async', request_id=request_id) }}">
         <input type="hidden" name="github_branch" value="{{ github_branch or '' }}">
+        <input type="hidden" name="source_flow" value="{{ source_flow or 'add_data' }}">
         <button type="submit" class="govuk-button" data-module="govuk-button">
           {% if github_branch %}Add to existing branch on GitHub{% else %}Create new branch and Add to GitHub{% endif %}
         </button>

--- a/application/templates/datamanager/entities_preview.html
+++ b/application/templates/datamanager/entities_preview.html
@@ -188,6 +188,7 @@
       <form method="post" action="{{ url_for('datamanager.add_data_confirm_async', request_id=request_id) }}">
         <input type="hidden" name="github_branch" value="{{ github_branch or '' }}">
         <input type="hidden" name="source_flow" value="{{ source_flow or 'add_data' }}">
+        <input type="hidden" name="return_url" value="{{ return_url or url_for('datamanager.dashboard_get') }}">
         <button type="submit" class="govuk-button" data-module="govuk-button">
           {% if github_branch %}Add to existing branch on GitHub{% else %}Create new branch and Add to GitHub{% endif %}
         </button>

--- a/application/templates/datamanager/flagged-resources-import.html
+++ b/application/templates/datamanager/flagged-resources-import.html
@@ -59,7 +59,7 @@ developer-agreement-transaction,8156bc2cbb89cf5586af5cd84f9bc37369875e37eaf3a453
           Include the header row. The CSV must include: {{ required_columns | join(', ') }}.
         </div>
         {% if errors.get('csv_data') %}
-        <p class="govuk-error-message">
+        <p class="govuk-error-message" id="csv-data-error">
           <span class="govuk-visually-hidden">Error:</span> {{ errors.csv_data }}
         </p>
         {% endif %}
@@ -68,7 +68,7 @@ developer-agreement-transaction,8156bc2cbb89cf5586af5cd84f9bc37369875e37eaf3a453
           id="csv-data"
           name="csv_data"
           rows="8"
-          aria-describedby="csv-data-hint"
+          aria-describedby="csv-data-hint{% if errors.get('csv_data') %} csv-data-error{% endif %}"
         >{{ csv_data }}</textarea>
       </div>
 

--- a/application/templates/datamanager/flagged-resources-import.html
+++ b/application/templates/datamanager/flagged-resources-import.html
@@ -26,7 +26,7 @@
       </summary>
       <div class="govuk-details__text">
         <pre class="app-code-block">
-          dataset,resource,organisation,reference,status,entities_created,error_code,message
+dataset,resource,organisation,reference,status,entities_created,error_code,message
 developer-agreement,7ad0c6cea336219db05f6d5054c6ee4e599c158f5104f4aee59df21d9ac390ca,local-authority:ARU,1684-da,error,,duplicate_entity_all_fields,"Matches existing entity(s) 4606914, 4607168, 4607177 developer-agreement-type::community-infrastructure-levy|end-date::|organisation::local-authority:aru|prefix::developer-agreement."
 developer-agreement-contribution,c17188a968a2f715e0d6db1a6e285c57a5980a86af9998ee1c07c6f726e11439,local-authority:ARU,784-da-1-S106NF,error,,duplicate_entity_all_fields,Matches existing entity(s) 4317330 contribution-purpose::affordable-housing|developer-agreement::784-da|end-date::|organisation::local-authority:aru|prefix::developer-agreement-contribution|start-date::2018-09-03|units::90.
 developer-agreement-contribution,c17188a968a2f715e0d6db1a6e285c57a5980a86af9998ee1c07c6f726e11439,local-authority:ARU,790-da-10-S106NF,error,,duplicate_entity_all_fields,Matches existing entity(s) 4317378 contribution-purpose::open-space-and-leisure|developer-agreement::790-da|end-date::|organisation::local-authority:aru|prefix::developer-agreement-contribution|start-date::2019-03-07|units::1.

--- a/application/templates/datamanager/flagged-resources-import.html
+++ b/application/templates/datamanager/flagged-resources-import.html
@@ -64,12 +64,15 @@ developer-agreement-transaction,8156bc2cbb89cf5586af5cd84f9bc37369875e37eaf3a453
         </p>
         {% endif %}
         <textarea
-          class="govuk-textarea {% if errors.get('csv_data') %}govuk-textarea--error{% endif %}"
+          class="govuk-textarea govuk-!-margin-bottom-0 {% if errors.get('csv_data') %}govuk-textarea--error{% endif %}"
           id="csv-data"
           name="csv_data"
           rows="8"
           aria-describedby="csv-data-hint{% if errors.get('csv_data') %} csv-data-error{% endif %}"
         >{{ csv_data }}</textarea>
+        <div class="govuk-hint govuk-!-margin-bottom-2">
+          Use the CSV file upload option if your CSV is larger than 10MB.
+        </div>
       </div>
 
       {{ govukButton({

--- a/application/templates/datamanager/flagged-resources-import.html
+++ b/application/templates/datamanager/flagged-resources-import.html
@@ -1,0 +1,97 @@
+{% extends 'layouts/base.html' %}
+
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    {{ govukBackLink({
+      'text': 'Back',
+      'href': url_for('assign_entities.flagged_resources_start')
+    }) }}
+
+    <h1 class="govuk-heading-xl">Import simple assign CSV</h1>
+
+    <p class="govuk-body">
+      Paste your simple assign CSV output below. The CSV should include headers and can include multiple rows for the same resource and dataset.
+    </p>
+
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          CSV format example
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <pre class="app-code-block">
+          dataset,resource,organisation,reference,status,entities_created,error_code,message
+developer-agreement,7ad0c6cea336219db05f6d5054c6ee4e599c158f5104f4aee59df21d9ac390ca,local-authority:ARU,1684-da,error,,duplicate_entity_all_fields,"Matches existing entity(s) 4606914, 4607168, 4607177 developer-agreement-type::community-infrastructure-levy|end-date::|organisation::local-authority:aru|prefix::developer-agreement."
+developer-agreement-contribution,c17188a968a2f715e0d6db1a6e285c57a5980a86af9998ee1c07c6f726e11439,local-authority:ARU,784-da-1-S106NF,error,,duplicate_entity_all_fields,Matches existing entity(s) 4317330 contribution-purpose::affordable-housing|developer-agreement::784-da|end-date::|organisation::local-authority:aru|prefix::developer-agreement-contribution|start-date::2018-09-03|units::90.
+developer-agreement-contribution,c17188a968a2f715e0d6db1a6e285c57a5980a86af9998ee1c07c6f726e11439,local-authority:ARU,790-da-10-S106NF,error,,duplicate_entity_all_fields,Matches existing entity(s) 4317378 contribution-purpose::open-space-and-leisure|developer-agreement::790-da|end-date::|organisation::local-authority:aru|prefix::developer-agreement-contribution|start-date::2019-03-07|units::1.
+developer-agreement-contribution,c17188a968a2f715e0d6db1a6e285c57a5980a86af9998ee1c07c6f726e11439,local-authority:ARU,1013-da-8-S106NF,error,,duplicate_entity_all_fields,"Matches existing entity(s) 4302968, 4302968 contribution-purpose::open-space-and-leisure|developer-agreement::1013-da|end-date::|organisation::local-authority:aru|prefix::developer-agreement-contribution|start-date::2021-02-05|units::1."
+developer-agreement-contribution,c17188a968a2f715e0d6db1a6e285c57a5980a86af9998ee1c07c6f726e11439,local-authority:ARU,1138-da-10-CIL,error,,duplicate_entity_all_fields,"Matches existing entity(s) 4317493, 4317495 amount::1000|contribution-purpose::community-infrastructure-levy|developer-agreement::1138-da|end-date::|organisation::local-authority:aru|prefix::developer-agreement-contribution|start-date::2022-01-06."
+developer-agreement-contribution,c17188a968a2f715e0d6db1a6e285c57a5980a86af9998ee1c07c6f726e11439,local-authority:ARU,1144-da-20-S106F,error,,duplicate_entity_all_fields,Matches existing entity(s) 4317504 amount::2349.79|contribution-purpose::community-facilities|developer-agreement::1144-da|end-date::|organisation::local-authority:aru|prefix::developer-agreement-contribution|start-date::2021-10-12.
+developer-agreement-transaction,8156bc2cbb89cf5586af5cd84f9bc37369875e37eaf3a4532569672c12dda9a2,local-authority:ARU,,error,,large_number_of_new_entities,Resource contains a large number of new entities (256) compared to the previous version (1258). Old resource hash: 35557bf4bb0329afabcbc664731a3f398c992124743a6cb9547e671fcad44d56.</pre>
+      </div>
+    </details>
+
+    {% if errors.get('csv_data') %}
+    <div class="govuk-error-summary" role="alert" data-module="govuk-error-summary">
+      <h2 class="govuk-error-summary__title">There is a problem</h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <li><a href="#csv-data">{{ errors.csv_data }}</a></li>
+        </ul>
+      </div>
+    </div>
+    {% endif %}
+
+    <form method="post" action="{{ url_for('assign_entities.flagged_resources_import') }}">
+      <input type="hidden" name="mode" value="parse">
+
+      <div class="govuk-form-group {% if errors.get('csv_data') %}govuk-form-group--error{% endif %}">
+        <label class="govuk-label govuk-label--m" for="csv-data">
+          CSV data
+        </label>
+        <div id="csv-data-hint" class="govuk-hint">
+          Include the header row. The CSV must include: {{ required_columns | join(', ') }}.
+        </div>
+        {% if errors.get('csv_data') %}
+        <p class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> {{ errors.csv_data }}
+        </p>
+        {% endif %}
+        <textarea
+          class="govuk-textarea {% if errors.get('csv_data') %}govuk-textarea--error{% endif %}"
+          id="csv-data"
+          name="csv_data"
+          rows="8"
+          aria-describedby="csv-data-hint"
+        >{{ csv_data }}</textarea>
+      </div>
+
+      {{ govukButton({
+        'text': 'Parse CSV',
+        'attributes': { 'id': 'parse-button' }
+      }) }}
+    </form>
+
+  </div>
+</div>
+{% endblock %}
+
+{% block pageScripts %}
+<style>
+  .app-code-block {
+    background-color: #f3f2f1;
+    border: 1px solid #b1b4b6;
+    padding: 15px;
+    overflow-x: auto;
+    font-family: monospace;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+</style>
+{% endblock %}

--- a/application/templates/datamanager/flagged-resources-start.html
+++ b/application/templates/datamanager/flagged-resources-start.html
@@ -49,7 +49,7 @@
     </div>
     {% endif %}
 
-    <form method="post" action="{{ url_for('assign_entities.flagged_resources_start') }}" novalidate>
+    <form method="post" action="{{ url_for('assign_entities.flagged_resources_start') }}" id="assign-entities-manual-form" novalidate>
 
       <div class="govuk-form-group {% if errors.dataset %}govuk-form-group--error{% endif %}">
         <label class="govuk-label" for="dataset-autocomplete">Dataset <span class="govuk-required">*</span></label>
@@ -113,6 +113,13 @@
     document.getElementById("csv-file-upload").addEventListener("change", function() {
       if (this.files.length > 0) {
         this.closest("form").submit();
+      }
+    });
+
+    document.getElementById("assign-entities-manual-form").addEventListener("submit", function() {
+      const datasetVisible = document.getElementById("dataset-autocomplete");
+      if (datasetVisible) {
+        datasetHidden.value = datasetVisible.value;
       }
     });
   });

--- a/application/templates/datamanager/flagged-resources-start.html
+++ b/application/templates/datamanager/flagged-resources-start.html
@@ -1,30 +1,24 @@
 {% extends 'layouts/base.html' %}
 
-{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
-{% from "govuk_frontend_jinja/components/input/macro.html" import govukInput %}
-
-{% block pageStylesheets %}
-<link rel="stylesheet" href="{{ url_for('static', filename='stylesheets/accessible-autocomplete.min.css') }}">
-{% endblock %}
+{% block pageTitle %}Assign Entities{% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Assign entities</h1>
     <p class="govuk-body-l">
-      Review resources flagged by the simple assign process before assigning new entities.
+      Review resources flagged by the simple batch assign process before assigning new entities.
     </p>
     <p class="govuk-body">
-      Import or upload the CSV output to see grouped resources that need attention. You can also enter a dataset and resource directly to check a single resource.
+      Upload the CSV output to see grouped resources that need attention.
     </p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>Use CSV import when you have a simple assign output file.</li>
-      <li>Use the input fields when you already know the dataset and resource hash.</li>
+      <li>Use CSV upload when you have a simple batch assign output file.</li>
       <li>Select a resource on the next page to review the entity comparison.</li>
     </ul>
     <br>
     <div style="display:flex; gap: 1rem; align-items: center; margin-bottom: 1rem;">
-      <a href="{{ url_for('assign_entities.flagged_resources_import') }}" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button">Import from CSV</a>
+      {# <a href="{{ url_for('assign_entities.flagged_resources_import') }}" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button">Import from CSV</a> #}
       <form method="post" action="{{ url_for('assign_entities.flagged_resources_import') }}" enctype="multipart/form-data" style="margin:0;">
         <input type="hidden" name="mode" value="parse">
         <input type="file" name="csv_file" id="csv-file-upload" accept=".csv" style="display:none;">
@@ -33,93 +27,14 @@
     </div>
   </div>
 </div>
-
-<div class="govuk-grid-row govuk-!-margin-top-6">
-  <div class="govuk-grid-column-one-half">
-    {% if errors %}
-    <div class="govuk-error-summary" role="alert" data-module="govuk-error-summary">
-      <h2 class="govuk-error-summary__title">There is a problem</h2>
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          {% if errors.form %}<li><a href="#dataset-autocomplete">{{ errors.form }}</a></li>{% endif %}
-          {% if errors.dataset %}<li><a href="#dataset-autocomplete">{{ errors.dataset }}</a></li>{% endif %}
-          {% if errors.resource %}<li><a href="#resource">{{ errors.resource }}</a></li>{% endif %}
-        </ul>
-      </div>
-    </div>
-    {% endif %}
-
-    <form method="post" action="{{ url_for('assign_entities.flagged_resources_start') }}" id="assign-entities-manual-form" novalidate>
-
-      <div class="govuk-form-group {% if errors.dataset %}govuk-form-group--error{% endif %}">
-        <label class="govuk-label" for="dataset-autocomplete">Dataset <span class="govuk-required">*</span></label>
-        {% if errors.dataset %}
-        <p class="govuk-error-message">
-          <span class="govuk-visually-hidden">Error:</span> {{ errors.dataset }}
-        </p>
-        {% endif %}
-        <div id="autocomplete-container"></div>
-        <input type="hidden" name="dataset" id="dataset" value="{{ form.dataset }}">
-      </div>
-
-      <div class="govuk-form-group {% if errors.resource %}govuk-form-group--error{% endif %}">
-        {{ govukInput({
-          'label': { 'html': 'Resource <span class="govuk-required">*</span>' },
-          'id': 'resource',
-          'name': 'resource',
-          'value': form.resource,
-          'errorMessage': ({ 'text': errors.resource } if errors.resource else None)
-        }) }}
-      </div>
-
-      <div class="govuk-form-group govuk-!-margin-top-6" style="display: flex; justify-content: flex-end;">
-        {{ govukButton({
-          'text': 'Continue'
-        }) }}
-      </div>
-    </form>
-  </div>
-</div>
 {% endblock %}
 
 {% block pageScripts %}
-<script {% if config["ENV"]=="production" %}nonce="{{ csp_nonce() }}" {% endif %} src="{{ url_for('static', filename='javascripts/accessible-autocomplete.min.js') }}"></script>
 <script {% if config["ENV"]=="production" %}nonce="{{ csp_nonce() }}" {% endif %}>
   document.addEventListener("DOMContentLoaded", function() {
-    const datasetHidden = document.getElementById("dataset");
-    const datasetContainer = document.getElementById("autocomplete-container");
-    const datasetValue = datasetHidden.value || "";
-
-    accessibleAutocomplete({
-      element: datasetContainer,
-      id: "dataset-autocomplete",
-      name: "dataset-autocomplete-visible",
-      defaultValue: datasetValue,
-      minLength: 2,
-      confirmOnBlur: false,
-      autoselect: true,
-      displayMenu: "overlay",
-      placeholder: "Type dataset name...",
-      source: function(query, populateResults) {
-        fetch(`{{ url_for('datamanager.dashboard_get') }}?autocomplete=${encodeURIComponent(query)}`)
-          .then((response) => response.json())
-          .then((data) => populateResults(data));
-      },
-      onConfirm: function(val) {
-        datasetHidden.value = val;
-      }
-    });
-
     document.getElementById("csv-file-upload").addEventListener("change", function() {
       if (this.files.length > 0) {
         this.closest("form").submit();
-      }
-    });
-
-    document.getElementById("assign-entities-manual-form").addEventListener("submit", function() {
-      const datasetVisible = document.getElementById("dataset-autocomplete");
-      if (datasetVisible) {
-        datasetHidden.value = datasetVisible.value;
       }
     });
   });

--- a/application/templates/datamanager/flagged-resources-start.html
+++ b/application/templates/datamanager/flagged-resources-start.html
@@ -1,0 +1,120 @@
+{% extends 'layouts/base.html' %}
+
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/input/macro.html" import govukInput %}
+
+{% block pageStylesheets %}
+<link rel="stylesheet" href="{{ url_for('static', filename='stylesheets/accessible-autocomplete.min.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">Assign entities</h1>
+    <p class="govuk-body-l">
+      Review resources flagged by the simple assign process before assigning new entities.
+    </p>
+    <p class="govuk-body">
+      Import or upload the CSV output to see grouped resources that need attention. You can also enter a dataset and resource directly to check a single resource.
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Use CSV import when you have a simple assign output file.</li>
+      <li>Use the input fields when you already know the dataset and resource hash.</li>
+      <li>Select a resource on the next page to review the entity comparison.</li>
+    </ul>
+    <br>
+    <div style="display:flex; gap: 1rem; align-items: center; margin-bottom: 1rem;">
+      <a href="{{ url_for('assign_entities.flagged_resources_import') }}" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button">Import from CSV</a>
+      <form method="post" action="{{ url_for('assign_entities.flagged_resources_import') }}" enctype="multipart/form-data" style="margin:0;">
+        <input type="hidden" name="mode" value="parse">
+        <input type="file" name="csv_file" id="csv-file-upload" accept=".csv" style="display:none;">
+        <button type="button" class="govuk-button govuk-!-margin-bottom-0" onclick="document.getElementById('csv-file-upload').click()">Upload CSV file</button>
+      </form>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-top-6">
+  <div class="govuk-grid-column-one-half">
+    {% if errors %}
+    <div class="govuk-error-summary" role="alert" data-module="govuk-error-summary">
+      <h2 class="govuk-error-summary__title">There is a problem</h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          {% if errors.form %}<li><a href="#dataset-autocomplete">{{ errors.form }}</a></li>{% endif %}
+          {% if errors.dataset %}<li><a href="#dataset-autocomplete">{{ errors.dataset }}</a></li>{% endif %}
+          {% if errors.resource %}<li><a href="#resource">{{ errors.resource }}</a></li>{% endif %}
+        </ul>
+      </div>
+    </div>
+    {% endif %}
+
+    <form method="post" action="{{ url_for('assign_entities.flagged_resources_start') }}" novalidate>
+
+      <div class="govuk-form-group {% if errors.dataset %}govuk-form-group--error{% endif %}">
+        <label class="govuk-label" for="dataset-autocomplete">Dataset <span class="govuk-required">*</span></label>
+        {% if errors.dataset %}
+        <p class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> {{ errors.dataset }}
+        </p>
+        {% endif %}
+        <div id="autocomplete-container"></div>
+        <input type="hidden" name="dataset" id="dataset" value="{{ form.dataset }}">
+      </div>
+
+      <div class="govuk-form-group {% if errors.resource %}govuk-form-group--error{% endif %}">
+        {{ govukInput({
+          'label': { 'html': 'Resource <span class="govuk-required">*</span>' },
+          'id': 'resource',
+          'name': 'resource',
+          'value': form.resource,
+          'errorMessage': ({ 'text': errors.resource } if errors.resource else None)
+        }) }}
+      </div>
+
+      <div class="govuk-form-group govuk-!-margin-top-6" style="display: flex; justify-content: flex-end;">
+        {{ govukButton({
+          'text': 'Continue'
+        }) }}
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}
+
+{% block pageScripts %}
+<script {% if config["ENV"]=="production" %}nonce="{{ csp_nonce() }}" {% endif %} src="{{ url_for('static', filename='javascripts/accessible-autocomplete.min.js') }}"></script>
+<script {% if config["ENV"]=="production" %}nonce="{{ csp_nonce() }}" {% endif %}>
+  document.addEventListener("DOMContentLoaded", function() {
+    const datasetHidden = document.getElementById("dataset");
+    const datasetContainer = document.getElementById("autocomplete-container");
+    const datasetValue = datasetHidden.value || "";
+
+    accessibleAutocomplete({
+      element: datasetContainer,
+      id: "dataset-autocomplete",
+      name: "dataset-autocomplete-visible",
+      defaultValue: datasetValue,
+      minLength: 2,
+      confirmOnBlur: false,
+      autoselect: true,
+      displayMenu: "overlay",
+      placeholder: "Type dataset name...",
+      source: function(query, populateResults) {
+        fetch(`{{ url_for('datamanager.dashboard_get') }}?autocomplete=${encodeURIComponent(query)}`)
+          .then((response) => response.json())
+          .then((data) => populateResults(data));
+      },
+      onConfirm: function(val) {
+        datasetHidden.value = val;
+      }
+    });
+
+    document.getElementById("csv-file-upload").addEventListener("change", function() {
+      if (this.files.length > 0) {
+        this.closest("form").submit();
+      }
+    });
+  });
+</script>
+{% endblock %}

--- a/application/templates/datamanager/flagged-resources-summary.html
+++ b/application/templates/datamanager/flagged-resources-summary.html
@@ -1,11 +1,15 @@
 {% extends 'layouts/base.html' %}
 
+
+{% block pageTitle %}Assign Entities - Flagged Resources{% endblock %}
+
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <span class="govuk-caption-xl">Assign entities</span>
     <hr style="border: none; border-top: 2px solid #b1b4b6; margin: 10px 0 10px;">
-    <h1 class="govuk-heading-xl" style="margin-bottom: 10px;">Flagged resources</h1>
+    <h1 class="govuk-heading-xl" style="margin-bottom: 10px;">Assign Entities - Flagged Resources</h1>
     <hr style="border: none; border-top: 2px solid #b1b4b6; margin: 0 0 20px;">
 
     <p class="govuk-hint govuk-!-margin-top-8 govuk-!-margin-bottom-4">
@@ -39,6 +43,7 @@
                 <input type="hidden" name="dataset" value="{{ resource.dataset }}">
                 <input type="hidden" name="resource" value="{{ resource.resource }}">
                 <input type="hidden" name="organisation" value="{{ resource.organisation }}">
+                <input type="hidden" name="errors" value="{{ resource.errors | map(attribute='code') | join(',') }}">
                 <button type="submit" class="govuk-link" style="background: none; border: 0; padding: 0; color: #1d70b8; text-decoration: underline; cursor: pointer; font: inherit;">{{ resource.resource }}</button>
               </form>
             </td>

--- a/application/templates/datamanager/flagged-resources-summary.html
+++ b/application/templates/datamanager/flagged-resources-summary.html
@@ -35,7 +35,12 @@
           <tr class="govuk-table__row" {% if resource.row_colour == 'orange' %}style="background-color: #ffd8b0;"{% elif resource.row_colour == 'red' %}style="background-color: #f6d7d2;"{% endif %}>
             <td class="govuk-table__cell">{{ loop.index }}</td>
             <td class="govuk-table__cell">
-              <a class="govuk-link" href="{{ url_for('assign_entities.flagged_resource_submit', dataset=resource.dataset, resource=resource.resource) }}">{{ resource.resource }}</a>
+              <form method="post" action="{{ url_for('assign_entities.flagged_resource_submit') }}" class="govuk-!-margin-bottom-0">
+                <input type="hidden" name="dataset" value="{{ resource.dataset }}">
+                <input type="hidden" name="resource" value="{{ resource.resource }}">
+                <input type="hidden" name="organisation" value="{{ resource.organisation }}">
+                <button type="submit" class="govuk-link" style="background: none; border: 0; padding: 0; color: #1d70b8; text-decoration: underline; cursor: pointer; font: inherit;">{{ resource.resource }}</button>
+              </form>
             </td>
             <td class="govuk-table__cell">{{ resource.dataset }}</td>
             <td class="govuk-table__cell">{{ resource.organisation }}</td>

--- a/application/templates/datamanager/flagged-resources-summary.html
+++ b/application/templates/datamanager/flagged-resources-summary.html
@@ -1,0 +1,81 @@
+{% extends 'layouts/base.html' %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-xl">Assign entities</span>
+    <hr style="border: none; border-top: 2px solid #b1b4b6; margin: 10px 0 10px;">
+    <h1 class="govuk-heading-xl" style="margin-bottom: 10px;">Flagged resources</h1>
+    <hr style="border: none; border-top: 2px solid #b1b4b6; margin: 0 0 20px;">
+
+    <p class="govuk-hint govuk-!-margin-top-8 govuk-!-margin-bottom-4">
+      Select a resource to run the assign entities check for that resource.
+      Only resources with errors are shown.
+    </p>
+
+    <div class="govuk-!-margin-top-4 govuk-!-margin-bottom-6" style="background-color: #f3f2f1; padding: 15px 20px; border-left: 4px solid #1d70b8;">
+      <p class="govuk-body govuk-!-margin-bottom-0">
+        <strong>{{ resource_count }}</strong> resource{{ '' if resource_count == 1 else 's' }} require review.
+      </p>
+    </div>
+
+    <div class="app-scrollable-container app-scrollable">
+      <table class="govuk-table dl-table app-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">No.</th>
+            <th scope="col" class="govuk-table__header">Resource</th>
+            <th scope="col" class="govuk-table__header">Dataset</th>
+            <th scope="col" class="govuk-table__header">Organisation</th>
+            <th scope="col" class="govuk-table__header">Errors</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          {% for resource in resources %}
+          <tr class="govuk-table__row" {% if resource.row_colour == 'orange' %}style="background-color: #ffd8b0;"{% elif resource.row_colour == 'red' %}style="background-color: #f6d7d2;"{% endif %}>
+            <td class="govuk-table__cell">{{ loop.index }}</td>
+            <td class="govuk-table__cell">
+              <a class="govuk-link" href="{{ url_for('assign_entities.flagged_resource_submit', dataset=resource.dataset, resource=resource.resource) }}">{{ resource.resource }}</a>
+            </td>
+            <td class="govuk-table__cell">{{ resource.dataset }}</td>
+            <td class="govuk-table__cell">{{ resource.organisation }}</td>
+            <td class="govuk-table__cell">
+              {% if resource.errors %}
+                {% for error in resource.errors %}
+                <strong class="govuk-tag {% if resource.row_colour == 'orange' %}govuk-tag--orange{% elif resource.row_colour == 'red' %}govuk-tag--red{% else %}govuk-tag--grey{% endif %} govuk-!-margin-right-1 govuk-!-margin-bottom-1">{{ error.abbreviation }}</strong>
+                {% endfor %}
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <ul class="govuk-list govuk-body-s govuk-!-margin-top-4 govuk-!-margin-bottom-6" style="color: #505a5f;">
+      <li><span style="display: inline-block; width: 0.35em; height: 0.35em; border: 1px solid #0b0c0c; border-radius: 50%; background-color: #ffffff; vertical-align: 0; margin-left: 0.15em;"></span> <strong>White</strong> — Entity growth is above threshold</li>
+      <li><strong style="color: #f47738;">&#9679;</strong> <strong>Orange</strong> — Entity growth is above threshold (needs careful review)</li>
+      <li><strong style="color: #d4351c;">&#9679;</strong> <strong>Red</strong> — Other errors</li>
+    </ul>
+
+    {% if error_key %}
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">Error key</h2>
+    <dl class="govuk-summary-list">
+      {% for error in error_key %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <strong class="govuk-tag govuk-tag--grey">{{ error.abbreviation }}</strong>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ error.message }}
+        </dd>
+      </div>
+      {% endfor %}
+    </dl>
+    {% endif %}
+    <br>
+    <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-6">
+      <a class="govuk-link" href="{{ url_for('assign_entities.flagged_resources_start') }}">Upload another CSV</a>
+    </p>
+  </div>
+</div>
+{% endblock %}

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -90,16 +90,30 @@
         </div>
       </div>
 
-      {# Assign entities card (UI only) #}
+      {# Assign entities card #}
       <div class="govuk-grid-column-one-third">
-        <div class="app-tools-list__item">
+        <div class="app-tools-list__item" {% if add_data_lock %}data-blocked="true"{% endif %}>
           <div style="display:flex; justify-content:space-between; align-items:flex-start; flex:0 0 auto;">
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0" style="color:#505a5f;">Assign entities</h3>
-            <strong class="govuk-tag app-tag--inactive">INACTIVE</strong>
+            {% if add_data_lock %}
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><a href="{{ url_for('assign_entities.flagged_resources_start') }}" class="govuk-link govuk-link--no-visited-state app-tools-list__card-link" style="text-decoration:none; color:inherit;">Assign entities</a></h3>
+            <strong class="govuk-tag app-tag--locked">LOCKED</strong>
+            {% else %}
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><a href="{{ url_for('assign_entities.flagged_resources_start') }}" class="govuk-link govuk-link--no-visited-state app-tools-list__card-link" style="text-decoration:none; color:inherit;">Assign entities</a></h3>
+            <strong class="govuk-tag app-tag--unlocked">UNLOCKED</strong>
+            {% endif %}
           </div>
           <p class="govuk-body-s govuk-!-margin-top-2" style="flex:1;">Assign entity numbers to new data entries</p>
+          {% if add_data_lock %}
+          <p class="govuk-body-s govuk-!-margin-bottom-0">Locked by <strong>{{ add_data_lock.locked_by }}</strong><br>{{ add_data_lock.locked_at.strftime('%-d %B %Y at %H:%M') }}</p>
+          {% endif %}
           <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-          <button type="button" class="app-process-action-btn" disabled style="opacity:0.4; cursor:not-allowed;">Lock this process</button>
+          <form method="post" action="{{ url_for('base.toggle_add_data_lock') }}" style="flex:0 0 auto; width:100%;">
+            {% if add_data_lock %}
+            <button type="submit" class="app-process-action-btn">Unlock this process</button>
+            {% else %}
+            <button type="submit" class="app-process-action-btn">Lock this process</button>
+            {% endif %}
+          </form>
         </div>
       </div>
 

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -80,7 +80,7 @@
           <p class="govuk-body-s govuk-!-margin-bottom-0">Locked by <strong>{{ add_data_lock.locked_by }}</strong><br>{{ add_data_lock.locked_at.strftime('%-d %B %Y at %H:%M') }}</p>
           {% endif %}
           <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-          <form method="post" action="{{ url_for('base.toggle_add_data_lock') }}" style="flex:0 0 auto; width:100%;">
+          <form method="post" action="{{ url_for('base.toggle_process_lock', process='add-data') }}" style="flex:0 0 auto; width:100%;">
             {% if add_data_lock %}
             <button type="submit" class="app-process-action-btn">Unlock this process</button>
             {% else %}
@@ -92,9 +92,9 @@
 
       {# Assign entities card #}
       <div class="govuk-grid-column-one-third">
-        <div class="app-tools-list__item" {% if add_data_lock %}data-blocked="true"{% endif %}>
+        <div class="app-tools-list__item" {% if assign_entities_lock %}data-blocked="true"{% endif %}>
           <div style="display:flex; justify-content:space-between; align-items:flex-start; flex:0 0 auto;">
-            {% if add_data_lock %}
+            {% if assign_entities_lock %}
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><a href="{{ url_for('assign_entities.flagged_resources_start') }}" class="govuk-link govuk-link--no-visited-state app-tools-list__card-link" style="text-decoration:none; color:inherit;">Assign entities</a></h3>
             <strong class="govuk-tag app-tag--locked">LOCKED</strong>
             {% else %}
@@ -103,12 +103,12 @@
             {% endif %}
           </div>
           <p class="govuk-body-s govuk-!-margin-top-2" style="flex:1;">Assign entity numbers to new data entries</p>
-          {% if add_data_lock %}
-          <p class="govuk-body-s govuk-!-margin-bottom-0">Locked by <strong>{{ add_data_lock.locked_by }}</strong><br>{{ add_data_lock.locked_at.strftime('%-d %B %Y at %H:%M') }}</p>
+          {% if assign_entities_lock %}
+          <p class="govuk-body-s govuk-!-margin-bottom-0">Locked by <strong>{{ assign_entities_lock.locked_by }}</strong><br>{{ assign_entities_lock.locked_at.strftime('%-d %B %Y at %H:%M') }}</p>
           {% endif %}
           <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-          <form method="post" action="{{ url_for('base.toggle_add_data_lock') }}" style="flex:0 0 auto; width:100%;">
-            {% if add_data_lock %}
+          <form method="post" action="{{ url_for('base.toggle_process_lock', process='assign-entities') }}" style="flex:0 0 auto; width:100%;">
+            {% if assign_entities_lock %}
             <button type="submit" class="app-process-action-btn">Unlock this process</button>
             {% else %}
             <button type="submit" class="app-process-action-btn">Lock this process</button>
@@ -126,7 +126,23 @@
         <p class="govuk-body"><strong>{{ add_data_blocked_by }}</strong> has locked the Add Data process.</p>
         <p class="govuk-body">Would you like to unlock it?</p>
         <div style="display:flex;gap:1rem;align-items:center;">
-          <form method="post" action="{{ url_for('base.toggle_add_data_lock') }}">
+          <form method="post" action="{{ url_for('base.toggle_process_lock', process='add-data') }}">
+            <button type="submit" class="govuk-button govuk-!-margin-bottom-0">Yes, unlock it</button>
+          </form>
+          <a href="{{ url_for('base.index') }}" class="govuk-link">No, go back</a>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+
+    {% if assign_entities_blocked_by %}
+    <div id="assign-entities-blocked-modal" style="position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);z-index:1000;display:flex;align-items:center;justify-content:center;">
+      <div style="background:#fff;padding:2rem;max-width:480px;width:90%;">
+        <h2 class="govuk-heading-m">Assign Entities is currently locked</h2>
+        <p class="govuk-body"><strong>{{ assign_entities_blocked_by }}</strong> has locked the Assign Entities process.</p>
+        <p class="govuk-body">Would you like to unlock it?</p>
+        <div style="display:flex;gap:1rem;align-items:center;">
+          <form method="post" action="{{ url_for('base.toggle_process_lock', process='assign-entities') }}">
             <button type="submit" class="govuk-button govuk-!-margin-bottom-0">Yes, unlock it</button>
           </form>
           <a href="{{ url_for('base.index') }}" class="govuk-link">No, go back</a>

--- a/config/config.py
+++ b/config/config.py
@@ -94,7 +94,7 @@ def get_request_api_endpoint():
     env = os.getenv("ENVIRONMENT", "local").lower()
 
     mapping = {
-        "local": "http://localhost:8000",
+        "local": "http://host.docker.internal:8000",
         "development": "http://development-pub-async-api-lb-69142969.eu-west-2.elb.amazonaws.com",
         "staging": "http://staging-pub-async-api-lb-12493311.eu-west-2.elb.amazonaws.com",
         "production": "http://production-pub-async-api-lb-636110663.eu-west-2.elb.amazonaws.com",

--- a/config/config.py
+++ b/config/config.py
@@ -94,7 +94,7 @@ def get_request_api_endpoint():
     env = os.getenv("ENVIRONMENT", "local").lower()
 
     mapping = {
-        "local": "http://host.docker.internal:8000",
+        "local": "http://localhost:8000",
         "development": "http://development-pub-async-api-lb-69142969.eu-west-2.elb.amazonaws.com",
         "staging": "http://staging-pub-async-api-lb-12493311.eu-west-2.elb.amazonaws.com",
         "production": "http://production-pub-async-api-lb-636110663.eu-west-2.elb.amazonaws.com",

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -16,3 +16,4 @@ sentry-sdk[flask]
 PyGithub
 pydantic
 flask-sslify
+pandas

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import responses as rsps
 
+from application.blueprints.base.views import ADD_DATA_LOCK, ASSIGN_ENTITIES_LOCK
 from application.db.models import ServiceLock
 from application.extensions import db
 from config.config import get_request_api_endpoint
@@ -71,8 +72,8 @@ def test_flagged_resources_import_page_loads(client):
 
 
 def test_assign_entities_tile_links_to_start_page(client):
-    db.session.query(ServiceLock).filter_by(name="add-data").delete()
-    db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
+    db.session.query(ServiceLock).filter_by(name=ADD_DATA_LOCK).delete()
+    db.session.query(ServiceLock).filter_by(name=ASSIGN_ENTITIES_LOCK).delete()
     db.session.commit()
 
     response = client.get("/")
@@ -84,11 +85,11 @@ def test_assign_entities_tile_links_to_start_page(client):
 
 
 def test_add_data_lock_does_not_block_assign_entities(client):
-    db.session.query(ServiceLock).filter_by(name="add-data").delete()
-    db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
+    db.session.query(ServiceLock).filter_by(name=ADD_DATA_LOCK).delete()
+    db.session.query(ServiceLock).filter_by(name=ASSIGN_ENTITIES_LOCK).delete()
     db.session.add(
         ServiceLock(
-            name="add-data",
+            name=ADD_DATA_LOCK,
             locked_by="someone",
             locked_at=datetime.utcnow(),
         )
@@ -98,19 +99,19 @@ def test_add_data_lock_does_not_block_assign_entities(client):
     try:
         response = client.get("/assign-entities")
     finally:
-        db.session.query(ServiceLock).filter_by(name="add-data").delete()
-        db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
+        db.session.query(ServiceLock).filter_by(name=ADD_DATA_LOCK).delete()
+        db.session.query(ServiceLock).filter_by(name=ASSIGN_ENTITIES_LOCK).delete()
         db.session.commit()
 
     assert response.status_code == 200
 
 
 def test_assign_entities_uses_assign_entities_process_lock(client):
-    db.session.query(ServiceLock).filter_by(name="add-data").delete()
-    db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
+    db.session.query(ServiceLock).filter_by(name=ADD_DATA_LOCK).delete()
+    db.session.query(ServiceLock).filter_by(name=ASSIGN_ENTITIES_LOCK).delete()
     db.session.add(
         ServiceLock(
-            name="assign-entities",
+            name=ASSIGN_ENTITIES_LOCK,
             locked_by="someone",
             locked_at=datetime.utcnow(),
         )
@@ -120,8 +121,8 @@ def test_assign_entities_uses_assign_entities_process_lock(client):
     try:
         response = client.get("/assign-entities")
     finally:
-        db.session.query(ServiceLock).filter_by(name="add-data").delete()
-        db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
+        db.session.query(ServiceLock).filter_by(name=ADD_DATA_LOCK).delete()
+        db.session.query(ServiceLock).filter_by(name=ASSIGN_ENTITIES_LOCK).delete()
         db.session.commit()
 
     assert response.status_code == 302
@@ -129,11 +130,11 @@ def test_assign_entities_uses_assign_entities_process_lock(client):
 
 
 def test_assign_entities_card_can_unlock_assign_entities_process(client):
-    db.session.query(ServiceLock).filter_by(name="add-data").delete()
-    db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
+    db.session.query(ServiceLock).filter_by(name=ADD_DATA_LOCK).delete()
+    db.session.query(ServiceLock).filter_by(name=ASSIGN_ENTITIES_LOCK).delete()
     db.session.add(
         ServiceLock(
-            name="assign-entities",
+            name=ASSIGN_ENTITIES_LOCK,
             locked_by="someone",
             locked_at=datetime.utcnow(),
         )
@@ -143,8 +144,8 @@ def test_assign_entities_card_can_unlock_assign_entities_process(client):
     try:
         response = client.get("/")
     finally:
-        db.session.query(ServiceLock).filter_by(name="add-data").delete()
-        db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
+        db.session.query(ServiceLock).filter_by(name=ADD_DATA_LOCK).delete()
+        db.session.query(ServiceLock).filter_by(name=ASSIGN_ENTITIES_LOCK).delete()
         db.session.commit()
 
     assert response.status_code == 200

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -42,7 +42,7 @@ CSV_INPUT = (
 
 
 def test_flagged_resources_start_page_loads(client):
-    response = client.get("/asign-entities")
+    response = client.get("/assign-entities")
 
     assert response.status_code == 200
     assert b"Assign entities" in response.data
@@ -55,7 +55,7 @@ def test_flagged_resources_start_page_loads(client):
 
 
 def test_flagged_resources_import_page_loads(client):
-    response = client.get("/asign-entities/import")
+    response = client.get("/assign-entities/import")
 
     assert response.status_code == 200
     assert b"Import simple assign CSV" in response.data
@@ -75,7 +75,7 @@ def test_assign_entities_tile_links_to_start_page(client):
 
     assert response.status_code == 200
     assert b"Assign entities" in response.data
-    assert b"/asign-entities" in response.data
+    assert b"/assign-entities" in response.data
     assert response.data.count(b"Lock this process") == 2
 
 
@@ -91,7 +91,7 @@ def test_assign_entities_uses_add_data_process_lock(client):
     db.session.commit()
 
     try:
-        response = client.get("/asign-entities")
+        response = client.get("/assign-entities")
     finally:
         db.session.query(ServiceLock).filter_by(name="add_data").delete()
         db.session.commit()
@@ -124,17 +124,17 @@ def test_assign_entities_card_can_unlock_shared_process(client):
 
 def test_csv_upload_groups_resource_dataset_combinations(client):
     redirect_response = client.post(
-        "/asign-entities/import",
+        "/assign-entities/import",
         data={"mode": "parse", "csv_data": CSV_INPUT},
     )
 
     assert redirect_response.status_code == 302
-    assert "/asign-entities/resources" in redirect_response.headers["Location"]
+    assert "/assign-entities/resources" in redirect_response.headers["Location"]
     with client.session_transaction() as sess:
         assert sess.get("flagged_resource_cache_key")
 
     response = client.post(
-        "/asign-entities/import",
+        "/assign-entities/import",
         data={"mode": "parse", "csv_data": CSV_INPUT},
         follow_redirects=True,
     )
@@ -233,7 +233,7 @@ def test_csv_import_rejects_error_rows_without_error_code(client):
     )
 
     response = client.post(
-        "/asign-entities/import",
+        "/assign-entities/import",
         data={"mode": "parse", "csv_data": csv_input},
     )
 
@@ -250,7 +250,7 @@ def test_csv_import_preserves_na_error_code(client):
     )
 
     response = client.post(
-        "/asign-entities/import",
+        "/assign-entities/import",
         data={"mode": "parse", "csv_data": csv_input},
         follow_redirects=True,
     )
@@ -266,7 +266,7 @@ def test_pasted_csv_import_handles_request_entity_too_large(client, app):
 
     try:
         response = client.post(
-            "/asign-entities/import",
+            "/assign-entities/import",
             data={"mode": "parse", "csv_data": CSV_INPUT},
         )
     finally:
@@ -278,7 +278,7 @@ def test_pasted_csv_import_handles_request_entity_too_large(client, app):
 
 def test_uploaded_csv_groups_resource_dataset_combinations(client):
     response = client.post(
-        "/asign-entities/import",
+        "/assign-entities/import",
         data={
             "mode": "parse",
             "csv_file": (BytesIO(CSV_INPUT.encode("utf-8")), "flagged.csv"),
@@ -364,7 +364,7 @@ def test_assign_entities_check_results_does_not_show_retire_endpoints(client):
                             return_value=[],
                         ):
                             response = client.get(
-                                "/asign-entities/check-results/assign-id-1"
+                                "/assign-entities/check-results/assign-id-1"
                                 "?entity_search=Name+2"
                             )
 
@@ -386,9 +386,63 @@ def test_assign_entities_check_results_does_not_show_retire_endpoints(client):
 
 
 @rsps.activate
+def test_assign_entities_check_results_hides_entity_pagination_when_empty(client):
+    rsps.add(
+        rsps.GET,
+        f"{ASYNC_BASE}/assign-empty-id",
+        json={
+            "status": "COMPLETE",
+            "params": {
+                "dataset": "tree",
+                "organisation": "local-authority:ABC",
+            },
+            "response": {
+                "data": {
+                    "source-summary": {},
+                    "pipeline-summary": {"new-in-resource": 0},
+                }
+            },
+        },
+        status=200,
+    )
+    rsps.add(
+        rsps.GET,
+        f"{ASYNC_BASE}/assign-empty-id/response-details",
+        json=[],
+        status=200,
+    )
+
+    transform_controller = "application.blueprints.datamanager.controllers.transform"
+
+    with patch(f"{transform_controller}.get_org_entity", return_value=90):
+        with patch(f"{transform_controller}.get_organisation_name"):
+            with patch(f"{transform_controller}.get_dataset_name", return_value="Tree"):
+                with patch(
+                    f"{transform_controller}.get_entity_count_for_organisation_and_dataset",
+                    return_value=0,
+                ):
+                    with patch(
+                        f"{transform_controller}.get_entities_for_organisation_and_dataset",
+                        return_value=[],
+                    ):
+                        response = client.get(
+                            "/assign-entities/check-results/assign-empty-id"
+                        )
+
+    assert response.status_code == 200
+    entities_panel = response.data[
+        response.data.index(b'id="entities-table"') : response.data.index(
+            b'id="transformed-table"'
+        )
+    ]
+    assert b"Showing entities" not in entities_panel
+    assert b'aria-label="Pagination"' not in entities_panel
+
+
+@rsps.activate
 def test_resource_link_submits_assign_entities_request(client):
     import_response = client.post(
-        "/asign-entities/import",
+        "/assign-entities/import",
         data={"csv_data": CSV_INPUT},
     )
     assert import_response.status_code == 302
@@ -416,7 +470,7 @@ def test_resource_link_submits_assign_entities_request(client):
                     ],
                 ):
                     response = client.post(
-                        "/asign-entities/resource",
+                        "/assign-entities/resource",
                         data={
                             "dataset": "tree",
                             "resource": "resource-a",
@@ -425,7 +479,7 @@ def test_resource_link_submits_assign_entities_request(client):
                     )
 
     assert response.status_code == 302
-    assert "/asign-entities/check-results/assign-id-1" in response.headers["Location"]
+    assert "/assign-entities/check-results/assign-id-1" in response.headers["Location"]
     assert len(rsps.calls) == 1
     assert rsps.calls[0].request.url == ASYNC_BASE
     assert rsps.calls[0].request.headers["Content-Type"] == "application/json"
@@ -468,12 +522,12 @@ def test_direct_dataset_resource_skips_summary_page(client):
                     ],
                 ):
                     response = client.post(
-                        "/asign-entities",
+                        "/assign-entities",
                         data={"dataset": "Tree", "resource": "resource-a"},
                     )
 
     assert response.status_code == 302
-    assert "/asign-entities/check-results/assign-id-1" in response.headers["Location"]
+    assert "/assign-entities/check-results/assign-id-1" in response.headers["Location"]
 
 
 @rsps.activate
@@ -496,7 +550,7 @@ def test_resource_submit_uses_selected_organisation(client):
                     "application.blueprints.datamanager.controllers.flagged_resources.get_resource"
                 ) as get_resource:
                     response = client.post(
-                        "/asign-entities/resource",
+                        "/assign-entities/resource",
                         data={
                             "dataset": "tree",
                             "resource": "resource-a",

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -1,0 +1,369 @@
+import json
+from datetime import datetime
+from io import BytesIO
+from unittest.mock import patch
+
+import responses as rsps
+
+from application.db.models import ServiceLock
+from application.extensions import db
+from config.config import get_request_api_endpoint
+
+
+ASYNC_BASE = f"{get_request_api_endpoint()}/requests"
+
+
+CSV_INPUT = (
+    "dataset,resource,organisation,reference,status,entities_created,error_code,message\n"
+    "tree,resource-a,local-authority:ABC,ref-1,error,12%,LARGE_NUMBER_OF_NEW_ENTITIES,Entity growth is 12%\n"
+    "tree,resource-a,local-authority:ABC,ref-2,passed,1,,\n"
+    "article-4-direction-area,resource-b,local-authority:XYZ,ref-3,error,0,CURRENT_RESOURCE_EMPTY,Missing reference\n"
+    "article-4-direction-area,resource-b,local-authority:XYZ,ref-4,error,0,"
+    "CURRENT_RESOURCE_NO_NEW_ENTITIES,No new entities\n"
+    "article-4-direction-area,resource-b,local-authority:XYZ,ref-5,error,0,"
+    "DUPLICATE_ENTITY_ALL_FIELDS,Duplicate entities\n"
+    "article-4-direction-area,resource-b,local-authority:XYZ,ref-6,error,0,"
+    "DUPLICATE_REFERENCE_ORGANISATION_IN_NEW_RESOURCE,Duplicate new resource\n"
+    "article-4-direction-area,resource-b,local-authority:XYZ,ref-7,error,0,"
+    "DUPLICATE_REFERENCE_ORGANISATION,Duplicate existing\n"
+    "article-4-direction-area,resource-b,local-authority:XYZ,ref-8,error,0,"
+    "MISSING_ORGANISATION,Missing organisation\n"
+    "article-4-direction-area,resource-b,local-authority:XYZ,ref-9,error,0,"
+    "MISSING_REFERENCE,Missing reference\n"
+    "article-4-direction-area,resource-b,local-authority:XYZ,ref-10,error,0,"
+    "INVALID_URI_ISSUE,Invalid URI\n"
+    "article-4-direction-area,resource-b,local-authority:XYZ,ref-11,error,0,"
+    "PREVIOUS_RESOURCE_NOT_FOUND,Previous resource not found\n"
+    "article-4-direction-area,resource-b,local-authority:XYZ,ref-12,error,0,"
+    "PREVIOUS_RESOURCE_EMPTY,Previous resource is empty\n"
+    "tree,resource-c,local-authority:ABC,ref-4,successful,0,,Success\n"
+    "tree,resource-d,local-authority:ABC,ref-5,error,12%,LARGE_NUMBER_OF_NEW_ENTITIES,Entity growth is 12%\n"
+    "tree,resource-d,local-authority:ABC,ref-6,error,0,CURRENT_RESOURCE_EMPTY,Missing reference\n"
+)
+
+
+def test_flagged_resources_start_page_loads(client):
+    response = client.get("/asign-entities")
+
+    assert response.status_code == 200
+    assert b"Assign entities" in response.data
+    assert b"Review resources flagged by the simple assign process" in response.data
+    assert b"Use CSV import when you have a simple assign output file" in response.data
+    assert b"autocomplete-container" in response.data
+    assert b"accessible-autocomplete.min.js" in response.data
+    assert b"Import from CSV" in response.data
+    assert b"Upload CSV file" in response.data
+
+
+def test_flagged_resources_import_page_loads(client):
+    response = client.get("/asign-entities/import")
+
+    assert response.status_code == 200
+    assert b"Import simple assign CSV" in response.data
+    assert b"CSV format example" in response.data
+    assert b"CSV data" in response.data
+
+
+def test_assign_entities_tile_links_to_start_page(client):
+    db.session.query(ServiceLock).filter_by(name="add_data").delete()
+    db.session.commit()
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b"Assign entities" in response.data
+    assert b"/asign-entities" in response.data
+    assert response.data.count(b"Lock this process") == 2
+
+
+def test_assign_entities_uses_add_data_process_lock(client):
+    db.session.query(ServiceLock).filter_by(name="add_data").delete()
+    db.session.add(
+        ServiceLock(
+            name="add_data",
+            locked_by="someone",
+            locked_at=datetime.utcnow(),
+        )
+    )
+    db.session.commit()
+
+    try:
+        response = client.get("/asign-entities")
+    finally:
+        db.session.query(ServiceLock).filter_by(name="add_data").delete()
+        db.session.commit()
+
+    assert response.status_code == 302
+    assert "add_data_blocked_by=someone" in response.headers["Location"]
+
+
+def test_assign_entities_card_can_unlock_shared_process(client):
+    db.session.query(ServiceLock).filter_by(name="add_data").delete()
+    db.session.add(
+        ServiceLock(
+            name="add_data",
+            locked_by="someone",
+            locked_at=datetime.utcnow(),
+        )
+    )
+    db.session.commit()
+
+    try:
+        response = client.get("/")
+    finally:
+        db.session.query(ServiceLock).filter_by(name="add_data").delete()
+        db.session.commit()
+
+    assert response.status_code == 200
+    assert response.data.count(b"Unlock this process") == 2
+    assert b"Locked by <strong>someone</strong>" in response.data
+
+
+def test_csv_upload_groups_resource_dataset_combinations(client):
+    redirect_response = client.post(
+        "/asign-entities/import",
+        data={"mode": "parse", "csv_data": CSV_INPUT},
+    )
+
+    assert redirect_response.status_code == 302
+    assert (
+        "/asign-entities/resources"
+        in redirect_response.headers["Location"]
+    )
+    with client.session_transaction() as sess:
+        assert sess.get("flagged_resource_cache_key")
+        assert "flagged_resource_rows" not in sess
+
+    response = client.post(
+        "/asign-entities/import",
+        data={"mode": "parse", "csv_data": CSV_INPUT},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Flagged resources" in response.data
+    assert b"CSV import results" not in response.data
+    assert b"resources require review" in response.data
+    assert response.data.count(b">resource-a</a>") == 1
+    assert b"resource-b" in response.data
+    assert response.data.index(b">resource-a</a>") < response.data.index(b"resource-b")
+    assert response.data.index(b">resource-a</a>") < response.data.index(b">resource-d</a>")
+    assert response.data.index(b">resource-d</a>") < response.data.index(b"resource-b")
+    assert b"resource-c" not in response.data
+    assert b"Tree" not in response.data
+    assert b"Organisation ABC" not in response.data
+    assert b"local-authority:ABC" in response.data
+    assert b"Dataset" in response.data
+    assert b"Organisation" in response.data
+    assert b"Resource" in response.data
+    assert b"Errors" in response.data
+    assert b"No." in response.data
+    assert b"govuk-tag--red" in response.data
+    assert b"govuk-tag--orange" in response.data
+    assert b"govuk-tag--grey" in response.data
+    assert b">EG</strong>" in response.data
+    assert b">CRE</strong>" in response.data
+    assert b">NNE</strong>" in response.data
+    assert b">DEAF</strong>" in response.data
+    assert b">DRON</strong>" in response.data
+    assert b">DRO</strong>" in response.data
+    assert b">MO</strong>" in response.data
+    assert b">MR</strong>" in response.data
+    assert b">IUI</strong>" in response.data
+    assert b">PRE</strong>" in response.data
+    assert b">PRNF</strong>" in response.data
+    assert b"Entity growth is above threshold" in response.data
+    assert b"Resource empty" in response.data
+    assert b"No new entities" in response.data
+    assert b"Resource contains duplicates with existing entities (all fields)" in response.data
+    assert (
+        b"Resource contains duplicate entities (organisation and reference)"
+        in response.data
+    )
+    assert (
+        b"Resource contains duplicates with existing entities "
+        b"(Reference and organisation only)" in response.data
+    )
+    assert b"Resource contain entities with missing organisation value" in response.data
+    assert b"Resource contain entities with missing reference values" in response.data
+    assert b"Resource has known issues with invalid URIs" in response.data
+    assert b"Previous resource is empty" in response.data
+    assert b"Previous resource not found" in response.data
+    assert b"Error key" in response.data
+    error_key_html = response.data[response.data.index(b"Error key"):]
+    assert error_key_html.index(b">EG</strong>") < error_key_html.index(b">CRE</strong>")
+    assert b"background-color: #ffd8b0" in response.data
+    assert b"background-color: #f6d7d2" in response.data
+    assert b"background-color: #d4edda" not in response.data
+    assert b"White" in response.data
+    assert b"Orange" in response.data
+    assert b"Entity growth is above threshold" in response.data
+    assert b"Entity growth is above threshold (needs careful review)" in response.data
+    assert b"Red" in response.data
+    assert b"Other errors" in response.data
+    assert b"Multiple errors" not in response.data
+    assert b"LARGE_NUMBER_OF_NEW_ENTITIES" not in response.data
+    assert b"CURRENT_RESOURCE_EMPTY" not in response.data
+    assert b"CURRENT_RESOURCE_NO_NEW_ENTITIES" not in response.data
+    assert b"DUPLICATE_ENTITY_ALL_FIELDS" not in response.data
+    assert b"DUPLICATE_REFERENCE_ORGANISATION_IN_NEW_RESOURCE" not in response.data
+    assert b"DUPLICATE_REFERENCE_ORGANISATION" not in response.data
+    assert b"MISSING_ORGANISATION" not in response.data
+    assert b"MISSING_REFERENCE" not in response.data
+    assert b"INVALID_URI_ISSUE" not in response.data
+    assert b"PREVIOUS_RESOURCE_EMPTY" not in response.data
+    assert b"PREVIOUS_RESOURCE_NOT_FOUND" not in response.data
+    assert b"No code" not in response.data
+
+
+def test_csv_import_rejects_error_rows_without_error_code(client):
+    csv_input = (
+        "dataset,resource,organisation,reference,status,entities_created,error_code,message\n"
+        "tree,resource-a,local-authority:ABC,ref-1,error,12%,,Entity growth is 12%\n"
+    )
+
+    response = client.post(
+        "/asign-entities/import",
+        data={"mode": "parse", "csv_data": csv_input},
+    )
+
+    assert response.status_code == 200
+    assert b"Rows with status &#39;error&#39; must include an error_code" in response.data
+
+
+def test_csv_import_preserves_na_error_code(client):
+    csv_input = (
+        "dataset,resource,organisation,reference,status,entities_created,error_code,message\n"
+        "tree,resource-a,local-authority:ABC,ref-1,error,12%,NA,Missing thing\n"
+    )
+
+    response = client.post(
+        "/asign-entities/import",
+        data={"mode": "parse", "csv_data": csv_input},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b">NA</strong>" in response.data
+    assert b"No code" not in response.data
+
+
+def test_uploaded_csv_groups_resource_dataset_combinations(client):
+    response = client.post(
+        "/asign-entities/import",
+        data={
+            "mode": "parse",
+            "csv_file": (BytesIO(CSV_INPUT.encode("utf-8")), "flagged.csv"),
+        },
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Select a resource" in response.data
+    assert response.data.count(b">resource-a</a>") == 1
+    assert b"resource-b" in response.data
+
+
+def test_flagged_resource_detail_post_redirects_to_preview(client):
+    response = client.post(
+        "/asign-entities/check-results/assign-id-1",
+        data={"retire_endpoints": ["endpoint-a"]},
+    )
+
+    assert response.status_code == 302
+    assert (
+        "/datamanager/add-data/assign-id-1/entities"
+        in response.headers["Location"]
+    )
+
+
+@rsps.activate
+def test_resource_link_submits_assign_entities_request(client):
+    client.post(
+        "/asign-entities/import",
+        data={"csv_data": CSV_INPUT},
+    )
+    rsps.add(rsps.POST, ASYNC_BASE, json={"id": "assign-id-1"}, status=202)
+
+    with patch(
+        "application.blueprints.datamanager.controllers.flagged_resources.get_dataset_id",
+        return_value=None,
+    ):
+        with patch(
+            "application.blueprints.datamanager.controllers.flagged_resources.get_dataset_name",
+            return_value="Tree",
+        ):
+            with patch(
+                "application.blueprints.datamanager.controllers.flagged_resources.get_collection_id",
+                return_value="tree",
+            ):
+                with patch(
+                    "application.blueprints.datamanager.controllers.flagged_resources.get_resource",
+                    return_value=[
+                        {
+                            "pipeline": "tree",
+                            "organisation": "local-authority:ABC",
+                        }
+                    ],
+                ):
+                    response = client.get(
+                        "/asign-entities/resource?dataset=tree&resource=resource-a"
+                    )
+
+    assert response.status_code == 302
+    assert (
+        "/asign-entities/check-results/assign-id-1"
+        in response.headers["Location"]
+    )
+    assert len(rsps.calls) == 1
+    assert rsps.calls[0].request.url == ASYNC_BASE
+    assert rsps.calls[0].request.headers["Content-Type"] == "application/json"
+    assert json.loads(rsps.calls[0].request.body) == {
+        "params": {
+            "type": "add_data",
+            "resource": "resource-a",
+            "dataset": "tree",
+            "collection": "tree",
+            "authoritative": True,
+            "organisationName": "local-authority:ABC",
+            "organisation": "local-authority:ABC",
+        }
+    }
+
+
+@rsps.activate
+def test_direct_dataset_resource_skips_summary_page(client):
+    rsps.add(rsps.POST, ASYNC_BASE, json={"id": "assign-id-1"}, status=202)
+
+    with patch(
+        "application.blueprints.datamanager.controllers.flagged_resources.get_dataset_id",
+        return_value="tree",
+    ):
+        with patch(
+            "application.blueprints.datamanager.controllers.flagged_resources.get_dataset_name",
+            return_value="Tree",
+        ):
+            with patch(
+                "application.blueprints.datamanager.controllers.flagged_resources.get_collection_id",
+                return_value="tree",
+            ):
+                with patch(
+                    "application.blueprints.datamanager.controllers.flagged_resources.get_resource",
+                    return_value=[
+                        {
+                            "pipeline": "tree",
+                            "organisation": "local-authority:ABC",
+                        }
+                    ],
+                ):
+                    response = client.post(
+                        "/asign-entities",
+                        data={"dataset": "Tree", "resource": "resource-a"},
+                    )
+
+    assert response.status_code == 302
+    assert (
+        "/asign-entities/check-results/assign-id-1"
+        in response.headers["Location"]
+    )

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -9,7 +9,6 @@ from application.db.models import ServiceLock
 from application.extensions import db
 from config.config import get_request_api_endpoint
 
-
 ASYNC_BASE = f"{get_request_api_endpoint()}/requests"
 
 
@@ -126,13 +125,9 @@ def test_csv_upload_groups_resource_dataset_combinations(client):
     )
 
     assert redirect_response.status_code == 302
-    assert (
-        "/asign-entities/resources"
-        in redirect_response.headers["Location"]
-    )
+    assert "/asign-entities/resources" in redirect_response.headers["Location"]
     with client.session_transaction() as sess:
         assert sess.get("flagged_resource_cache_key")
-        assert "flagged_resource_rows" not in sess
 
     response = client.post(
         "/asign-entities/import",
@@ -144,11 +139,17 @@ def test_csv_upload_groups_resource_dataset_combinations(client):
     assert b"Flagged resources" in response.data
     assert b"CSV import results" not in response.data
     assert b"resources require review" in response.data
-    assert response.data.count(b">resource-a</a>") == 1
+    assert response.data.count(b">resource-a</button>") == 1
     assert b"resource-b" in response.data
-    assert response.data.index(b">resource-a</a>") < response.data.index(b"resource-b")
-    assert response.data.index(b">resource-a</a>") < response.data.index(b">resource-d</a>")
-    assert response.data.index(b">resource-d</a>") < response.data.index(b"resource-b")
+    assert response.data.index(b">resource-a</button>") < response.data.index(
+        b"resource-b"
+    )
+    assert response.data.index(b">resource-a</button>") < response.data.index(
+        b">resource-d</button>"
+    )
+    assert response.data.index(b">resource-d</button>") < response.data.index(
+        b"resource-b"
+    )
     assert b"resource-c" not in response.data
     assert b"Tree" not in response.data
     assert b"Organisation ABC" not in response.data
@@ -175,7 +176,10 @@ def test_csv_upload_groups_resource_dataset_combinations(client):
     assert b"Entity growth is above threshold" in response.data
     assert b"Resource empty" in response.data
     assert b"No new entities" in response.data
-    assert b"Resource contains duplicates with existing entities (all fields)" in response.data
+    assert (
+        b"Resource contains duplicates with existing entities (all fields)"
+        in response.data
+    )
     assert (
         b"Resource contains duplicate entities (organisation and reference)"
         in response.data
@@ -190,8 +194,10 @@ def test_csv_upload_groups_resource_dataset_combinations(client):
     assert b"Previous resource is empty" in response.data
     assert b"Previous resource not found" in response.data
     assert b"Error key" in response.data
-    error_key_html = response.data[response.data.index(b"Error key"):]
-    assert error_key_html.index(b">EG</strong>") < error_key_html.index(b">CRE</strong>")
+    error_key_html = response.data[response.data.index(b"Error key") :]
+    assert error_key_html.index(b">EG</strong>") < error_key_html.index(
+        b">CRE</strong>"
+    )
     assert b"background-color: #ffd8b0" in response.data
     assert b"background-color: #f6d7d2" in response.data
     assert b"background-color: #d4edda" not in response.data
@@ -228,7 +234,9 @@ def test_csv_import_rejects_error_rows_without_error_code(client):
     )
 
     assert response.status_code == 200
-    assert b"Rows with status &#39;error&#39; must include an error_code" in response.data
+    assert (
+        b"Rows with status &#39;error&#39; must include an error_code" in response.data
+    )
 
 
 def test_csv_import_preserves_na_error_code(client):
@@ -261,7 +269,7 @@ def test_uploaded_csv_groups_resource_dataset_combinations(client):
 
     assert response.status_code == 200
     assert b"Select a resource" in response.data
-    assert response.data.count(b">resource-a</a>") == 1
+    assert response.data.count(b">resource-a</button>") == 1
     assert b"resource-b" in response.data
 
 
@@ -272,18 +280,16 @@ def test_flagged_resource_detail_post_redirects_to_preview(client):
     )
 
     assert response.status_code == 302
-    assert (
-        "/datamanager/add-data/assign-id-1/entities"
-        in response.headers["Location"]
-    )
+    assert "/datamanager/add-data/assign-id-1/entities" in response.headers["Location"]
 
 
 @rsps.activate
 def test_resource_link_submits_assign_entities_request(client):
-    client.post(
+    import_response = client.post(
         "/asign-entities/import",
         data={"csv_data": CSV_INPUT},
     )
+    assert import_response.status_code == 302
     rsps.add(rsps.POST, ASYNC_BASE, json={"id": "assign-id-1"}, status=202)
 
     with patch(
@@ -307,15 +313,17 @@ def test_resource_link_submits_assign_entities_request(client):
                         }
                     ],
                 ):
-                    response = client.get(
-                        "/asign-entities/resource?dataset=tree&resource=resource-a"
+                    response = client.post(
+                        "/asign-entities/resource",
+                        data={
+                            "dataset": "tree",
+                            "resource": "resource-a",
+                            "organisation": "local-authority:ABC",
+                        },
                     )
 
     assert response.status_code == 302
-    assert (
-        "/asign-entities/check-results/assign-id-1"
-        in response.headers["Location"]
-    )
+    assert "/asign-entities/check-results/assign-id-1" in response.headers["Location"]
     assert len(rsps.calls) == 1
     assert rsps.calls[0].request.url == ASYNC_BASE
     assert rsps.calls[0].request.headers["Content-Type"] == "application/json"
@@ -363,7 +371,39 @@ def test_direct_dataset_resource_skips_summary_page(client):
                     )
 
     assert response.status_code == 302
-    assert (
-        "/asign-entities/check-results/assign-id-1"
-        in response.headers["Location"]
+    assert "/asign-entities/check-results/assign-id-1" in response.headers["Location"]
+
+
+@rsps.activate
+def test_resource_submit_uses_selected_organisation(client):
+    rsps.add(rsps.POST, ASYNC_BASE, json={"id": "assign-id-1"}, status=202)
+
+    with patch(
+        "application.blueprints.datamanager.controllers.flagged_resources.get_dataset_id",
+        return_value=None,
+    ):
+        with patch(
+            "application.blueprints.datamanager.controllers.flagged_resources.get_dataset_name",
+            return_value="Tree",
+        ):
+            with patch(
+                "application.blueprints.datamanager.controllers.flagged_resources.get_collection_id",
+                return_value="tree",
+            ):
+                with patch(
+                    "application.blueprints.datamanager.controllers.flagged_resources.get_resource"
+                ) as get_resource:
+                    response = client.post(
+                        "/asign-entities/resource",
+                        data={
+                            "dataset": "tree",
+                            "resource": "resource-a",
+                            "organisation": "local-authority:XYZ",
+                        },
+                    )
+
+    assert response.status_code == 302
+    get_resource.assert_not_called()
+    assert json.loads(rsps.calls[0].request.body)["params"]["organisation"] == (
+        "local-authority:XYZ"
     )

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -334,7 +334,7 @@ def test_uploaded_csv_import_handles_request_entity_too_large(client, app):
         response = client.post(
             "/assign-entities/import",
             data={
-                "mode": "parse",
+                "mode": "upload",
                 "csv_file": (BytesIO(CSV_INPUT.encode("utf-8")), "flagged.csv"),
             },
             content_type="multipart/form-data",

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -273,14 +273,77 @@ def test_uploaded_csv_groups_resource_dataset_combinations(client):
     assert b"resource-b" in response.data
 
 
-def test_flagged_resource_detail_post_redirects_to_preview(client):
-    response = client.post(
-        "/asign-entities/check-results/assign-id-1",
-        data={"retire_endpoints": ["endpoint-a"]},
+@rsps.activate
+def test_assign_entities_check_results_does_not_show_retire_endpoints(client):
+    rsps.add(
+        rsps.GET,
+        f"{ASYNC_BASE}/assign-id-1",
+        json={
+            "status": "COMPLETE",
+            "params": {
+                "dataset": "tree",
+                "organisation": "local-authority:ABC",
+            },
+            "response": {
+                "data": {
+                    "source-summary": {
+                        "existing_endpoint_for_organisation_dataset": ["endpoint-a"]
+                    },
+                    "pipeline-summary": {"new-in-resource": 1},
+                }
+            },
+        },
+        status=200,
+    )
+    rsps.add(
+        rsps.GET,
+        f"{ASYNC_BASE}/assign-id-1/response-details",
+        json=[
+            {
+                "entry_number": 1,
+                "transformed_row": [
+                    {"entity": "1", "field": "reference", "value": "ref-1"},
+                    {"entity": "1", "field": "name", "value": "Name 1"},
+                ],
+                "issue_logs": [],
+            }
+        ],
+        status=200,
     )
 
-    assert response.status_code == 302
-    assert "/datamanager/add-data/assign-id-1/entities" in response.headers["Location"]
+    transform_controller = "application.blueprints.datamanager.controllers.transform"
+
+    with patch(
+        f"{transform_controller}.get_endpoint_urls_for_hashes",
+        return_value={
+            "endpoint-a": {
+                "endpoint_url": "https://example.com/data.csv",
+                "end_date": "",
+            }
+        },
+    ):
+        with patch(f"{transform_controller}.get_org_entity", return_value=90):
+            with patch(f"{transform_controller}.get_organisation_name"):
+                with patch(
+                    f"{transform_controller}.get_dataset_name", return_value="Tree"
+                ):
+                    with patch(
+                        f"{transform_controller}.get_entity_count_for_organisation_and_dataset",
+                        return_value=1,
+                    ):
+                        with patch(
+                            f"{transform_controller}.get_entities_for_organisation_and_dataset",
+                            return_value=[],
+                        ):
+                            response = client.get(
+                                "/asign-entities/check-results/assign-id-1"
+                            )
+
+    assert response.status_code == 200
+    assert b"Data Submission Assessment" in response.data
+    assert b"Retire endpoints" not in response.data
+    assert b"retire_endpoints" not in response.data
+    assert b"/datamanager/add-data/assign-id-1/entities" in response.data
 
 
 @rsps.activate

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -306,7 +306,15 @@ def test_assign_entities_check_results_does_not_show_retire_endpoints(client):
                     {"entity": "1", "field": "name", "value": "Name 1"},
                 ],
                 "issue_logs": [],
-            }
+            },
+            {
+                "entry_number": 2,
+                "transformed_row": [
+                    {"entity": "2", "field": "reference", "value": "ref-2"},
+                    {"entity": "2", "field": "name", "value": "Name 2"},
+                ],
+                "issue_logs": [],
+            },
         ],
         status=200,
     )
@@ -337,10 +345,21 @@ def test_assign_entities_check_results_does_not_show_retire_endpoints(client):
                         ):
                             response = client.get(
                                 "/asign-entities/check-results/assign-id-1"
+                                "?entity_search=Name+2"
                             )
 
     assert response.status_code == 200
     assert b"Data Submission Assessment" in response.data
+    assert b"Search entities" in response.data
+    assert b'name="entity_search"' in response.data
+    assert b'value="Name 2"' in response.data
+    entities_panel = response.data[
+        response.data.index(b'id="entities-table"') : response.data.index(
+            b'id="transformed-table"'
+        )
+    ]
+    assert b"Name 2" in entities_panel
+    assert b"Name 1" not in entities_panel
     assert b"Retire endpoints" not in response.data
     assert b"retire_endpoints" not in response.data
     assert b"/datamanager/add-data/assign-id-1/entities" in response.data

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -71,7 +71,8 @@ def test_flagged_resources_import_page_loads(client):
 
 
 def test_assign_entities_tile_links_to_start_page(client):
-    db.session.query(ServiceLock).filter_by(name="add_data").delete()
+    db.session.query(ServiceLock).filter_by(name="add-data").delete()
+    db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
     db.session.commit()
 
     response = client.get("/")
@@ -82,11 +83,12 @@ def test_assign_entities_tile_links_to_start_page(client):
     assert response.data.count(b"Lock this process") == 2
 
 
-def test_assign_entities_uses_add_data_process_lock(client):
-    db.session.query(ServiceLock).filter_by(name="add_data").delete()
+def test_add_data_lock_does_not_block_assign_entities(client):
+    db.session.query(ServiceLock).filter_by(name="add-data").delete()
+    db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
     db.session.add(
         ServiceLock(
-            name="add_data",
+            name="add-data",
             locked_by="someone",
             locked_at=datetime.utcnow(),
         )
@@ -96,18 +98,42 @@ def test_assign_entities_uses_add_data_process_lock(client):
     try:
         response = client.get("/assign-entities")
     finally:
-        db.session.query(ServiceLock).filter_by(name="add_data").delete()
+        db.session.query(ServiceLock).filter_by(name="add-data").delete()
+        db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
+        db.session.commit()
+
+    assert response.status_code == 200
+
+
+def test_assign_entities_uses_assign_entities_process_lock(client):
+    db.session.query(ServiceLock).filter_by(name="add-data").delete()
+    db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
+    db.session.add(
+        ServiceLock(
+            name="assign-entities",
+            locked_by="someone",
+            locked_at=datetime.utcnow(),
+        )
+    )
+    db.session.commit()
+
+    try:
+        response = client.get("/assign-entities")
+    finally:
+        db.session.query(ServiceLock).filter_by(name="add-data").delete()
+        db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
         db.session.commit()
 
     assert response.status_code == 302
-    assert "add_data_blocked_by=someone" in response.headers["Location"]
+    assert "assign_entities_blocked_by=someone" in response.headers["Location"]
 
 
-def test_assign_entities_card_can_unlock_shared_process(client):
-    db.session.query(ServiceLock).filter_by(name="add_data").delete()
+def test_assign_entities_card_can_unlock_assign_entities_process(client):
+    db.session.query(ServiceLock).filter_by(name="add-data").delete()
+    db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
     db.session.add(
         ServiceLock(
-            name="add_data",
+            name="assign-entities",
             locked_by="someone",
             locked_at=datetime.utcnow(),
         )
@@ -117,12 +143,22 @@ def test_assign_entities_card_can_unlock_shared_process(client):
     try:
         response = client.get("/")
     finally:
-        db.session.query(ServiceLock).filter_by(name="add_data").delete()
+        db.session.query(ServiceLock).filter_by(name="add-data").delete()
+        db.session.query(ServiceLock).filter_by(name="assign-entities").delete()
         db.session.commit()
 
     assert response.status_code == 200
-    assert response.data.count(b"Unlock this process") == 2
+    assert response.data.count(b"Unlock this process") == 1
+    assert response.data.count(b"Lock this process") == 1
     assert b"Locked by <strong>someone</strong>" in response.data
+    assert b"/process-lock/assign-entities/toggle" in response.data
+
+
+def test_unknown_process_lock_redirects_home(client):
+    response = client.post("/process-lock/unknown/toggle")
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/index"
 
 
 def test_csv_upload_groups_resource_dataset_combinations(client):

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -496,6 +496,7 @@ def test_resource_link_submits_assign_entities_request(client):
             "dataset": "tree",
             "collection": "tree",
             "authoritative": True,
+            "github_branch": "config-manager-update",
             "organisationName": "local-authority:ABC",
             "organisation": "local-authority:ABC",
         }
@@ -534,6 +535,9 @@ def test_direct_dataset_resource_skips_summary_page(client):
 
     assert response.status_code == 302
     assert "/assign-entities/check-results/assign-id-1" in response.headers["Location"]
+    assert json.loads(rsps.calls[0].request.body)["params"]["github_branch"] == (
+        "config-manager-update"
+    )
 
 
 @rsps.activate
@@ -566,6 +570,9 @@ def test_resource_submit_uses_selected_organisation(client):
 
     assert response.status_code == 302
     get_resource.assert_not_called()
+    assert json.loads(rsps.calls[0].request.body)["params"]["github_branch"] == (
+        "config-manager-update"
+    )
     assert json.loads(rsps.calls[0].request.body)["params"]["organisation"] == (
         "local-authority:XYZ"
     )

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -162,6 +162,26 @@ def test_unknown_process_lock_redirects_home(client):
     assert response.headers["Location"] == "/index"
 
 
+def test_process_lock_toggle_allows_authenticated_non_admin(client, app):
+    previous_authentication_on = app.config["AUTHENTICATION_ON"]
+    app.config["AUTHENTICATION_ON"] = True
+    db.session.query(ServiceLock).filter_by(name=ADD_DATA_LOCK).delete()
+    db.session.commit()
+
+    try:
+        with client.session_transaction() as sess:
+            sess["user"] = {"login": "test-user", "is_admin": False}
+
+        response = client.post("/process-lock/add-data/toggle")
+        assert response.status_code == 302
+        assert response.headers["Location"] == "/index"
+        assert db.session.get(ServiceLock, ADD_DATA_LOCK).locked_by == "test-user"
+    finally:
+        app.config["AUTHENTICATION_ON"] = previous_authentication_on
+        db.session.query(ServiceLock).filter_by(name=ADD_DATA_LOCK).delete()
+        db.session.commit()
+
+
 def test_csv_upload_groups_resource_dataset_combinations(client):
     redirect_response = client.post(
         "/assign-entities/import",
@@ -304,6 +324,28 @@ def test_pasted_csv_import_handles_request_entity_too_large(client, app):
 
     assert response.status_code == 413
     assert b"The pasted CSV is too large. Upload the CSV file instead." in response.data
+
+
+def test_uploaded_csv_import_handles_request_entity_too_large(client, app):
+    previous_limit = app.config.get("MAX_CONTENT_LENGTH")
+    app.config["MAX_CONTENT_LENGTH"] = 10
+
+    try:
+        response = client.post(
+            "/assign-entities/import",
+            data={
+                "mode": "parse",
+                "csv_file": (BytesIO(CSV_INPUT.encode("utf-8")), "flagged.csv"),
+            },
+            content_type="multipart/form-data",
+        )
+    finally:
+        app.config["MAX_CONTENT_LENGTH"] = previous_limit
+
+    assert response.status_code == 413
+    assert b"The uploaded CSV is too large. Upload a file smaller than 10MB." in (
+        response.data
+    )
 
 
 def test_uploaded_csv_groups_resource_dataset_combinations(client):
@@ -536,6 +578,7 @@ def test_resource_link_submits_assign_entities_request(client):
             "github_branch": "config-manager-update",
             "organisationName": "local-authority:ABC",
             "organisation": "local-authority:ABC",
+            "return_endpoint": "assign_entities.flagged_resources_summary",
         }
     }
 
@@ -572,9 +615,9 @@ def test_direct_dataset_resource_skips_summary_page(client):
 
     assert response.status_code == 302
     assert "/assign-entities/check-results/assign-id-1" in response.headers["Location"]
-    assert json.loads(rsps.calls[0].request.body)["params"]["github_branch"] == (
-        "config-manager-update"
-    )
+    params = json.loads(rsps.calls[0].request.body)["params"]
+    assert params["github_branch"] == "config-manager-update"
+    assert params["return_endpoint"] == "assign_entities.flagged_resources_start"
 
 
 @rsps.activate
@@ -612,4 +655,7 @@ def test_resource_submit_uses_selected_organisation(client):
     )
     assert json.loads(rsps.calls[0].request.body)["params"]["organisation"] == (
         "local-authority:XYZ"
+    )
+    assert json.loads(rsps.calls[0].request.body)["params"]["return_endpoint"] == (
+        "assign_entities.flagged_resources_summary"
     )

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -61,6 +61,10 @@ def test_flagged_resources_import_page_loads(client):
     assert b"Import simple assign CSV" in response.data
     assert b"CSV format example" in response.data
     assert b"CSV data" in response.data
+    assert (
+        b"Use the CSV file upload option if your CSV is larger than 10MB."
+        in response.data
+    )
 
 
 def test_assign_entities_tile_links_to_start_page(client):
@@ -254,6 +258,22 @@ def test_csv_import_preserves_na_error_code(client):
     assert response.status_code == 200
     assert b">NA</strong>" in response.data
     assert b"No code" not in response.data
+
+
+def test_pasted_csv_import_handles_request_entity_too_large(client, app):
+    previous_limit = app.config.get("MAX_CONTENT_LENGTH")
+    app.config["MAX_CONTENT_LENGTH"] = 10
+
+    try:
+        response = client.post(
+            "/asign-entities/import",
+            data={"mode": "parse", "csv_data": CSV_INPUT},
+        )
+    finally:
+        app.config["MAX_CONTENT_LENGTH"] = previous_limit
+
+    assert response.status_code == 413
+    assert b"The pasted CSV is too large. Upload the CSV file instead." in response.data
 
 
 def test_uploaded_csv_groups_resource_dataset_combinations(client):

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -46,12 +46,15 @@ def test_flagged_resources_start_page_loads(client):
 
     assert response.status_code == 200
     assert b"Assign entities" in response.data
-    assert b"Review resources flagged by the simple assign process" in response.data
-    assert b"Use CSV import when you have a simple assign output file" in response.data
-    assert b"autocomplete-container" in response.data
-    assert b"accessible-autocomplete.min.js" in response.data
-    assert b"Import from CSV" in response.data
+    assert b"Upload the CSV output to see grouped resources" in response.data
+    assert (
+        b"Use CSV upload when you have a simple batch assign output file"
+        in response.data
+    )
     assert b"Upload CSV file" in response.data
+    assert b"Import from CSV" not in response.data
+    assert b"autocomplete-container" not in response.data
+    assert b"accessible-autocomplete.min.js" not in response.data
 
 
 def test_flagged_resources_import_page_loads(client):
@@ -140,7 +143,7 @@ def test_csv_upload_groups_resource_dataset_combinations(client):
     )
 
     assert response.status_code == 200
-    assert b"Flagged resources" in response.data
+    assert b"Assign Entities - Flagged Resources" in response.data
     assert b"CSV import results" not in response.data
     assert b"resources require review" in response.data
     assert response.data.count(b">resource-a</button>") == 1
@@ -166,6 +169,7 @@ def test_csv_upload_groups_resource_dataset_combinations(client):
     assert b"govuk-tag--red" in response.data
     assert b"govuk-tag--orange" in response.data
     assert b"govuk-tag--grey" in response.data
+    assert b'name="errors" value="LARGE_NUMBER_OF_NEW_ENTITIES"' in response.data
     assert b">EG</strong>" in response.data
     assert b">CRE</strong>" in response.data
     assert b">NNE</strong>" in response.data
@@ -212,17 +216,6 @@ def test_csv_upload_groups_resource_dataset_combinations(client):
     assert b"Red" in response.data
     assert b"Other errors" in response.data
     assert b"Multiple errors" not in response.data
-    assert b"LARGE_NUMBER_OF_NEW_ENTITIES" not in response.data
-    assert b"CURRENT_RESOURCE_EMPTY" not in response.data
-    assert b"CURRENT_RESOURCE_NO_NEW_ENTITIES" not in response.data
-    assert b"DUPLICATE_ENTITY_ALL_FIELDS" not in response.data
-    assert b"DUPLICATE_REFERENCE_ORGANISATION_IN_NEW_RESOURCE" not in response.data
-    assert b"DUPLICATE_REFERENCE_ORGANISATION" not in response.data
-    assert b"MISSING_ORGANISATION" not in response.data
-    assert b"MISSING_REFERENCE" not in response.data
-    assert b"INVALID_URI_ISSUE" not in response.data
-    assert b"PREVIOUS_RESOURCE_EMPTY" not in response.data
-    assert b"PREVIOUS_RESOURCE_NOT_FOUND" not in response.data
     assert b"No code" not in response.data
 
 
@@ -303,6 +296,7 @@ def test_assign_entities_check_results_does_not_show_retire_endpoints(client):
             "params": {
                 "dataset": "tree",
                 "organisation": "local-authority:ABC",
+                "resource": "resource-a",
             },
             "response": {
                 "data": {
@@ -366,10 +360,12 @@ def test_assign_entities_check_results_does_not_show_retire_endpoints(client):
                             response = client.get(
                                 "/assign-entities/check-results/assign-id-1"
                                 "?entity_search=Name+2"
+                                "&errors=large_number_of_new_entities,"
+                                "current_resource_empty"
                             )
 
     assert response.status_code == 200
-    assert b"Data Submission Assessment" in response.data
+    assert b"Assign Entities - Resource Details" in response.data
     assert b"Search entities" in response.data
     assert b'name="entity_search"' in response.data
     assert b'value="Name 2"' in response.data
@@ -380,6 +376,13 @@ def test_assign_entities_check_results_does_not_show_retire_endpoints(client):
     ]
     assert b"Name 2" in entities_panel
     assert b"Name 1" not in entities_panel
+    assert b"Resource hash" in response.data
+    assert b"resource-a" in response.data
+    assert b"Endpoints" in response.data
+    assert b"https://example.com/data.csv" in response.data
+    assert b"endpoint-a" in response.data
+    assert b"Errors" in response.data
+    assert b"Entity growth is above threshold, Resource empty" in response.data
     assert b"Retire endpoints" not in response.data
     assert b"retire_endpoints" not in response.data
     assert b"/datamanager/add-data/assign-id-1/entities" in response.data
@@ -475,11 +478,14 @@ def test_resource_link_submits_assign_entities_request(client):
                             "dataset": "tree",
                             "resource": "resource-a",
                             "organisation": "local-authority:ABC",
+                            "errors": "large_number_of_new_entities,current_resource_empty",
                         },
                     )
 
     assert response.status_code == 302
-    assert "/assign-entities/check-results/assign-id-1" in response.headers["Location"]
+    location = response.headers["Location"]
+    assert "/assign-entities/check-results/assign-id-1" in location
+    assert "errors=large_number_of_new_entities,current_resource_empty" in location
     assert len(rsps.calls) == 1
     assert rsps.calls[0].request.url == ASYNC_BASE
     assert rsps.calls[0].request.headers["Content-Type"] == "application/json"

--- a/tests/unit/blueprints/datamanager/controllers/test_add.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_add.py
@@ -33,6 +33,23 @@ class TestAddDataConfirmRoute:
         assert (
             b"triggered" in response.data.lower() or b"success" in response.data.lower()
         )
+        assert b'href="/datamanager/"' in response.data
+        assert b"Add more data" in response.data
+
+    def test_assign_entities_success_links_back_to_assign_entities(self, client):
+        with client.session_transaction() as sess:
+            sess["user"] = {"login": "test-user"}
+        with patch(
+            "application.blueprints.datamanager.controllers.preview.trigger_add_data_async_workflow",
+            return_value={"success": True, "message": "Workflow triggered"},
+        ):
+            response = client.post(
+                "/datamanager/add-data/test-id/confirm-async",
+                data={"source_flow": "assign_entities"},
+            )
+        assert response.status_code == 200
+        assert b'href="/assign-entities/resources"' in response.data
+        assert b"Assign more entities" in response.data
 
     def test_returns_error_when_workflow_raises(self, client):
         with client.session_transaction() as sess:

--- a/tests/unit/blueprints/datamanager/controllers/test_add.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_add.py
@@ -45,10 +45,28 @@ class TestAddDataConfirmRoute:
         ):
             response = client.post(
                 "/datamanager/add-data/test-id/confirm-async",
-                data={"source_flow": "assign_entities"},
+                data={
+                    "source_flow": "assign_entities",
+                    "return_url": "/assign-entities/resources",
+                },
             )
         assert response.status_code == 200
         assert b'href="/assign-entities/resources"' in response.data
+        assert b"Assign more entities" in response.data
+
+    def test_assign_entities_success_defaults_back_to_start_page(self, client):
+        with client.session_transaction() as sess:
+            sess["user"] = {"login": "test-user"}
+        with patch(
+            "application.blueprints.datamanager.controllers.preview.trigger_add_data_async_workflow",
+            return_value={"success": True, "message": "Workflow triggered"},
+        ):
+            response = client.post(
+                "/datamanager/add-data/test-id/confirm-async",
+                data={"source_flow": "assign_entities"},
+            )
+        assert response.status_code == 200
+        assert b'href="/assign-entities/"' in response.data
         assert b"Assign more entities" in response.data
 
     def test_returns_error_when_workflow_raises(self, client):


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds the Assign entities flow for reviewing simple assign CSV output and checking flagged resources.

This includes:
- New `/asign-entities` flow from the homepage Assign entities tile
- CSV paste/upload support for simple assign output
- Grouped flagged resources summary page
- Error abbreviation mapping and legend for flagged resources
- Colour/status handling for entity growth and other error combinations
- Dataset/resource direct entry path that skips the CSV summary page
- Shared Add Data transform/check-results page reused for page 3
- Shared Add Data process lock applied to Assign entities
- Homepage lock/unlock controls for Assign entities
- Route update so async result pages use `/asign-entities/check-results/<id>`

## Related Tickets & Documents

- Ticket Link
- Related Issue #2517
- Closes #

## QA Instructions, Screenshots, Recordings

To test locally:

1. Open the homepage and confirm the Assign entities card is shown.
2. Confirm Add Data and Assign entities share the same lock state:
   - locking from either card should lock both
   - unlocking from either card should unlock both
3. Open Assign entities.
4. Test CSV import by pasting or uploading a CSV with columns:

   `dataset,resource,organisation,reference,status,entities_created,error_code,message`

5. Confirm the summary page:
   - groups rows by resource, dataset, and organisation
   - only shows resources with `status=error`
   - shows raw dataset and organisation values
   - shows row numbers
   - maps CSV error codes to abbreviations
   - shows the colour legend above the error key
   - sorts entity-growth-only rows first
6. Select a resource and confirm it submits the async request and redirects to `/asign-entities/check-results/<request_id>`.
7. Confirm page 3 reuses the Add Data transform/check-results view and continues to preview correctly.

Tested via acceptance tests.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why:
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

No post-deployment tasks identified.

## [optional] Are there any dependencies on other PRs or Work?

The async API needs to support the Assign entities request payload and return compatible Add Data/check-results response data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added an “Assign Entities” workflow for flagged resources with CSV upload/paste parsing, grouped review, and async check-results (including new summary, import, and resource-details pages).
  - Enhanced transform/check UI with configurable endpoints, entity search, and improved pagination/empty states.
  - Updated process locking UI to support “assign-entities” alongside “add-data”.
- **Refactor**
  - Centralised login and process-lock gating and introduced a generic process-lock toggle.
- **Bug Fixes**
  - Reject `status=error` rows missing a valid `error_code`; return clearer 413 error pages for oversized CSV input.
- **Tests**
  - Added end-to-end acceptance and unit coverage for the full workflow.
- **Chores**
  - Added the `pandas` dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->