### PR TITLE
feat: Implement duplicate entity redirection handling in Assign Entit…

### DIFF
--- a/application/blueprints/datamanager/controllers/preview.py
+++ b/application/blueprints/datamanager/controllers/preview.py
@@ -29,6 +29,16 @@ from ..utils.csv_formats import (
 logger = logging.getLogger(__name__)
 
 
+def _load_json_list(value: str | None) -> list:
+    if not value:
+        return []
+    try:
+        loaded = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return []
+    return loaded if isinstance(loaded, list) else []
+
+
 def build_old_entity_redirect_table(entity_redirects: list[dict]) -> dict | None:
     if not entity_redirects:
         return None
@@ -152,10 +162,10 @@ def handle_entities_preview(request_id, req):
     # Retire endpoint details
     request_meta = db.session.get(RequestMeta, request_id)
     endpoints_to_retire = (
-        json.loads(request_meta.endpoints_to_retire or "[]") if request_meta else []
+        _load_json_list(request_meta.endpoints_to_retire) if request_meta else []
     )
     entity_redirects = (
-        json.loads(request_meta.entity_redirects or "[]") if request_meta else []
+        _load_json_list(request_meta.entity_redirects) if request_meta else []
     )
     old_entity_redirect_table_params = build_old_entity_redirect_table(entity_redirects)
     existing_endpoints = (
@@ -233,10 +243,10 @@ def handle_add_data_confirm(
 ):
     request_meta = db.session.get(RequestMeta, request_id)
     endpoints_to_retire = (
-        json.loads(request_meta.endpoints_to_retire or "[]") if request_meta else []
+        _load_json_list(request_meta.endpoints_to_retire) if request_meta else []
     )
     entity_redirects = (
-        json.loads(request_meta.entity_redirects or "[]") if request_meta else []
+        _load_json_list(request_meta.entity_redirects) if request_meta else []
     )
     try:
         result = trigger_add_data_async_workflow(

--- a/application/blueprints/datamanager/controllers/preview.py
+++ b/application/blueprints/datamanager/controllers/preview.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import date
 
 from flask import (
     render_template,
@@ -26,6 +27,44 @@ from ..utils.csv_formats import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def build_old_entity_redirect_table(entity_redirects: list[dict]) -> dict | None:
+    if not entity_redirects:
+        return None
+
+    columns = [
+        "old-entity",
+        "status",
+        "entity",
+        "notes",
+        "end-date",
+        "entry-date",
+        "start-date",
+    ]
+    entry_date = date.today().isoformat()
+    rows = []
+    for redirect in entity_redirects:
+        row = {
+            "old-entity": str(redirect.get("old_entity", "")),
+            "status": "301",
+            "entity": str(redirect.get("entity", "")),
+            "notes": str(
+                redirect.get("notes")
+                or "Redirect duplicate entity selected in Assign Entities"
+            ),
+            "end-date": "",
+            "entry-date": entry_date,
+            "start-date": "",
+        }
+        rows.append({"columns": {c: {"value": row[c]} for c in columns}})
+
+    return {
+        "columns": columns,
+        "fields": columns,
+        "rows": rows,
+        "columnNameProcessing": "none",
+    }
 
 
 def handle_entities_preview(request_id, req):
@@ -115,6 +154,10 @@ def handle_entities_preview(request_id, req):
     endpoints_to_retire = (
         json.loads(request_meta.endpoints_to_retire or "[]") if request_meta else []
     )
+    entity_redirects = (
+        json.loads(request_meta.entity_redirects or "[]") if request_meta else []
+    )
+    old_entity_redirect_table_params = build_old_entity_redirect_table(entity_redirects)
     existing_endpoints = (
         source_summary_data.get("existing_endpoint_for_organisation_dataset") or []
     )
@@ -163,6 +206,8 @@ def handle_entities_preview(request_id, req):
         source_flow=source_flow,
         return_url=return_url,
         retire_summary=retire_summary,
+        entity_redirects=entity_redirects,
+        old_entity_redirect_table_params=old_entity_redirect_table_params,
         new_count=int(pipeline_summary.get("new-in-resource") or 0),
         existing_count=int(pipeline_summary.get("existing-in-resource") or 0),
         endpoint_already_exists=endpoint_already_exists,
@@ -190,12 +235,16 @@ def handle_add_data_confirm(
     endpoints_to_retire = (
         json.loads(request_meta.endpoints_to_retire or "[]") if request_meta else []
     )
+    entity_redirects = (
+        json.loads(request_meta.entity_redirects or "[]") if request_meta else []
+    )
     try:
         result = trigger_add_data_async_workflow(
             request_id=request_id,
             triggered_by=f"{session.get('user', {}).get('login', 'unknown')}",
             github_branch=github_branch,
             endpoints_to_retire=endpoints_to_retire,
+            entity_redirects=entity_redirects,
         )
     except GitHubWorkflowError as e:
         logger.exception(f"GitHub async workflow error: {e}")

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -11,7 +11,6 @@ from . import ControllerError
 from ..config import get_entity_geojson_url, get_entity_search_url
 from ..services.async_api import fetch_response_details
 from ..services.dataset import get_dataset_name, get_dataset_typology
-from ..services.duplicates import REDIRECT_NOTE
 from ..services.organisation import get_org_entity, get_organisation_name
 from ..services.doc_crawler import check_endpoint_in_doc, is_gov_uk_url
 from ..services.endpoint import get_endpoint_urls_for_hashes
@@ -267,7 +266,8 @@ def _dedup_candidate_form_value(candidate: dict) -> str:
             "old_reference": candidate.get("old_reference", ""),
             "new_reference": candidate.get("new_reference", ""),
             "match_type": candidate.get("match_type", ""),
-            "notes": candidate.get("notes") or REDIRECT_NOTE,
+            "notes": candidate.get("notes")
+            or "Redirect duplicate entity selected in Assign Entities",
         },
         separators=(",", ":"),
     )

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -1,8 +1,9 @@
+import json
 import logging
 import re
 
 import requests
-from flask import render_template, request as flask_request
+from flask import current_app, render_template, request as flask_request
 from shapely import wkt
 from shapely.geometry import mapping
 
@@ -10,6 +11,7 @@ from . import ControllerError
 from ..config import get_entity_geojson_url, get_entity_search_url
 from ..services.async_api import fetch_response_details
 from ..services.dataset import get_dataset_name, get_dataset_typology
+from ..services.duplicates import REDIRECT_NOTE
 from ..services.organisation import get_org_entity, get_organisation_name
 from ..services.doc_crawler import check_endpoint_in_doc, is_gov_uk_url
 from ..services.endpoint import get_endpoint_urls_for_hashes
@@ -232,6 +234,54 @@ def _entity_row_matches_filter(row: dict, category_filter: str) -> bool:
     if not category_filter:
         return True
     return row.get("category") == category_filter
+
+
+def _name_similarity_percent(value) -> float:
+    if value in (None, ""):
+        return 0
+    try:
+        similarity = float(str(value).strip().rstrip("%"))
+    except (TypeError, ValueError):
+        return 0
+    return similarity * 100 if 0 < similarity <= 1 else similarity
+
+
+def _dedup_candidate_auto_select(candidate: dict) -> bool:
+    match_type = str(candidate.get("match_type", "")).replace(" ", "_").lower()
+    if match_type == "complete_match":
+        return True
+    if match_type != "single_match":
+        return False
+    return _name_similarity_percent(candidate.get("name_similarity")) > 85
+
+
+def _dedup_candidate_form_value(candidate: dict) -> str:
+    if candidate.get("form_value"):
+        return str(candidate.get("form_value"))
+
+    return json.dumps(
+        {
+            "old_entity": candidate.get("old_entity", ""),
+            "entity": candidate.get("entity", ""),
+            "dataset": candidate.get("dataset", ""),
+            "old_reference": candidate.get("old_reference", ""),
+            "new_reference": candidate.get("new_reference", ""),
+            "match_type": candidate.get("match_type", ""),
+            "notes": candidate.get("notes") or REDIRECT_NOTE,
+        },
+        separators=(",", ":"),
+    )
+
+
+def _prepare_duplicate_candidates(candidates: list[dict]) -> list[dict]:
+    return [
+        {
+            **candidate,
+            "auto_select": _dedup_candidate_auto_select(candidate),
+            "form_value": _dedup_candidate_form_value(candidate),
+        }
+        for candidate in candidates
+    ]
 
 
 def _count_categories(rows: list) -> dict:
@@ -566,6 +616,7 @@ def handle_check_transform(
     params = req.get("params") or {}
     organisation_code = params.get("organisationName") or params.get("organisation", "")
     dataset_id = params.get("dataset", "")
+    is_assign_entities = transform_endpoint == "assign_entities.flagged_resource_detail"
     resource_hash = params.get("resource", "")
     organisation_display = get_organisation_name(organisation_code)
     dataset_display = get_dataset_name(dataset_id, default=dataset_id)
@@ -607,6 +658,11 @@ def handle_check_transform(
     source_summary = response_data.get("source-summary") or {}
     existing_endpoints = _resolve_existing_endpoints(source_summary)
     pipelines_append_required = source_summary.get("pipelines_append_required")
+    pipeline_summary = response_data.get("pipeline-summary") or {}
+    show_dedup_tab = is_assign_entities and dataset_id == "conservation-area"
+    duplicate_candidates = _prepare_duplicate_candidates(
+        pipeline_summary.get("duplicate-candidates") or [] if show_dedup_tab else []
+    )
 
     # Calculate pagination for transformed facts and issue logs, and for entities.
     page_number = max(1, int(flask_request.args.get("page_number", 1)))
@@ -687,6 +743,14 @@ def handle_check_transform(
         endpoint_url=endpoint_url,
         documentation_url=documentation_url,
         resource_hash=resource_hash,
+        show_dedup_tab=show_dedup_tab,
+        duplicate_candidates=duplicate_candidates,
+        planning_entity_base_url=(
+            current_app.config.get(
+                "PLANNING_BASE_URL", "https://www.planning.data.gov.uk"
+            ).rstrip("/")
+            + "/entity"
+        ),
         geometries=geometries,
         geometry_points=geometry_points,
         boundary_geojson=boundary_geojson,

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -246,6 +246,9 @@ def _name_similarity_percent(value) -> float:
 
 
 def _dedup_candidate_auto_select(candidate: dict) -> bool:
+    if candidate.get("old_entity_redirects"):
+        return False
+
     match_type = str(candidate.get("match_type", "")).replace(" ", "_").lower()
     if match_type == "complete_match":
         return True

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -41,6 +41,7 @@ from .controllers.preview import (
     handle_add_data_confirm,
 )
 from .controllers.transform import handle_check_transform
+from .services.duplicates import parse_selected_redirects
 from .services.async_api import (
     AsyncAPIError,
     fetch_request,
@@ -310,6 +311,21 @@ def flagged_resource_detail(request_id):
         return render_template("datamanager/error.html", message=e.message)
 
 
+def flagged_resource_detail_post(request_id):
+    redirects = parse_selected_redirects(request.form.getlist("entity_redirects"))
+    meta = db.session.get(RequestMeta, request_id)
+    if meta is None:
+        meta = RequestMeta(
+            request_id=request_id,
+            entity_redirects=json.dumps(redirects),
+        )
+        db.session.add(meta)
+    else:
+        meta.entity_redirects = json.dumps(redirects)
+    db.session.commit()
+    return redirect(url_for("datamanager.entities_preview", request_id=request_id))
+
+
 datamanager_bp.add_url_rule("/", view_func=dashboard_get, methods=["GET"])
 datamanager_bp.add_url_rule("/", view_func=dashboard_add, methods=["POST"])
 datamanager_bp.add_url_rule(
@@ -365,4 +381,9 @@ assign_entities_bp.add_url_rule(
     "/check-results/<request_id>",
     view_func=flagged_resource_detail,
     methods=["GET"],
+)
+assign_entities_bp.add_url_rule(
+    "/check-results/<request_id>",
+    view_func=flagged_resource_detail_post,
+    methods=["POST"],
 )

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -312,7 +312,13 @@ def flagged_resource_detail(request_id):
 
 
 def flagged_resource_detail_post(request_id):
-    redirects = parse_selected_redirects(request.form.getlist("entity_redirects"))
+    req = fetch_request(request_id)
+    response_data = (req.get("response") or {}).get("data") or {}
+    pipeline_summary = response_data.get("pipeline-summary") or {}
+    duplicate_candidates = pipeline_summary.get("duplicate-candidates") or []
+    redirects = parse_selected_redirects(
+        request.form.getlist("entity_redirects"), duplicate_candidates
+    )
     meta = db.session.get(RequestMeta, request_id)
     if meta is None:
         meta = RequestMeta(

--- a/application/blueprints/datamanager/services/duplicates.py
+++ b/application/blueprints/datamanager/services/duplicates.py
@@ -1,19 +1,47 @@
 import json
+import re
 
 REDIRECT_NOTE = "Redirect duplicate entity selected in Assign Entities"
+_WHOLE_NUMBER_RE = re.compile(r"^\s*[+-]?\d+(?:\.0+)?\s*$")
 
 
 def _normalise_entity_id(raw) -> str:
     if raw is None or raw == "":
         return ""
-    try:
-        return str(int(float(str(raw))))
-    except (ValueError, TypeError):
+    if isinstance(raw, int):
         return str(raw)
+    if isinstance(raw, float):
+        return str(int(raw)) if raw.is_integer() else str(raw)
+
+    raw_str = str(raw)
+    if not _WHOLE_NUMBER_RE.match(raw_str):
+        return raw_str
+
+    try:
+        return str(int(float(raw_str)))
+    except (ValueError, TypeError):
+        return raw_str
 
 
-def parse_selected_redirects(values: list[str]) -> list[dict]:
+def _candidate_key(candidate: dict) -> tuple[str, str, str]:
+    return (
+        _normalise_entity_id(candidate.get("old_entity", "")),
+        _normalise_entity_id(candidate.get("entity", "")),
+        str(candidate.get("dataset", "") or ""),
+    )
+
+
+def parse_selected_redirects(
+    values: list[str], duplicate_candidates: list[dict] | None = None
+) -> list[dict]:
     selected = []
+    valid_keys = (
+        {_candidate_key(candidate) for candidate in duplicate_candidates}
+        if duplicate_candidates is not None
+        else None
+    )
+    seen_old_entities = set()
+
     for value in values:
         try:
             row = json.loads(value)
@@ -27,6 +55,11 @@ def parse_selected_redirects(values: list[str]) -> list[dict]:
         dataset = str(row.get("dataset", "") or "")
         if not old_entity or not entity or not dataset:
             continue
+        if valid_keys is not None and (old_entity, entity, dataset) not in valid_keys:
+            continue
+        if old_entity in seen_old_entities:
+            continue
+        seen_old_entities.add(old_entity)
 
         selected.append(
             {

--- a/application/blueprints/datamanager/services/duplicates.py
+++ b/application/blueprints/datamanager/services/duplicates.py
@@ -1,9 +1,6 @@
 import json
 import re
 
-REDIRECT_NOTE = "Redirect duplicate entity selected in Assign Entities"
-_WHOLE_NUMBER_RE = re.compile(r"^\s*[+-]?\d+(?:\.0+)?\s*$")
-
 
 def _normalise_entity_id(raw) -> str:
     if raw is None or raw == "":
@@ -14,7 +11,7 @@ def _normalise_entity_id(raw) -> str:
         return str(int(raw)) if raw.is_integer() else str(raw)
 
     raw_str = str(raw)
-    if not _WHOLE_NUMBER_RE.match(raw_str):
+    if not re.match(r"^\s*[+-]?\d+(?:\.0+)?\s*$", raw_str):
         return raw_str
 
     try:
@@ -69,7 +66,10 @@ def parse_selected_redirects(
                 "old_reference": str(row.get("old_reference", "") or ""),
                 "new_reference": str(row.get("new_reference", "") or ""),
                 "match_type": str(row.get("match_type", "") or ""),
-                "notes": str(row.get("notes", "") or REDIRECT_NOTE),
+                "notes": str(
+                    row.get("notes", "")
+                    or "Redirect duplicate entity selected in Assign Entities"
+                ),
             }
         )
 

--- a/application/blueprints/datamanager/services/duplicates.py
+++ b/application/blueprints/datamanager/services/duplicates.py
@@ -1,0 +1,43 @@
+import json
+
+REDIRECT_NOTE = "Redirect duplicate entity selected in Assign Entities"
+
+
+def _normalise_entity_id(raw) -> str:
+    if raw is None or raw == "":
+        return ""
+    try:
+        return str(int(float(str(raw))))
+    except (ValueError, TypeError):
+        return str(raw)
+
+
+def parse_selected_redirects(values: list[str]) -> list[dict]:
+    selected = []
+    for value in values:
+        try:
+            row = json.loads(value)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(row, dict):
+            continue
+
+        old_entity = _normalise_entity_id(row.get("old_entity", ""))
+        entity = _normalise_entity_id(row.get("entity", ""))
+        dataset = str(row.get("dataset", "") or "")
+        if not old_entity or not entity or not dataset:
+            continue
+
+        selected.append(
+            {
+                "old_entity": old_entity,
+                "entity": entity,
+                "dataset": dataset,
+                "old_reference": str(row.get("old_reference", "") or ""),
+                "new_reference": str(row.get("new_reference", "") or ""),
+                "match_type": str(row.get("match_type", "") or ""),
+                "notes": str(row.get("notes", "") or REDIRECT_NOTE),
+            }
+        )
+
+    return selected

--- a/application/blueprints/datamanager/services/duplicates.py
+++ b/application/blueprints/datamanager/services/duplicates.py
@@ -29,14 +29,10 @@ def _candidate_key(candidate: dict) -> tuple[str, str, str]:
 
 
 def parse_selected_redirects(
-    values: list[str], duplicate_candidates: list[dict] | None = None
+    values: list[str], duplicate_candidates: list[dict]
 ) -> list[dict]:
     selected = []
-    valid_keys = (
-        {_candidate_key(candidate) for candidate in duplicate_candidates}
-        if duplicate_candidates is not None
-        else None
-    )
+    valid_keys = {_candidate_key(candidate) for candidate in duplicate_candidates}
     seen_old_entities = set()
 
     for value in values:
@@ -52,7 +48,7 @@ def parse_selected_redirects(
         dataset = str(row.get("dataset", "") or "")
         if not old_entity or not entity or not dataset:
             continue
-        if valid_keys is not None and (old_entity, entity, dataset) not in valid_keys:
+        if (old_entity, entity, dataset) not in valid_keys:
             continue
         if old_entity in seen_old_entities:
             continue

--- a/application/blueprints/datamanager/services/github.py
+++ b/application/blueprints/datamanager/services/github.py
@@ -2,6 +2,7 @@
 GitHub App service for authenticating and triggering workflows.
 """
 
+import json
 import time
 import logging
 import requests
@@ -121,6 +122,7 @@ def trigger_add_data_async_workflow(
     triggered_by: str = "config-manager",
     github_branch: str = None,
     endpoints_to_retire: list = None,
+    entity_redirects: list = None,
 ) -> dict:
     """
     Trigger the 'add-data-async-script' workflow in the digital-land/config repository.
@@ -139,6 +141,11 @@ def trigger_add_data_async_workflow(
                 "branch": github_branch,
                 "retire_endpoints": (
                     ",".join(endpoints_to_retire or []) if endpoints_to_retire else ""
+                ),
+                "entity_redirects": (
+                    json.dumps(entity_redirects, separators=(",", ":"))
+                    if entity_redirects
+                    else ""
                 ),
                 "environment": current_app.config.get("ENVIRONMENT"),
             },

--- a/application/db/models.py
+++ b/application/db/models.py
@@ -448,6 +448,7 @@ class RequestMeta(db.Model):
     endpoints_to_retire = db.Column(
         db.Text, nullable=True
     )  # JSON list of endpoint hashes
+    entity_redirects = db.Column(db.Text, nullable=True)  # JSON list of old-entity rows
 
 
 class Filter(DateModel, VersionedMixin):

--- a/application/templates/components/check-transform-base.html
+++ b/application/templates/components/check-transform-base.html
@@ -84,6 +84,7 @@
         <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
           <a class="govuk-tabs__tab" href="#entities-table">Entities</a>
         </li>
+        {% block extra_tabs scoped %}{% endblock %}
         <li class="govuk-tabs__list-item">
           <a class="govuk-tabs__tab" href="#transformed-table">Transformed</a>
         </li>
@@ -167,6 +168,8 @@
         {{ govukPagination(entity_pagination_params) }}
         {% endif %}
       </div>
+
+      {% block extra_panels scoped %}{% endblock %}
 
       <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="transformed-table">
         <p class="govuk-hint govuk-!-margin-bottom-4">The individual facts extracted from the submitted data by the pipeline <b>with entity lookup enabled</b>.</p>

--- a/application/templates/datamanager/assign-entities-check-results.html
+++ b/application/templates/datamanager/assign-entities-check-results.html
@@ -46,13 +46,224 @@
     </dl>
 {% endblock %}
 
+{% block extra_tabs %}
+        {% if show_dedup_tab %}
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#duplicates-table">Dedup <strong class="govuk-tag govuk-tag--red govuk-!-margin-left-1">{{ duplicate_candidates | length }}</strong></a>
+        </li>
+        {% endif %}
+{% endblock %}
+
+{% block extra_panels %}
+      {% if show_dedup_tab %}
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="duplicates-table">
+        <p class="govuk-hint govuk-!-margin-bottom-4">Possible spatial duplicates between entities in this resource and existing platform entities for this dataset. <strong style="color: #00703c;">Green</strong> is the new provision entity. <strong style="color: #d4692a;">Orange</strong> is the existing platform entity.</p>
+        <form method="post" action="{{ url_for('assign_entities.flagged_resource_detail_post', request_id=request_id) }}" id="duplicate-redirect-form">
+          {% if duplicate_candidates %}
+          <div class="govuk-!-margin-bottom-2" style="display: flex; align-items: center; gap: 15px; flex-wrap: wrap;">
+            <span class="govuk-body-s govuk-!-margin-bottom-0" style="color: #505a5f;"><strong style="color: #00703c;">&#9679;</strong> Green: new provision entity</span>
+            <span class="govuk-body-s govuk-!-margin-bottom-0" style="color: #505a5f;"><strong style="color: #d4692a;">&#9679;</strong> Orange: existing platform entity</span>
+          </div>
+          <div class="app-scrollable-container app-scrollable">
+            <table class="govuk-table dl-table app-table app-duplicates-table">
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header app-checkbox-header">
+                    <div class="govuk-checkboxes govuk-checkboxes--small app-checkboxes--table-header" data-module="govuk-checkboxes">
+                      <div class="govuk-checkboxes__item">
+                        <input class="govuk-checkboxes__input" id="entity-redirect-select-all" type="checkbox">
+                        <label class="govuk-label govuk-checkboxes__label" for="entity-redirect-select-all">
+                          <span class="govuk-visually-hidden">Select all redirects</span>
+                        </label>
+                      </div>
+                    </div>
+                  </th>
+                  <th scope="col" class="govuk-table__header">New Entity</th>
+                  <th scope="col" class="govuk-table__header">Old entity</th>
+                  <th scope="col" class="govuk-table__header">Reference</th>
+                  <th scope="col" class="govuk-table__header">Name</th>
+                  <th scope="col" class="govuk-table__header">Entry date</th>
+                  <th scope="col" class="govuk-table__header">End date</th>
+                  <th scope="col" class="govuk-table__header">Organisation</th>
+                  <th scope="col" class="govuk-table__header">Evidence</th>
+                </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                {% for row in duplicate_candidates %}
+                <tr class="govuk-table__row duplicate-row">
+                  <td class="govuk-table__cell">
+                    <div class="govuk-checkboxes govuk-checkboxes--small app-checkboxes--table-header" data-module="govuk-checkboxes">
+                      <div class="govuk-checkboxes__item">
+                        {% if row.auto_select %}
+                        <input type="hidden" name="entity_redirects" value="{{ row.form_value | e }}">
+                        {% endif %}
+                        <input class="govuk-checkboxes__input duplicate-checkbox" id="entity-redirect-{{ loop.index }}" name="entity_redirects" type="checkbox" value="{{ row.form_value | e }}" {% if row.auto_select %}checked disabled{% endif %}>
+                        <label class="govuk-label govuk-checkboxes__label" for="entity-redirect-{{ loop.index }}">
+                          <span class="govuk-visually-hidden">Select redirect for entity {{ row.entity }}</span>
+                        </label>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="govuk-table__cell app-wrap">
+                    <div style="color: #00703c;">
+                      {% if _flagged_errors_query %}
+                      <a class="govuk-link" style="color: #00703c;" href="{{ url_for(_transform_endpoint, request_id=request_id, entity_search=row.entity, errors=_flagged_errors_query, _anchor='entities-table') }}"><code>{{ row.entity }}</code></a>
+                      {% else %}
+                      <a class="govuk-link" style="color: #00703c;" href="{{ url_for(_transform_endpoint, request_id=request_id, entity_search=row.entity, _anchor='entities-table') }}"><code>{{ row.entity }}</code></a>
+                      {% endif %}
+                    </div>
+                  </td>
+                  <td class="govuk-table__cell app-wrap">
+                    <div style="color: #d4692a;">
+                      {% if row.old_entity %}
+                      <a class="govuk-link" style="color: #d4692a;" href="{{ planning_entity_base_url }}/{{ row.old_entity }}" target="_blank" rel="noopener noreferrer"><code>{{ row.old_entity }}</code></a>
+                      {% else %}
+                      <code></code>
+                      {% endif %}
+                    </div>
+                  </td>
+                  <td class="govuk-table__cell app-wrap">
+                    <div style="color: #00703c;">{{ row.new_reference or '' }}</div>
+                    <div style="color: #d4692a;">{{ row.old_reference or '' }}</div>
+                  </td>
+                  <td class="govuk-table__cell app-wrap">
+                    <div style="color: #00703c;">{{ row.new_name or '' }}</div>
+                    <div style="color: #d4692a;">{{ row.old_name or '' }}</div>
+                  </td>
+                  <td class="govuk-table__cell app-wrap">
+                    <div style="color: #00703c;">{{ row.get("new_entry_date") or row.get("new_entry-date") or '' }}</div>
+                    <div style="color: #d4692a;">{{ row.get("old_entry_date") or row.get("old_entry-date") or '' }}</div>
+                  </td>
+                  <td class="govuk-table__cell app-wrap">
+                    <div style="color: #00703c;">{{ row.get("new_end_date") or row.get("new_end-date") or '' }}</div>
+                    <div style="color: #d4692a;">{{ row.get("old_end_date") or row.get("old_end-date") or '' }}</div>
+                  </td>
+                  <td class="govuk-table__cell app-wrap">
+                    <div style="color: #00703c;">{{ row.new_organisation or row.new_organisation_entity or '' }}</div>
+                    <div style="color: #d4692a;">{{ row.old_organisation or row.old_organisation_entity or '' }}</div>
+                  </td>
+                  <td class="govuk-table__cell app-wrap">{{ row.evidence or 'Spatial match' }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          <p class="govuk-!-margin-top-2" id="duplicate-selected-count" style="white-space: nowrap;">No entities selected for redirection</p>
+          {% else %}
+          <p class="govuk-body">No possible duplicates to display.</p>
+          {% endif %}
+        </form>
+      </div>
+      {% else %}
+      <form method="post" action="{{ url_for('assign_entities.flagged_resource_detail_post', request_id=request_id) }}" id="duplicate-redirect-form"></form>
+      {% endif %}
+{% endblock %}
+
 {% block action_buttons %}
     <div class="govuk-button-group govuk-!-margin-top-6">
-      <a href="{{ url_for('datamanager.entities_preview', request_id=request_id) }}" class="govuk-button">
+      <button type="submit" form="duplicate-redirect-form" class="govuk-button" data-module="govuk-button">
         Continue to preview
-      </a>
+      </button>
       <a href="{{ url_for('datamanager.dashboard_get') }}" class="govuk-link">
         Cancel
       </a>
     </div>
+{% endblock %}
+
+{% block pageScripts %}{{ super() }}
+<style>
+  .app-duplicates-table .govuk-table__header,
+  .app-duplicates-table .govuk-table__cell {
+    vertical-align: middle;
+  }
+  .app-duplicates-table .app-checkbox-header {
+    padding-bottom: 10px;
+    padding-top: 10px;
+    text-align: center;
+    width: 24px;
+  }
+  .app-duplicates-table .app-checkboxes--table-header {
+    display: inline-block;
+    height: 24px;
+    margin: 0;
+    vertical-align: middle;
+    width: 24px;
+  }
+  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__item {
+    display: block;
+    height: 24px;
+    min-height: 24px;
+    position: relative;
+    width: 24px;
+  }
+  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__input {
+    height: 24px;
+    left: 0;
+    margin: 0;
+    position: absolute;
+    top: 0;
+    width: 24px;
+  }
+  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__label::before {
+    left: 0;
+    top: 0;
+  }
+  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__label::after {
+    left: 6px;
+    top: 7px;
+  }
+  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__label {
+    display: block;
+    height: 24px;
+    min-height: 0;
+    max-width: none;
+    padding: 0;
+    width: 24px;
+  }
+</style>
+<script>
+  var selectedCount = document.getElementById('duplicate-selected-count');
+  var duplicateCheckboxes = document.querySelectorAll('.duplicate-checkbox');
+  var selectAllCheckbox = document.getElementById('entity-redirect-select-all');
+  function updateDuplicateSelection() {
+    var count = 0;
+    var selectableCount = 0;
+    var selectableSelectedCount = 0;
+    duplicateCheckboxes.forEach(function(checkbox) {
+      var row = checkbox.closest('.duplicate-row');
+      if (!checkbox.disabled) {
+        selectableCount += 1;
+        if (checkbox.checked) selectableSelectedCount += 1;
+      }
+      if (checkbox.checked) {
+        count += 1;
+        if (row) row.style.backgroundColor = '#dbeafe';
+      } else if (row) {
+        row.style.backgroundColor = '';
+      }
+    });
+    if (selectAllCheckbox) {
+      selectAllCheckbox.disabled = selectableCount === 0;
+      selectAllCheckbox.checked = selectableCount > 0 && selectableSelectedCount === selectableCount;
+      selectAllCheckbox.indeterminate = selectableSelectedCount > 0 && selectableSelectedCount < selectableCount;
+    }
+    if (selectedCount) {
+      selectedCount.textContent = count === 0
+        ? 'No entities selected for redirection'
+        : count + ' ' + (count === 1 ? 'entity' : 'entities') + ' selected for redirection';
+    }
+  }
+  duplicateCheckboxes.forEach(function(checkbox) {
+    checkbox.addEventListener('change', updateDuplicateSelection);
+  });
+  if (selectAllCheckbox) {
+    selectAllCheckbox.addEventListener('change', function() {
+      duplicateCheckboxes.forEach(function(checkbox) {
+        if (!checkbox.disabled) checkbox.checked = selectAllCheckbox.checked;
+      });
+      updateDuplicateSelection();
+    });
+  }
+  updateDuplicateSelection();
+</script>
 {% endblock %}

--- a/application/templates/datamanager/assign-entities-check-results.html
+++ b/application/templates/datamanager/assign-entities-check-results.html
@@ -46,11 +46,6 @@
     </dl>
 {% endblock %}
 
-{% block pageStylesheets %}
-{{ super() }}
-<link rel="stylesheet" href="{{ url_for('static', filename='stylesheets/entity-redirect-selection.css') }}">
-{% endblock %}
-
 {% block extra_tabs %}
         {% if show_dedup_tab %}
         <li class="govuk-tabs__list-item">
@@ -153,7 +148,14 @@
               </tbody>
             </table>
           </div>
-          <p class="govuk-!-margin-top-2" id="duplicate-selected-count" style="white-space: nowrap;">No entities selected for redirection</p>
+          {% set selected_count = duplicate_candidates | selectattr('auto_select') | list | length %}
+          <p class="govuk-!-margin-top-2" id="duplicate-selected-count" style="white-space: nowrap;">
+            {% if selected_count %}
+            {{ selected_count }} {{ 'entity' if selected_count == 1 else 'entities' }} selected for redirection
+            {% else %}
+            No entities selected for redirection
+            {% endif %}
+          </p>
           {% else %}
           <p class="govuk-body">No possible duplicates to display.</p>
           {% endif %}
@@ -176,5 +178,99 @@
 {% endblock %}
 
 {% block pageScripts %}{{ super() }}
-<script src="{{ url_for('static', filename='javascripts/entity-redirect-selection.js') }}"></script>
+<style {% if config["ENV"]=="production" %}nonce="{{ csp_nonce() }}" {% endif %}>
+  .app-duplicates-table .govuk-table__header,
+  .app-duplicates-table .govuk-table__cell {
+    vertical-align: middle;
+  }
+  .app-duplicates-table .app-checkbox-header {
+    padding-bottom: 10px;
+    padding-top: 10px;
+    text-align: center;
+    width: 24px;
+  }
+  .app-duplicates-table .app-checkboxes--table-header {
+    display: inline-block;
+    height: 24px;
+    margin: 0;
+    vertical-align: middle;
+    width: 24px;
+  }
+  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__item {
+    display: block;
+    height: 24px;
+    min-height: 24px;
+    position: relative;
+    width: 24px;
+  }
+  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__input {
+    height: 24px;
+    left: 0;
+    margin: 0;
+    position: absolute;
+    top: 0;
+    width: 24px;
+  }
+  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__label::before {
+    left: 0;
+    top: 0;
+  }
+  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__label::after {
+    left: 6px;
+    top: 7px;
+  }
+  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__label {
+    display: block;
+    height: 24px;
+    min-height: 0;
+    max-width: none;
+    padding: 0;
+    width: 24px;
+  }
+</style>
+<script {% if config["ENV"]=="production" %}nonce="{{ csp_nonce() }}" {% endif %}>
+  var selectedCount = document.getElementById('duplicate-selected-count');
+  var duplicateCheckboxes = document.querySelectorAll('.duplicate-checkbox');
+  var selectAllCheckbox = document.getElementById('entity-redirect-select-all');
+  function updateDuplicateSelection() {
+    var count = 0;
+    var selectableCount = 0;
+    var selectableSelectedCount = 0;
+    duplicateCheckboxes.forEach(function(checkbox) {
+      var row = checkbox.closest('.duplicate-row');
+      if (!checkbox.disabled) {
+        selectableCount += 1;
+        if (checkbox.checked) selectableSelectedCount += 1;
+      }
+      if (checkbox.checked) {
+        count += 1;
+        if (row) row.style.backgroundColor = '#dbeafe';
+      } else if (row) {
+        row.style.backgroundColor = '';
+      }
+    });
+    if (selectAllCheckbox) {
+      selectAllCheckbox.disabled = selectableCount === 0;
+      selectAllCheckbox.checked = selectableCount > 0 && selectableSelectedCount === selectableCount;
+      selectAllCheckbox.indeterminate = selectableSelectedCount > 0 && selectableSelectedCount < selectableCount;
+    }
+    if (selectedCount) {
+      selectedCount.textContent = count === 0
+        ? 'No entities selected for redirection'
+        : count + ' ' + (count === 1 ? 'entity' : 'entities') + ' selected for redirection';
+    }
+  }
+  duplicateCheckboxes.forEach(function(checkbox) {
+    checkbox.addEventListener('change', updateDuplicateSelection);
+  });
+  if (selectAllCheckbox) {
+    selectAllCheckbox.addEventListener('change', function() {
+      duplicateCheckboxes.forEach(function(checkbox) {
+        if (!checkbox.disabled) checkbox.checked = selectAllCheckbox.checked;
+      });
+      updateDuplicateSelection();
+    });
+  }
+  updateDuplicateSelection();
+</script>
 {% endblock %}

--- a/application/templates/datamanager/assign-entities-check-results.html
+++ b/application/templates/datamanager/assign-entities-check-results.html
@@ -85,6 +85,7 @@
                   <th scope="col" class="govuk-table__header">Entry date</th>
                   <th scope="col" class="govuk-table__header">End date</th>
                   <th scope="col" class="govuk-table__header">Organisation</th>
+                  <th scope="col" class="govuk-table__header">Current redirects</th>
                   <th scope="col" class="govuk-table__header">Evidence</th>
                 </tr>
               </thead>
@@ -105,42 +106,47 @@
                     </div>
                   </td>
                   <td class="govuk-table__cell app-wrap">
-                    <div style="color: #00703c;">
+                    <div class="app-duplicate-new-entity">
                       {% if _flagged_errors_query %}
-                      <a class="govuk-link" style="color: #00703c;" href="{{ url_for(_transform_endpoint, request_id=request_id, entity_search=row.entity, errors=_flagged_errors_query, _anchor='entities-table') }}"><code>{{ row.entity }}</code></a>
+                      <a class="govuk-link app-duplicate-new-entity" href="{{ url_for(_transform_endpoint, request_id=request_id, entity_search=row.entity, errors=_flagged_errors_query, _anchor='entities-table') }}"><code>{{ row.entity }}</code></a>
                       {% else %}
-                      <a class="govuk-link" style="color: #00703c;" href="{{ url_for(_transform_endpoint, request_id=request_id, entity_search=row.entity, _anchor='entities-table') }}"><code>{{ row.entity }}</code></a>
+                      <a class="govuk-link app-duplicate-new-entity" href="{{ url_for(_transform_endpoint, request_id=request_id, entity_search=row.entity, _anchor='entities-table') }}"><code>{{ row.entity }}</code></a>
                       {% endif %}
                     </div>
                   </td>
                   <td class="govuk-table__cell app-wrap">
-                    <div style="color: #d4692a;">
+                    <div class="app-duplicate-old-entity">
                       {% if row.old_entity %}
-                      <a class="govuk-link" style="color: #d4692a;" href="{{ planning_entity_base_url }}/{{ row.old_entity }}" target="_blank" rel="noopener noreferrer"><code>{{ row.old_entity }}</code></a>
+                      <a class="govuk-link app-duplicate-old-entity" href="{{ planning_entity_base_url }}/{{ row.old_entity }}" target="_blank" rel="noopener noreferrer"><code>{{ row.old_entity }}</code></a>
                       {% else %}
                       <code></code>
                       {% endif %}
                     </div>
                   </td>
                   <td class="govuk-table__cell app-wrap">
-                    <div style="color: #00703c;">{{ row.new_reference or '' }}</div>
-                    <div style="color: #d4692a;">{{ row.old_reference or '' }}</div>
+                    <div class="app-duplicate-new-entity">{{ row.new_reference or '' }}</div>
+                    <div class="app-duplicate-old-entity">{{ row.old_reference or '' }}</div>
                   </td>
                   <td class="govuk-table__cell app-wrap">
-                    <div style="color: #00703c;">{{ row.new_name or '' }}</div>
-                    <div style="color: #d4692a;">{{ row.old_name or '' }}</div>
+                    <div class="app-duplicate-new-entity">{{ row.new_name or '' }}</div>
+                    <div class="app-duplicate-old-entity">{{ row.old_name or '' }}</div>
                   </td>
                   <td class="govuk-table__cell app-wrap">
-                    <div style="color: #00703c;">{{ row.get("new_entry_date") or row.get("new_entry-date") or '' }}</div>
-                    <div style="color: #d4692a;">{{ row.get("old_entry_date") or row.get("old_entry-date") or '' }}</div>
+                    <div class="app-duplicate-new-entity">{{ row.get("new_entry_date") or row.get("new_entry-date") or '' }}</div>
+                    <div class="app-duplicate-old-entity">{{ row.get("old_entry_date") or row.get("old_entry-date") or '' }}</div>
                   </td>
                   <td class="govuk-table__cell app-wrap">
-                    <div style="color: #00703c;">{{ row.get("new_end_date") or row.get("new_end-date") or '' }}</div>
-                    <div style="color: #d4692a;">{{ row.get("old_end_date") or row.get("old_end-date") or '' }}</div>
+                    <div class="app-duplicate-new-entity">{{ row.get("new_end_date") or row.get("new_end-date") or '' }}</div>
+                    <div class="app-duplicate-old-entity">{{ row.get("old_end_date") or row.get("old_end-date") or '' }}</div>
                   </td>
                   <td class="govuk-table__cell app-wrap">
-                    <div style="color: #00703c;">{{ row.new_organisation or row.new_organisation_entity or '' }}</div>
-                    <div style="color: #d4692a;">{{ row.old_organisation or row.old_organisation_entity or '' }}</div>
+                    <div class="app-duplicate-new-entity">{{ row.new_organisation or row.new_organisation_entity or '' }}</div>
+                    <div class="app-duplicate-old-entity">{{ row.old_organisation or row.old_organisation_entity or '' }}</div>
+                  </td>
+                  <td class="govuk-table__cell app-wrap app-duplicate-old-entity">
+                    {% for redirect in row.old_entity_redirects or [] %}
+                      {{ redirect.get("entity", "") }}{% if redirect.get("status") %} ({{ redirect.get("status") }}){% endif %}{% if not loop.last %}, {% endif %}
+                    {% endfor %}
                   </td>
                   <td class="govuk-table__cell app-wrap">{{ row.evidence or 'Spatial match' }}</td>
                 </tr>
@@ -182,6 +188,12 @@
   .app-duplicates-table .govuk-table__header,
   .app-duplicates-table .govuk-table__cell {
     vertical-align: middle;
+  }
+  .app-duplicate-new-entity {
+    color: #00703c;
+  }
+  .app-duplicate-old-entity {
+    color: #d4692a;
   }
   .app-duplicates-table .app-checkbox-header {
     padding-bottom: 10px;

--- a/application/templates/datamanager/assign-entities-check-results.html
+++ b/application/templates/datamanager/assign-entities-check-results.html
@@ -46,6 +46,11 @@
     </dl>
 {% endblock %}
 
+{% block pageStylesheets %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='stylesheets/entity-redirect-selection.css') }}">
+{% endblock %}
+
 {% block extra_tabs %}
         {% if show_dedup_tab %}
         <li class="govuk-tabs__list-item">
@@ -171,99 +176,5 @@
 {% endblock %}
 
 {% block pageScripts %}{{ super() }}
-<style>
-  .app-duplicates-table .govuk-table__header,
-  .app-duplicates-table .govuk-table__cell {
-    vertical-align: middle;
-  }
-  .app-duplicates-table .app-checkbox-header {
-    padding-bottom: 10px;
-    padding-top: 10px;
-    text-align: center;
-    width: 24px;
-  }
-  .app-duplicates-table .app-checkboxes--table-header {
-    display: inline-block;
-    height: 24px;
-    margin: 0;
-    vertical-align: middle;
-    width: 24px;
-  }
-  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__item {
-    display: block;
-    height: 24px;
-    min-height: 24px;
-    position: relative;
-    width: 24px;
-  }
-  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__input {
-    height: 24px;
-    left: 0;
-    margin: 0;
-    position: absolute;
-    top: 0;
-    width: 24px;
-  }
-  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__label::before {
-    left: 0;
-    top: 0;
-  }
-  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__label::after {
-    left: 6px;
-    top: 7px;
-  }
-  .app-duplicates-table .app-checkboxes--table-header .govuk-checkboxes__label {
-    display: block;
-    height: 24px;
-    min-height: 0;
-    max-width: none;
-    padding: 0;
-    width: 24px;
-  }
-</style>
-<script>
-  var selectedCount = document.getElementById('duplicate-selected-count');
-  var duplicateCheckboxes = document.querySelectorAll('.duplicate-checkbox');
-  var selectAllCheckbox = document.getElementById('entity-redirect-select-all');
-  function updateDuplicateSelection() {
-    var count = 0;
-    var selectableCount = 0;
-    var selectableSelectedCount = 0;
-    duplicateCheckboxes.forEach(function(checkbox) {
-      var row = checkbox.closest('.duplicate-row');
-      if (!checkbox.disabled) {
-        selectableCount += 1;
-        if (checkbox.checked) selectableSelectedCount += 1;
-      }
-      if (checkbox.checked) {
-        count += 1;
-        if (row) row.style.backgroundColor = '#dbeafe';
-      } else if (row) {
-        row.style.backgroundColor = '';
-      }
-    });
-    if (selectAllCheckbox) {
-      selectAllCheckbox.disabled = selectableCount === 0;
-      selectAllCheckbox.checked = selectableCount > 0 && selectableSelectedCount === selectableCount;
-      selectAllCheckbox.indeterminate = selectableSelectedCount > 0 && selectableSelectedCount < selectableCount;
-    }
-    if (selectedCount) {
-      selectedCount.textContent = count === 0
-        ? 'No entities selected for redirection'
-        : count + ' ' + (count === 1 ? 'entity' : 'entities') + ' selected for redirection';
-    }
-  }
-  duplicateCheckboxes.forEach(function(checkbox) {
-    checkbox.addEventListener('change', updateDuplicateSelection);
-  });
-  if (selectAllCheckbox) {
-    selectAllCheckbox.addEventListener('change', function() {
-      duplicateCheckboxes.forEach(function(checkbox) {
-        if (!checkbox.disabled) checkbox.checked = selectAllCheckbox.checked;
-      });
-      updateDuplicateSelection();
-    });
-  }
-  updateDuplicateSelection();
-</script>
+<script src="{{ url_for('static', filename='javascripts/entity-redirect-selection.js') }}"></script>
 {% endblock %}

--- a/application/templates/datamanager/entities_preview.html
+++ b/application/templates/datamanager/entities_preview.html
@@ -184,6 +184,19 @@
     </div>
     {% endif %}
 
+    <!-- Old Entity Summary -->
+    {% if old_entity_redirect_table_params %}
+    <div class="govuk-!-margin-bottom-6">
+      <h2 class="govuk-heading-m"><u>Old Entity Summary</u></h2>
+      <div style="border: 1px solid #b1b4b6; padding: 20px;">
+        <h3 class="govuk-heading-s">old-entity.csv</h3>
+        <div class="app-scrollable-container app-scrollable govuk-!-margin-bottom-2">
+          {{ table(old_entity_redirect_table_params) }}
+        </div>
+      </div>
+    </div>
+    {% endif %}
+
     <div class="govuk-button-group">
       <form method="post" action="{{ url_for('datamanager.add_data_confirm_async', request_id=request_id) }}">
         <input type="hidden" name="github_branch" value="{{ github_branch or '' }}">

--- a/config/config.py
+++ b/config/config.py
@@ -100,7 +100,7 @@ def get_request_api_endpoint():
 
     mapping = {
         "local": "http://localhost:8000",
-        "development": "http://development-pub-async-api-lb-69142969.eu-west-2.elb.amazonaws.com",
+        "development": "https://pub-async.development.planning.data.gov.uk",
         "staging": "http://staging-pub-async-api-lb-12493311.eu-west-2.elb.amazonaws.com",
         "production": "http://production-pub-async-api-lb-636110663.eu-west-2.elb.amazonaws.com",
     }

--- a/migrations/versions/d4e5f6a7b8c9_add_request_meta_entity_redirects.py
+++ b/migrations/versions/d4e5f6a7b8c9_add_request_meta_entity_redirects.py
@@ -1,0 +1,26 @@
+"""add request_meta entity_redirects column
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-07-01 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "d4e5f6a7b8c9"
+down_revision = "c3d4e5f6a7b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "request_meta",
+        sa.Column("entity_redirects", sa.Text(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("request_meta", "entity_redirects")

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -464,7 +464,8 @@ def test_assign_entities_check_results_does_not_show_retire_endpoints(client):
     assert b"Entity growth is above threshold, Resource empty" in response.data
     assert b"Retire endpoints" not in response.data
     assert b"retire_endpoints" not in response.data
-    assert b"/datamanager/add-data/assign-id-1/entities" in response.data
+    assert b'action="/assign-entities/check-results/assign-id-1"' in response.data
+    assert b'form="duplicate-redirect-form"' in response.data
 
 
 @rsps.activate
@@ -695,22 +696,51 @@ def test_assign_entities_check_results_hides_dedup_for_other_datasets(client):
 
 def test_assign_entities_check_results_post_stores_redirects(client):
     request_id = "assign-post-id"
-    response = client.post(
-        f"/assign-entities/check-results/{request_id}",
-        data={
-            "entity_redirects": json.dumps(
-                {
-                    "old_entity": "100",
-                    "entity": "200",
-                    "dataset": "tree",
-                    "old_reference": "old-ref",
-                    "new_reference": "new-ref",
-                    "match_type": "complete_match",
-                    "notes": "Redirect duplicate entity selected in Assign Entities",
+    with patch(
+        "application.blueprints.datamanager.router.fetch_request",
+        return_value={
+            "response": {
+                "data": {
+                    "pipeline-summary": {
+                        "duplicate-candidates": [
+                            {
+                                "old_entity": "100",
+                                "entity": "200",
+                                "dataset": "tree",
+                            }
+                        ]
+                    }
                 }
-            )
+            }
         },
-    )
+    ):
+        response = client.post(
+            f"/assign-entities/check-results/{request_id}",
+            data={
+                "entity_redirects": [
+                    json.dumps(
+                        {
+                            "old_entity": "100",
+                            "entity": "200",
+                            "dataset": "tree",
+                            "old_reference": "old-ref",
+                            "new_reference": "new-ref",
+                            "match_type": "complete_match",
+                            "notes": (
+                                "Redirect duplicate entity selected in Assign Entities"
+                            ),
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "old_entity": "999",
+                            "entity": "200",
+                            "dataset": "tree",
+                        }
+                    ),
+                ]
+            },
+        )
 
     assert response.status_code == 302
     assert response.headers["Location"].endswith(

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -560,7 +560,22 @@ def test_assign_entities_check_results_shows_duplicate_candidates(client):
                                 "new_end_date": "",
                                 "name_similarity": 62,
                                 "evidence": "name similarity 62%",
-                            }
+                            },
+                            {
+                                "old_entity": "101",
+                                "entity": "201",
+                                "dataset": "conservation-area",
+                                "old_reference": "old-redirect-ref",
+                                "new_reference": "new-redirect-ref",
+                                "match_type": "complete_match",
+                                "old_entity_redirects": [
+                                    {
+                                        "old-entity": "101",
+                                        "entity": "300",
+                                        "status": "301",
+                                    }
+                                ],
+                            },
                         ],
                     },
                 }
@@ -611,8 +626,10 @@ def test_assign_entities_check_results_shows_duplicate_candidates(client):
     assert b"Match type" not in response.data
     assert b"Entry date" in response.data
     assert b"End date" in response.data
+    assert b"Current redirects" in response.data
     assert b"old-ref" in response.data
     assert b"new-ref" in response.data
+    assert b"300 (301)" in response.data
     assert b"2020-01-01" in response.data
     assert b"2026-01-01" in response.data
     assert (
@@ -623,6 +640,19 @@ def test_assign_entities_check_results_shows_duplicate_candidates(client):
     assert (
         b'id="entity-redirect-1" name="entity_redirects" type="checkbox"'
         in response.data
+    )
+    assert (
+        b'id="entity-redirect-2" name="entity_redirects" type="checkbox"'
+        in response.data
+    )
+    assert (
+        b'id="entity-redirect-2" name="entity_redirects" type="checkbox"'
+        b" value=" in response.data
+    )
+    assert (
+        b'id="entity-redirect-2" name="entity_redirects" type="checkbox"'
+        b" value="
+        b" checked disabled" not in response.data
     )
     assert b"old_entity" in response.data
     assert b"checked disabled" in response.data

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import responses as rsps
 
 from application.blueprints.base.views import ADD_DATA_LOCK, ASSIGN_ENTITIES_LOCK
-from application.db.models import ServiceLock
+from application.db.models import RequestMeta, ServiceLock
 from application.extensions import db
 from config.config import get_request_api_endpoint
 
@@ -519,6 +519,215 @@ def test_assign_entities_check_results_hides_entity_pagination_when_empty(client
     ]
     assert b"Showing entities" not in entities_panel
     assert b'aria-label="Pagination"' not in entities_panel
+
+
+@rsps.activate
+def test_assign_entities_check_results_shows_duplicate_candidates(client):
+    geometry = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"
+    rsps.add(
+        rsps.GET,
+        f"{ASYNC_BASE}/assign-duplicates-id",
+        json={
+            "status": "COMPLETE",
+            "params": {
+                "dataset": "conservation-area",
+                "organisation": "local-authority:ABC",
+                "resource": "resource-a",
+            },
+            "response": {
+                "data": {
+                    "source-summary": {},
+                    "pipeline-summary": {
+                        "new-in-resource": 1,
+                        "duplicate-candidates": [
+                            {
+                                "old_entity": "100",
+                                "entity": "200",
+                                "dataset": "conservation-area",
+                                "old_reference": "old-ref",
+                                "new_reference": "new-ref",
+                                "match_type": "complete_match",
+                                "notes": (
+                                    "Redirect duplicate entity selected in "
+                                    "Assign Entities"
+                                ),
+                                "old_name": "Old Tree",
+                                "new_name": "New Tree",
+                                "old_entry_date": "2020-01-01",
+                                "new_entry_date": "2026-01-01",
+                                "old_end_date": "",
+                                "new_end_date": "",
+                                "name_similarity": 62,
+                                "evidence": "name similarity 62%",
+                            }
+                        ],
+                    },
+                }
+            },
+        },
+        status=200,
+    )
+    rsps.add(
+        rsps.GET,
+        f"{ASYNC_BASE}/assign-duplicates-id/response-details",
+        json=[
+            {
+                "entry_number": 1,
+                "transformed_row": [
+                    {"entity": "200", "field": "reference", "value": "new-ref"},
+                    {"entity": "200", "field": "name", "value": "New Tree"},
+                    {"entity": "200", "field": "geometry", "value": geometry},
+                ],
+                "issue_logs": [],
+            }
+        ],
+        status=200,
+    )
+
+    transform_controller = "application.blueprints.datamanager.controllers.transform"
+
+    with patch(f"{transform_controller}.get_org_entity", return_value=90):
+        with patch(f"{transform_controller}.get_organisation_name"):
+            with patch(f"{transform_controller}.get_dataset_name", return_value="Tree"):
+                with patch(
+                    f"{transform_controller}.get_dataset_typology",
+                    return_value="entity",
+                ):
+                    with patch(
+                        f"{transform_controller}.get_entity_count_for_organisation_and_dataset",
+                        return_value=1,
+                    ):
+                        with patch(
+                            f"{transform_controller}.get_entities_for_organisation_and_dataset",
+                            return_value=[],
+                        ):
+                            response = client.get(
+                                "/assign-entities/check-results/assign-duplicates-id"
+                            )
+
+    assert response.status_code == 200
+    assert b"Dedup" in response.data
+    assert b"Match type" not in response.data
+    assert b"Entry date" in response.data
+    assert b"End date" in response.data
+    assert b"old-ref" in response.data
+    assert b"new-ref" in response.data
+    assert b"2020-01-01" in response.data
+    assert b"2026-01-01" in response.data
+    assert (
+        b'href="/assign-entities/check-results/assign-duplicates-id?'
+        b'entity_search=200#entities-table"'
+    ) in response.data
+    assert b'type="hidden" name="entity_redirects"' in response.data
+    assert (
+        b'id="entity-redirect-1" name="entity_redirects" type="checkbox"'
+        in response.data
+    )
+    assert b"old_entity" in response.data
+    assert b"checked disabled" in response.data
+    assert b"entity-redirect-select-all" in response.data
+    assert b"entities selected for redirection" in response.data
+
+
+@rsps.activate
+def test_assign_entities_check_results_hides_dedup_for_other_datasets(client):
+    rsps.add(
+        rsps.GET,
+        f"{ASYNC_BASE}/assign-tree-id",
+        json={
+            "status": "COMPLETE",
+            "params": {
+                "dataset": "tree",
+                "organisation": "local-authority:ABC",
+                "resource": "resource-a",
+            },
+            "response": {
+                "data": {
+                    "source-summary": {},
+                    "pipeline-summary": {
+                        "new-in-resource": 1,
+                        "duplicate-candidates": [
+                            {
+                                "old_entity": "100",
+                                "entity": "200",
+                                "dataset": "tree",
+                                "form_value": "{}",
+                            }
+                        ],
+                    },
+                }
+            },
+        },
+        status=200,
+    )
+    rsps.add(
+        rsps.GET,
+        f"{ASYNC_BASE}/assign-tree-id/response-details",
+        json=[],
+        status=200,
+    )
+
+    transform_controller = "application.blueprints.datamanager.controllers.transform"
+    with patch(f"{transform_controller}.get_org_entity", return_value=90):
+        with patch(f"{transform_controller}.get_organisation_name"):
+            with patch(f"{transform_controller}.get_dataset_name", return_value="Tree"):
+                with patch(
+                    f"{transform_controller}.get_dataset_typology",
+                    return_value="entity",
+                ):
+                    with patch(
+                        f"{transform_controller}.get_entity_count_for_organisation_and_dataset",
+                        return_value=1,
+                    ):
+                        with patch(
+                            f"{transform_controller}.get_entities_for_organisation_and_dataset",
+                            return_value=[],
+                        ):
+                            response = client.get(
+                                "/assign-entities/check-results/assign-tree-id"
+                            )
+
+    assert response.status_code == 200
+    assert b"Dedup" not in response.data
+    assert b'href="#duplicates-table"' not in response.data
+    assert b'id="duplicates-table"' not in response.data
+
+
+def test_assign_entities_check_results_post_stores_redirects(client):
+    request_id = "assign-post-id"
+    response = client.post(
+        f"/assign-entities/check-results/{request_id}",
+        data={
+            "entity_redirects": json.dumps(
+                {
+                    "old_entity": "100",
+                    "entity": "200",
+                    "dataset": "tree",
+                    "old_reference": "old-ref",
+                    "new_reference": "new-ref",
+                    "match_type": "complete_match",
+                    "notes": "Redirect duplicate entity selected in Assign Entities",
+                }
+            )
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(
+        f"/datamanager/add-data/{request_id}/entities"
+    )
+    meta = db.session.get(RequestMeta, request_id)
+    assert json.loads(meta.entity_redirects) == [
+        {
+            "old_entity": "100",
+            "entity": "200",
+            "dataset": "tree",
+            "old_reference": "old-ref",
+            "new_reference": "new-ref",
+            "match_type": "complete_match",
+            "notes": "Redirect duplicate entity selected in Assign Entities",
+        }
+    ]
 
 
 @rsps.activate

--- a/tests/unit/blueprints/datamanager/controllers/test_add.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_add.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 
 from application.blueprints.datamanager.services.github import GitHubWorkflowError
+from application.db.models import RequestMeta
+from application.extensions import db
 
 PENDING_ADD_DATA_RESULT = {
     "status": "PENDING",
@@ -18,6 +20,40 @@ class TestEntitiesPreviewRoute:
             response = client.get("/datamanager/add-data/test-id/entities")
         assert response.status_code == 200
         assert b"Preparing entities preview" in response.data
+
+    def test_renders_old_entity_redirect_table(self, client):
+        db.session.add(
+            RequestMeta(
+                request_id="test-id",
+                entity_redirects=(
+                    '[{"old_entity":"100","entity":"200",'
+                    '"dataset":"conservation-area"}]'
+                ),
+            )
+        )
+        db.session.commit()
+        result = {
+            "status": "COMPLETE",
+            "params": {"dataset": "conservation-area", "authoritative": False},
+            "response": {
+                "data": {
+                    "pipeline-summary": {"new-in-resource": 0},
+                    "endpoint-summary": {},
+                    "source-summary": {},
+                }
+            },
+        }
+        with patch(
+            "application.blueprints.datamanager.router.fetch_request",
+            return_value=result,
+        ):
+            response = client.get("/datamanager/add-data/test-id/entities")
+
+        assert response.status_code == 200
+        assert b"old-entity.csv" in response.data
+        assert b"100" in response.data
+        assert b"301" in response.data
+        assert b"200" in response.data
 
 
 class TestAddDataConfirmRoute:
@@ -79,3 +115,33 @@ class TestAddDataConfirmRoute:
             response = client.post("/datamanager/add-data/test-id/confirm-async")
         assert response.status_code == 200
         assert b"govuk-error-summary" in response.data
+
+    def test_confirm_passes_entity_redirects_to_workflow(self, client):
+        db.session.add(
+            RequestMeta(
+                request_id="confirm-redirect-id",
+                entity_redirects=(
+                    '[{"old_entity":"100","entity":"200",'
+                    '"dataset":"conservation-area"}]'
+                ),
+            )
+        )
+        db.session.commit()
+        with client.session_transaction() as sess:
+            sess["user"] = {"login": "test-user"}
+        with patch(
+            "application.blueprints.datamanager.controllers.preview.trigger_add_data_async_workflow",
+            return_value={"success": True, "message": "Workflow triggered"},
+        ) as trigger:
+            response = client.post(
+                "/datamanager/add-data/confirm-redirect-id/confirm-async"
+            )
+
+        assert response.status_code == 200
+        assert trigger.call_args.kwargs["entity_redirects"] == [
+            {
+                "old_entity": "100",
+                "entity": "200",
+                "dataset": "conservation-area",
+            }
+        ]

--- a/tests/unit/blueprints/datamanager/controllers/test_transform.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_transform.py
@@ -1,6 +1,39 @@
+import json
+
 from application.blueprints.datamanager.controllers.transform import (
+    _dedup_candidate_form_value,
     _prepare_duplicate_candidates,
 )
+from application.blueprints.datamanager.services.duplicates import REDIRECT_NOTE
+
+
+def test_dedup_candidate_form_value_builds_redirect_payload():
+    form_value = _dedup_candidate_form_value(
+        {
+            "old_entity": "100",
+            "entity": "200",
+            "dataset": "conservation-area",
+            "old_reference": "old-ref",
+            "new_reference": "new-ref",
+            "match_type": "complete_match",
+        }
+    )
+
+    assert json.loads(form_value) == {
+        "old_entity": "100",
+        "entity": "200",
+        "dataset": "conservation-area",
+        "old_reference": "old-ref",
+        "new_reference": "new-ref",
+        "match_type": "complete_match",
+        "notes": REDIRECT_NOTE,
+    }
+
+
+def test_dedup_candidate_form_value_keeps_existing_value():
+    assert _dedup_candidate_form_value({"form_value": '{"entity":"200"}'}) == (
+        '{"entity":"200"}'
+    )
 
 
 def test_prepare_duplicate_candidates_auto_selects_complete_matches():

--- a/tests/unit/blueprints/datamanager/controllers/test_transform.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_transform.py
@@ -48,6 +48,21 @@ def test_prepare_duplicate_candidates_auto_selects_complete_matches():
     assert candidates[0]["auto_select"] is True
 
 
+def test_prepare_duplicate_candidates_does_not_auto_select_existing_redirects():
+    candidates = _prepare_duplicate_candidates(
+        [
+            {
+                "match_type": "complete_match",
+                "old_entity_redirects": [
+                    {"old-entity": "100", "entity": "300", "status": "301"}
+                ],
+            }
+        ]
+    )
+
+    assert candidates[0]["auto_select"] is False
+
+
 def test_prepare_duplicate_candidates_auto_selects_single_matches_over_threshold():
     candidates = _prepare_duplicate_candidates(
         [

--- a/tests/unit/blueprints/datamanager/controllers/test_transform.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_transform.py
@@ -1,0 +1,42 @@
+from application.blueprints.datamanager.controllers.transform import (
+    _prepare_duplicate_candidates,
+)
+
+
+def test_prepare_duplicate_candidates_auto_selects_complete_matches():
+    candidates = _prepare_duplicate_candidates(
+        [
+            {
+                "match_type": "complete_match",
+                "name_similarity": 10,
+            }
+        ]
+    )
+
+    assert candidates[0]["auto_select"] is True
+
+
+def test_prepare_duplicate_candidates_auto_selects_single_matches_over_threshold():
+    candidates = _prepare_duplicate_candidates(
+        [
+            {
+                "match_type": "single_match",
+                "name_similarity": 86,
+            }
+        ]
+    )
+
+    assert candidates[0]["auto_select"] is True
+
+
+def test_prepare_duplicate_candidates_does_not_auto_select_single_matches_at_threshold():
+    candidates = _prepare_duplicate_candidates(
+        [
+            {
+                "match_type": "single_match",
+                "name_similarity": 85,
+            }
+        ]
+    )
+
+    assert candidates[0]["auto_select"] is False

--- a/tests/unit/blueprints/datamanager/controllers/test_transform.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_transform.py
@@ -4,7 +4,6 @@ from application.blueprints.datamanager.controllers.transform import (
     _dedup_candidate_form_value,
     _prepare_duplicate_candidates,
 )
-from application.blueprints.datamanager.services.duplicates import REDIRECT_NOTE
 
 
 def test_dedup_candidate_form_value_builds_redirect_payload():
@@ -26,7 +25,7 @@ def test_dedup_candidate_form_value_builds_redirect_payload():
         "old_reference": "old-ref",
         "new_reference": "new-ref",
         "match_type": "complete_match",
-        "notes": REDIRECT_NOTE,
+        "notes": "Redirect duplicate entity selected in Assign Entities",
     }
 
 

--- a/tests/unit/blueprints/datamanager/services/test_duplicates.py
+++ b/tests/unit/blueprints/datamanager/services/test_duplicates.py
@@ -1,6 +1,16 @@
 from application.blueprints.datamanager.services.duplicates import (
+    _normalise_entity_id,
     parse_selected_redirects,
 )
+
+
+def test_normalise_entity_id_keeps_fractional_and_non_numeric_values():
+    assert _normalise_entity_id("100") == "100"
+    assert _normalise_entity_id("100.0") == "100"
+    assert _normalise_entity_id("100.5") == "100.5"
+    assert _normalise_entity_id("abc") == "abc"
+    assert _normalise_entity_id(None) == ""
+    assert _normalise_entity_id("") == ""
 
 
 def test_parse_selected_redirects_filters_invalid_rows():
@@ -20,6 +30,45 @@ def test_parse_selected_redirects_filters_invalid_rows():
             "old_reference": "",
             "new_reference": "",
             "match_type": "complete_match",
+            "notes": "Redirect duplicate entity selected in Assign Entities",
+        }
+    ]
+
+
+def test_parse_selected_redirects_validates_against_duplicate_candidates():
+    redirects = parse_selected_redirects(
+        [
+            '{"old_entity":"100","entity":"200","dataset":"tree"}',
+            '{"old_entity":"999","entity":"200","dataset":"tree"}',
+        ],
+        duplicate_candidates=[
+            {"old_entity": "100", "entity": "200", "dataset": "tree"}
+        ],
+    )
+
+    assert [redirect["old_entity"] for redirect in redirects] == ["100"]
+
+
+def test_parse_selected_redirects_skips_repeated_old_entities():
+    redirects = parse_selected_redirects(
+        [
+            '{"old_entity":"100","entity":"200","dataset":"tree"}',
+            '{"old_entity":"100","entity":"201","dataset":"tree"}',
+        ],
+        duplicate_candidates=[
+            {"old_entity": "100", "entity": "200", "dataset": "tree"},
+            {"old_entity": "100", "entity": "201", "dataset": "tree"},
+        ],
+    )
+
+    assert redirects == [
+        {
+            "old_entity": "100",
+            "entity": "200",
+            "dataset": "tree",
+            "old_reference": "",
+            "new_reference": "",
+            "match_type": "",
             "notes": "Redirect duplicate entity selected in Assign Entities",
         }
     ]

--- a/tests/unit/blueprints/datamanager/services/test_duplicates.py
+++ b/tests/unit/blueprints/datamanager/services/test_duplicates.py
@@ -1,0 +1,25 @@
+from application.blueprints.datamanager.services.duplicates import (
+    parse_selected_redirects,
+)
+
+
+def test_parse_selected_redirects_filters_invalid_rows():
+    redirects = parse_selected_redirects(
+        [
+            '{"old_entity":"100","entity":"200","dataset":"tree","match_type":"complete_match"}',
+            '{"old_entity":"","entity":"201","dataset":"tree"}',
+            "not-json",
+        ]
+    )
+
+    assert redirects == [
+        {
+            "old_entity": "100",
+            "entity": "200",
+            "dataset": "tree",
+            "old_reference": "",
+            "new_reference": "",
+            "match_type": "complete_match",
+            "notes": "Redirect duplicate entity selected in Assign Entities",
+        }
+    ]

--- a/tests/unit/blueprints/datamanager/services/test_duplicates.py
+++ b/tests/unit/blueprints/datamanager/services/test_duplicates.py
@@ -19,7 +19,8 @@ def test_parse_selected_redirects_filters_invalid_rows():
             '{"old_entity":"100","entity":"200","dataset":"tree","match_type":"complete_match"}',
             '{"old_entity":"","entity":"201","dataset":"tree"}',
             "not-json",
-        ]
+        ],
+        [{"old_entity": "100", "entity": "200", "dataset": "tree"}],
     )
 
     assert redirects == [

--- a/tests/unit/blueprints/datamanager/services/test_github.py
+++ b/tests/unit/blueprints/datamanager/services/test_github.py
@@ -75,3 +75,39 @@ class TestTriggerAddDataAsyncWorkflow:
 
         assert result["success"] is False
         assert result["status_code"] == 422
+
+    def test_includes_entity_redirects_in_payload(self, app):
+        mock_dispatch = Mock()
+        mock_dispatch.status_code = 204
+
+        with app.app_context():
+            app.config["GITHUB_APP_ID"] = "app-id"
+            app.config["GITHUB_APP_INSTALLATION_ID"] = "install-id"
+            app.config["GITHUB_APP_PRIVATE_KEY"] = "key"
+            with patch(
+                "application.blueprints.datamanager.services.github.generate_jwt",
+                return_value="jwt-token",
+            ):
+                with patch(
+                    "application.blueprints.datamanager.services.github.get_installation_token",
+                    return_value="access-token",
+                ):
+                    with patch(
+                        "application.blueprints.datamanager.services.github.requests.post",
+                        return_value=mock_dispatch,
+                    ) as post:
+                        trigger_add_data_async_workflow(
+                            "request-123",
+                            entity_redirects=[
+                                {
+                                    "old_entity": "100",
+                                    "entity": "200",
+                                    "dataset": "conservation-area",
+                                }
+                            ],
+                        )
+
+        payload = post.call_args.kwargs["json"]
+        assert payload["client_payload"]["entity_redirects"] == (
+            '[{"old_entity":"100","entity":"200","dataset":"conservation-area"}]'
+        )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a deduplication review step to the Assign Entities check-results flow for `conservation-area` resources.

**Dedup review tab.** Assign Entities now shows a **Dedup** tab when the async response includes duplicate candidates for a conservation-area dataset. The tab lists possible spatial duplicates between new provision entities and existing platform entities, including:

- new entity and existing old entity
- reference and name values
- entry date and end date
- organisation
- compact duplicate evidence

The old entity links to the planning data entity page using the configured `PLANNING_BASE_URL`, and the new entity links back to the Entities tab filtered to that entity.

**Redirect selection.** Users can select duplicate rows for redirection before continuing to preview. Complete matches are preselected automatically, and single matches are preselected when `name_similarity` is greater than 85%. Auto-selected rows are disabled so they cannot be unselected. A select-all checkbox and selected-count label are included for manually selectable rows.

**Persistence and preview.** Continuing to preview now POSTs the selected redirects and stores them on `RequestMeta.entity_redirects`. The preview page shows an **Old Entity Summary** section for `old-entity.csv`, with the exact rows that will be sent onward:

- `old-entity`
- `status` as `301`
- `entity`
- `notes`
- `end-date`
- `entry-date`
- `start-date`

This fixes the case where preselected disabled rows were visible in the UI but did not appear in preview because disabled checkboxes are not submitted by the browser.

**GitHub dispatch.** The selected redirects are included in the add-data workflow dispatch payload as `entity_redirects`, without changing the user-facing Add to GitHub flow.

**Database.** Adds a nullable `entity_redirects` text column to `request_meta` for storing selected redirect rows between the check-results and preview pages.


## Related Tickets & Documents

- Closes #2545

## QA Instructions, Screenshots, Recordings

Use an Assign Entities request for a `conservation-area` resource where the async response includes duplicate candidates.

Check that:

- the **Dedup** tab appears only for `conservation-area`
- the tab badge shows the duplicate count in red
- complete matches are preselected and disabled
- single matches with `name_similarity > 85%` are preselected and disabled
- manually selected rows update the selected-count label
- the select-all checkbox selects manually selectable rows
- clicking **Continue to preview** shows an **Old Entity Summary** for `old-entity.csv`
- the preview table includes selected redirects with `status` set to `301`
- final Add to GitHub still follows the existing confirmation flow

## Added/updated tests?

- [x] Yes

Added/updated coverage for:

- Dedup tab rendering
- hiding Dedup for non-conservation-area datasets
- generated redirect form values when async does not provide `form_value`
- POST storage of selected redirects in `RequestMeta`
- preview rendering of `old-entity.csv` rows
- GitHub dispatch payload including `entity_redirects`
- redirect parsing and invalid row filtering
- auto-selection logic for complete matches and high-confidence single matches

## [optional] Are there any post deployment tasks we need to perform?

Run the database migration to add `request_meta.entity_redirects`.

## [optional] Are there any dependencies on other PRs or Work?

The async response must provide `pipeline-summary.duplicate-candidates` for conservation-area Assign Entities requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reviewing and submitting old-to-new entity redirect rows during the entity check and add-data confirmation flow.
  * Introduced an “Old Entity Summary” section on the entities preview when redirects are available.
  * Added a Dedup tab with selectable duplicate candidates and live redirect selection/count updates (shown only when applicable).
* **Bug Fixes**
  * Redirect selections are now safely parsed, validated, persisted, and forwarded through the async workflow.
* **Tests**
  * Expanded acceptance and unit coverage for redirect rendering, POST persistence, and workflow payload inclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->