### PR TITLE
feat: implement GitHub admin team membership check and update related…

### DIFF
--- a/application/blueprints/auth/views.py
+++ b/application/blueprints/auth/views.py
@@ -22,8 +22,12 @@ def _admin_team_slugs():
 
 def _is_member_of_admin_team(username, headers):
     org = current_app.config.get("GITHUB_ORG", "digital-land")
+    github_api_base_url = current_app.config["GITHUB_API_BASE_URL"]
     for team_slug in _admin_team_slugs():
-        url = f"https://api.github.com/orgs/{org}/teams/{team_slug}/memberships/{username}"
+        url = (
+            f"{github_api_base_url}/orgs/{org}/teams/{team_slug}"
+            f"/memberships/{username}"
+        )
         try:
             resp = requests.get(url, headers=headers, timeout=10)
         except requests.RequestException as e:
@@ -72,9 +76,8 @@ def authorize():
         # check if user is a member of digitial-land org - if they are the members endpoint
         # will return status code 204
         # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-        url = (
-            f"https://api.github.com/orgs/digital-land/members/{user_profile['login']}"
-        )
+        github_api_base_url = current_app.config["GITHUB_API_BASE_URL"]
+        url = f"{github_api_base_url}/orgs/digital-land/members/{user_profile['login']}"
         resp = requests.get(url, headers=headers)
         if resp.status_code == HTTPStatus.NO_CONTENT:
             user_profile["is_admin"] = _is_member_of_admin_team(
@@ -89,7 +92,7 @@ def authorize():
             params = {"access_token": token["access_token"]}
             headers = {"X-GitHub-Api-Version": "2022-11-28"}
             resp = requests.delete(
-                f"https://api.github.com/applications/{client_id}/grant",
+                f"{github_api_base_url}/applications/{client_id}/grant",
                 headers=headers,
                 params=params,
                 auth=(client_id, client_secret),

--- a/application/blueprints/auth/views.py
+++ b/application/blueprints/auth/views.py
@@ -73,12 +73,13 @@ def authorize():
             "Authorization": f"Bearer {token['access_token']}",
             "X-GitHub-Api-Version": "2022-11-28",
         }
-        # check if user is a member of digitial-land org - if they are the members endpoint
+        org = current_app.config.get("GITHUB_ORG", "digital-land")
+        # check if user is a member of the configured GitHub org - if they are the members endpoint
         # will return status code 204
         # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
         github_api_base_url = current_app.config["GITHUB_API_BASE_URL"]
-        url = f"{github_api_base_url}/orgs/digital-land/members/{user_profile['login']}"
-        resp = requests.get(url, headers=headers)
+        url = f"{github_api_base_url}/orgs/{org}/members/{user_profile['login']}"
+        resp = requests.get(url, headers=headers, timeout=10)
         if resp.status_code == HTTPStatus.NO_CONTENT:
             user_profile["is_admin"] = _is_member_of_admin_team(
                 user_profile["login"], headers
@@ -96,6 +97,7 @@ def authorize():
                 headers=headers,
                 params=params,
                 auth=(client_id, client_secret),
+                timeout=10,
             )
             flash(
                 "You must be a member of the digital-land organisation to be logged in"

--- a/application/blueprints/auth/views.py
+++ b/application/blueprints/auth/views.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+import logging
 
 import requests
 from flask import Blueprint, current_app, flash, redirect, request, session, url_for
@@ -7,6 +8,41 @@ from is_safe_url import is_safe_url
 from application.extensions import oauth
 
 auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
+logger = logging.getLogger(__name__)
+
+
+def _admin_team_slugs():
+    configured_slugs = current_app.config.get("GITHUB_ADMIN_TEAM_SLUGS", "manage-service-admins")
+    return [
+        slug.strip() for slug in configured_slugs.split(",") if slug and slug.strip()
+    ]
+
+
+def _is_member_of_admin_team(username, headers):
+    org = current_app.config.get("GITHUB_ORG", "digital-land")
+    for team_slug in _admin_team_slugs():
+        url = f"https://api.github.com/orgs/{org}/teams/{team_slug}/memberships/{username}"
+        try:
+            resp = requests.get(url, headers=headers, timeout=10)
+        except requests.RequestException as e:
+            logger.warning(
+                "Could not check GitHub team membership for %s/%s: %s",
+                org,
+                team_slug,
+                e,
+            )
+            continue
+
+        if resp.status_code == HTTPStatus.OK:
+            return (resp.json() or {}).get("state") == "active"
+        if resp.status_code not in (HTTPStatus.NOT_FOUND, HTTPStatus.FORBIDDEN):
+            logger.warning(
+                "Unexpected GitHub team membership response for %s/%s: %s",
+                org,
+                team_slug,
+                resp.status_code,
+            )
+    return False
 
 
 @auth_bp.get("/login")
@@ -37,6 +73,9 @@ def authorize():
         )
         resp = requests.get(url, headers=headers)
         if resp.status_code == HTTPStatus.NO_CONTENT:
+            user_profile["is_admin"] = _is_member_of_admin_team(
+                user_profile["login"], headers
+            )
             session["user"] = user_profile
             next_url = _make_next_url_safe(next_url)
             return redirect(next_url)

--- a/application/blueprints/auth/views.py
+++ b/application/blueprints/auth/views.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 def _admin_team_slugs():
-    configured_slugs = current_app.config.get("GITHUB_ADMIN_TEAM_SLUGS", "manage-service-admins")
+    configured_slugs = current_app.config.get(
+        "GITHUB_ADMIN_TEAM_SLUGS", "manage-service-admins"
+    )
     return [
         slug.strip() for slug in configured_slugs.split(",") if slug and slug.strip()
     ]

--- a/application/blueprints/auth/views.py
+++ b/application/blueprints/auth/views.py
@@ -36,7 +36,9 @@ def _is_member_of_admin_team(username, headers):
             continue
 
         if resp.status_code == HTTPStatus.OK:
-            return (resp.json() or {}).get("state") == "active"
+            if (resp.json() or {}).get("state") == "active":
+                return True
+            continue
         if resp.status_code not in (HTTPStatus.NOT_FOUND, HTTPStatus.FORBIDDEN):
             logger.warning(
                 "Unexpected GitHub team membership response for %s/%s: %s",

--- a/application/blueprints/datamanager/controllers/check.py
+++ b/application/blueprints/datamanager/controllers/check.py
@@ -28,7 +28,6 @@ from ..services.organisation import (
 )
 from ..utils import (
     build_check_tables,
-    get_allowed_override_users,
 )
 from ..utils.configure import (
     build_column_mapping_rows,
@@ -217,9 +216,7 @@ def handle_check_results(request_id, result):
 
     can_override = False
     if not allow_add_data:
-        current_user = (session.get("user") or {}).get("login", "")
-        allowed = get_allowed_override_users()
-        can_override = current_user.lower() in allowed
+        can_override = bool((session.get("user") or {}).get("is_admin"))
 
     return render_template(
         "datamanager/check-results.html",

--- a/application/blueprints/datamanager/controllers/form.py
+++ b/application/blueprints/datamanager/controllers/form.py
@@ -26,7 +26,6 @@ from ..services.dataset import (
     get_dataset_name,
     search_datasets,
 )
-from ..utils import get_allowed_override_users
 from ..services.organisation import (
     format_org_options,
     get_provision_orgs_for_dataset,
@@ -39,8 +38,7 @@ logger = logging.getLogger(__name__)
 def _is_admin():
     if not current_app.config.get("AUTHENTICATION_ON", True):
         return True
-    current_user = (session.get("user") or {}).get("login", "")
-    return current_user.lower() in get_allowed_override_users()
+    return bool((session.get("user") or {}).get("is_admin"))
 
 
 def _organisation_display_name(org_code: str, org_values: list) -> str:

--- a/application/blueprints/datamanager/services/github-add.md
+++ b/application/blueprints/datamanager/services/github-add.md
@@ -13,7 +13,7 @@ This workflow adds data to collection and pipeline CSV files by fetching a compl
 
 ## Triggering the Workflow
 
-**Endpoint:** `POST https://api.github.com/repos/digital-land/config/dispatches`
+**Endpoint:** `POST {GITHUB_API_BASE_URL}/repos/digital-land/config/dispatches`
 
 **Required headers:**
 - `Accept: application/vnd.github+json`

--- a/application/blueprints/datamanager/services/github.py
+++ b/application/blueprints/datamanager/services/github.py
@@ -93,7 +93,8 @@ def get_installation_token(jwt_token: str, installation_id: str) -> str:
     Raises:
         GitHubAppAuthError: If token exchange fails
     """
-    url = f"https://api.github.com/app/installations/{installation_id}/access_tokens"
+    github_api_base_url = current_app.config["GITHUB_API_BASE_URL"]
+    url = f"{github_api_base_url}/app/installations/{installation_id}/access_tokens"
     headers = {
         "Accept": "application/vnd.github+json",
         "Authorization": f"Bearer {jwt_token}",
@@ -146,7 +147,8 @@ def trigger_add_data_async_workflow(
         logger.info(f"Triggering async workflow for request_id: {request_id}")
         logger.info(f"Payload: {payload}")
 
-        url = "https://api.github.com/repos/digital-land/config/dispatches"
+        github_api_base_url = current_app.config["GITHUB_API_BASE_URL"]
+        url = f"{github_api_base_url}/repos/digital-land/config/dispatches"
         response = requests.post(
             url, headers=_github_headers(access_token), json=payload, timeout=10
         )

--- a/application/factory.py
+++ b/application/factory.py
@@ -178,7 +178,7 @@ def register_extensions(app):
         access_token_params=None,
         authorize_url="https://github.com/login/oauth/authorize",
         authorize_params=None,
-        api_base_url="https://api.github.com/",
+        api_base_url=f"{app.config['GITHUB_API_BASE_URL']}/",
         client_kwargs={"scope": "user:email read:org"},
     )
 

--- a/config/config.py
+++ b/config/config.py
@@ -22,6 +22,7 @@ class Config:
     GITHUB_APP_PRIVATE_KEY = base64.b64decode(
         os.getenv("GITHUB_APP_PRIVATE_KEY", "")
     ).decode("utf-8")
+    GITHUB_API_BASE_URL = os.getenv("GITHUB_API_BASE_URL", "https://api.github.com")
     GITHUB_ORG = os.getenv("GITHUB_ORG", "digital-land")
     GITHUB_ADMIN_TEAM_SLUGS = os.getenv(
         "GITHUB_ADMIN_TEAM_SLUGS", "manage-service-admins"

--- a/config/config.py
+++ b/config/config.py
@@ -22,6 +22,10 @@ class Config:
     GITHUB_APP_PRIVATE_KEY = base64.b64decode(
         os.getenv("GITHUB_APP_PRIVATE_KEY", "")
     ).decode("utf-8")
+    GITHUB_ORG = os.getenv("GITHUB_ORG", "digital-land")
+    GITHUB_ADMIN_TEAM_SLUGS = os.getenv(
+        "GITHUB_ADMIN_TEAM_SLUGS", "manage-service-admins"
+    )
     SAFE_URLS = set(os.getenv("SAFE_URLS", "").split(","))
     AUTHENTICATION_ON = True
     S3_BUCKET_URL = (

--- a/tests/unit/blueprints/auth/test_views.py
+++ b/tests/unit/blueprints/auth/test_views.py
@@ -7,6 +7,7 @@ from application.blueprints.auth.views import _is_member_of_admin_team
 def test_is_member_of_admin_team_returns_true_for_active_membership(app):
     app.config["GITHUB_ORG"] = "digital-land"
     app.config["GITHUB_ADMIN_TEAM_SLUGS"] = "manage-service-admins"
+    app.config["GITHUB_API_BASE_URL"] = "https://api.github.com"
     response = Mock(status_code=HTTPStatus.OK)
     response.json.return_value = {"state": "active"}
 
@@ -17,7 +18,7 @@ def test_is_member_of_admin_team_returns_true_for_active_membership(app):
 
     assert is_admin is True
     get.assert_called_once_with(
-        "https://api.github.com/orgs/digital-land/teams/manage-service-admins/memberships/gibahjoe",
+        f"{app.config['GITHUB_API_BASE_URL']}/orgs/digital-land/teams/manage-service-admins/memberships/gibahjoe",
         headers={"Authorization": "Bearer t"},
         timeout=10,
     )
@@ -26,6 +27,7 @@ def test_is_member_of_admin_team_returns_true_for_active_membership(app):
 def test_is_member_of_admin_team_returns_false_when_not_a_member(app):
     app.config["GITHUB_ORG"] = "digital-land"
     app.config["GITHUB_ADMIN_TEAM_SLUGS"] = "manage-service-admins"
+    app.config["GITHUB_API_BASE_URL"] = "https://api.github.com"
     response = Mock(status_code=HTTPStatus.NOT_FOUND)
 
     with app.app_context(), patch(
@@ -39,6 +41,7 @@ def test_is_member_of_admin_team_returns_false_when_not_a_member(app):
 def test_is_member_of_admin_team_checks_later_team_after_pending_membership(app):
     app.config["GITHUB_ORG"] = "digital-land"
     app.config["GITHUB_ADMIN_TEAM_SLUGS"] = "team-one,team-two"
+    app.config["GITHUB_API_BASE_URL"] = "https://api.github.com"
     pending_response = Mock(status_code=HTTPStatus.OK)
     pending_response.json.return_value = {"state": "pending"}
     active_response = Mock(status_code=HTTPStatus.OK)
@@ -53,8 +56,8 @@ def test_is_member_of_admin_team_checks_later_team_after_pending_membership(app)
     assert is_admin is True
     assert get.call_count == 2
     assert get.call_args_list[0].args[0] == (
-        "https://api.github.com/orgs/digital-land/teams/team-one/memberships/gibahjoe"
+        f"{app.config['GITHUB_API_BASE_URL']}/orgs/digital-land/teams/team-one/memberships/gibahjoe"
     )
     assert get.call_args_list[1].args[0] == (
-        "https://api.github.com/orgs/digital-land/teams/team-two/memberships/gibahjoe"
+        f"{app.config['GITHUB_API_BASE_URL']}/orgs/digital-land/teams/team-two/memberships/gibahjoe"
     )

--- a/tests/unit/blueprints/auth/test_views.py
+++ b/tests/unit/blueprints/auth/test_views.py
@@ -34,3 +34,27 @@ def test_is_member_of_admin_team_returns_false_when_not_a_member(app):
         is_admin = _is_member_of_admin_team("someone", {})
 
     assert is_admin is False
+
+
+def test_is_member_of_admin_team_checks_later_team_after_pending_membership(app):
+    app.config["GITHUB_ORG"] = "digital-land"
+    app.config["GITHUB_ADMIN_TEAM_SLUGS"] = "team-one,team-two"
+    pending_response = Mock(status_code=HTTPStatus.OK)
+    pending_response.json.return_value = {"state": "pending"}
+    active_response = Mock(status_code=HTTPStatus.OK)
+    active_response.json.return_value = {"state": "active"}
+
+    with app.app_context(), patch(
+        "application.blueprints.auth.views.requests.get",
+        side_effect=[pending_response, active_response],
+    ) as get:
+        is_admin = _is_member_of_admin_team("gibahjoe", {"Authorization": "Bearer t"})
+
+    assert is_admin is True
+    assert get.call_count == 2
+    assert get.call_args_list[0].args[0] == (
+        "https://api.github.com/orgs/digital-land/teams/team-one/memberships/gibahjoe"
+    )
+    assert get.call_args_list[1].args[0] == (
+        "https://api.github.com/orgs/digital-land/teams/team-two/memberships/gibahjoe"
+    )

--- a/tests/unit/blueprints/auth/test_views.py
+++ b/tests/unit/blueprints/auth/test_views.py
@@ -61,3 +61,74 @@ def test_is_member_of_admin_team_checks_later_team_after_pending_membership(app)
     assert get.call_args_list[1].args[0] == (
         f"{app.config['GITHUB_API_BASE_URL']}/orgs/digital-land/teams/team-two/memberships/gibahjoe"
     )
+
+
+def test_authorize_checks_configured_org_membership_with_timeout(client, app):
+    app.config["GITHUB_ORG"] = "custom-org"
+    app.config["GITHUB_API_BASE_URL"] = "https://api.github.com"
+    token = {"access_token": "token"}
+    user_response = Mock()
+    user_response.json.return_value = {"login": "gibahjoe"}
+    membership_response = Mock(status_code=HTTPStatus.NO_CONTENT)
+
+    with patch(
+        "application.blueprints.auth.views.oauth.github.authorize_access_token",
+        return_value=token,
+    ), patch(
+        "application.blueprints.auth.views.oauth.github.get",
+        return_value=user_response,
+    ), patch(
+        "application.blueprints.auth.views.requests.get",
+        return_value=membership_response,
+    ) as get, patch(
+        "application.blueprints.auth.views._is_member_of_admin_team",
+        return_value=False,
+    ):
+        response = client.get("/auth/authorize")
+
+    assert response.status_code == 302
+    get.assert_called_once_with(
+        f"{app.config['GITHUB_API_BASE_URL']}/orgs/custom-org/members/gibahjoe",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": "Bearer token",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        timeout=10,
+    )
+
+
+def test_authorize_revokes_grant_with_timeout_when_not_org_member(client, app):
+    app.config["GITHUB_ORG"] = "custom-org"
+    app.config["GITHUB_API_BASE_URL"] = "https://api.github.com"
+    app.config["GITHUB_CLIENT_ID"] = "client-id"
+    app.config["GITHUB_CLIENT_SECRET"] = "client-secret"
+    token = {"access_token": "token"}
+    user_response = Mock()
+    user_response.json.return_value = {"login": "gibahjoe"}
+    membership_response = Mock(status_code=HTTPStatus.NOT_FOUND)
+    revoke_response = Mock()
+
+    with patch(
+        "application.blueprints.auth.views.oauth.github.authorize_access_token",
+        return_value=token,
+    ), patch(
+        "application.blueprints.auth.views.oauth.github.get",
+        return_value=user_response,
+    ), patch(
+        "application.blueprints.auth.views.requests.get",
+        return_value=membership_response,
+    ), patch(
+        "application.blueprints.auth.views.requests.delete",
+        return_value=revoke_response,
+    ) as delete:
+        response = client.get("/auth/authorize")
+
+    assert response.status_code == 302
+    delete.assert_called_once_with(
+        f"{app.config['GITHUB_API_BASE_URL']}/applications/client-id/grant",
+        headers={"X-GitHub-Api-Version": "2022-11-28"},
+        params={"access_token": "token"},
+        auth=("client-id", "client-secret"),
+        timeout=10,
+    )

--- a/tests/unit/blueprints/auth/test_views.py
+++ b/tests/unit/blueprints/auth/test_views.py
@@ -1,0 +1,36 @@
+from http import HTTPStatus
+from unittest.mock import Mock, patch
+
+from application.blueprints.auth.views import _is_member_of_admin_team
+
+
+def test_is_member_of_admin_team_returns_true_for_active_membership(app):
+    app.config["GITHUB_ORG"] = "digital-land"
+    app.config["GITHUB_ADMIN_TEAM_SLUGS"] = "manage-service-admins"
+    response = Mock(status_code=HTTPStatus.OK)
+    response.json.return_value = {"state": "active"}
+
+    with app.app_context(), patch(
+        "application.blueprints.auth.views.requests.get", return_value=response
+    ) as get:
+        is_admin = _is_member_of_admin_team("gibahjoe", {"Authorization": "Bearer t"})
+
+    assert is_admin is True
+    get.assert_called_once_with(
+        "https://api.github.com/orgs/digital-land/teams/manage-service-admins/memberships/gibahjoe",
+        headers={"Authorization": "Bearer t"},
+        timeout=10,
+    )
+
+
+def test_is_member_of_admin_team_returns_false_when_not_a_member(app):
+    app.config["GITHUB_ORG"] = "digital-land"
+    app.config["GITHUB_ADMIN_TEAM_SLUGS"] = "manage-service-admins"
+    response = Mock(status_code=HTTPStatus.NOT_FOUND)
+
+    with app.app_context(), patch(
+        "application.blueprints.auth.views.requests.get", return_value=response
+    ):
+        is_admin = _is_member_of_admin_team("someone", {})
+
+    assert is_admin is False


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

replaces the markdown-based admin allowlist with GitHub team membership checks using the `manage-service-admins` team.

## Related Tickets & Documents

- Related Issue #2684

## QA Instructions, Screenshots, Recordings

Tested locally with unit and acceptance coverage for the updated flows.


Manual QA:
- Log in with a user in the `manage-service-admins` GitHub team and confirm admin-only controls are visible.
- Log in with a non-team user and confirm admin-only controls are hidden.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why:
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

Ensure the `manage-service-admins` team exists in the `digital-land` GitHub organisation and contains the users who should have admin/override permissions.

## [optional] Are there any dependencies on other PRs or Work?

Requires GitHub OAuth `read:org` access to be available so team membership can be checked at login.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin access now reflects GitHub team membership, using configurable organisation and admin team settings.
* **Bug Fixes**
  * Admin-only actions now consistently rely on the signed-in user’s admin status, with a safe fallback to non-admin access if checks fail.
* **Configuration**
  * GitHub API base URL and organisation/team settings are now configurable.
* **Documentation**
  * Workflow dispatch instructions updated to use the configured API base URL.
* **Tests**
  * Added unit tests covering admin-team membership checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->