### PR TITLE
preview page flags if overlap detected in entiy organiisation csv

### DIFF
--- a/application/blueprints/datamanager/controllers/preview.py
+++ b/application/blueprints/datamanager/controllers/preview.py
@@ -34,12 +34,12 @@ def _build_entity_organisation_summary(new_entities, authoritative, pipeline_sum
     entities were actually created; otherwise there is nothing to map.
 
     Returns (entity_org_table_params, has_entity_org, entity_org_warning,
-    entity_org_overlap_warning, entity_org_error_warning)
+    entity_org_overlap_info, entity_org_error_warning)
     """
     entity_org_table_params = None
     has_entity_org = False
     entity_org_warning = None
-    entity_org_overlap_warning = None
+    entity_org_overlap_info = None
     entity_org_error_warning = None
 
     if not new_entities:
@@ -47,7 +47,7 @@ def _build_entity_organisation_summary(new_entities, authoritative, pipeline_sum
             entity_org_table_params,
             has_entity_org,
             entity_org_warning,
-            entity_org_overlap_warning,
+            entity_org_overlap_info,
             entity_org_error_warning,
         )
 
@@ -57,34 +57,31 @@ def _build_entity_organisation_summary(new_entities, authoritative, pipeline_sum
             entity_org_table_params,
             has_entity_org,
             entity_org_warning,
-            entity_org_overlap_warning,
+            entity_org_overlap_info,
             entity_org_error_warning,
         )
 
     entity_organisation_data = pipeline_summary.get("entity-organisation") or []
     if entity_organisation_data:
-        (
-            entity_org_table_params,
-            has_entity_org,
-        ) = build_entity_organisation_csv(entity_organisation_data)
-
         entry = entity_organisation_data[0]
         if entry.get("overlap"):
-            entity_org_overlap_warning = (
-                "Entity org range mapping already assigned for these new "
-                "entities - likely a single source dataset"
-            )
-        if entry.get("error"):
+            entity_org_overlap_info = "Entity org already exists - no action needed"
+        elif entry.get("error"):
             entity_org_error_warning = (
                 "An error occurred creating the entity-organisation csv, "
                 "please re-run if you believe this is required"
             )
+        else:
+            (
+                entity_org_table_params,
+                has_entity_org,
+            ) = build_entity_organisation_csv(entity_organisation_data)
 
     return (
         entity_org_table_params,
         has_entity_org,
         entity_org_warning,
-        entity_org_overlap_warning,
+        entity_org_overlap_info,
         entity_org_error_warning,
     )
 
@@ -205,7 +202,7 @@ def handle_entities_preview(request_id, req):
         entity_org_table_params,
         has_entity_org,
         entity_org_warning,
-        entity_org_overlap_warning,
+        entity_org_overlap_info,
         entity_org_error_warning,
     ) = _build_entity_organisation_summary(new_entities, authoritative, pipeline_summary)
 
@@ -230,7 +227,7 @@ def handle_entities_preview(request_id, req):
         entity_org_table_params=entity_org_table_params,
         has_entity_org=has_entity_org,
         entity_org_warning=entity_org_warning,
-        entity_org_overlap_warning=entity_org_overlap_warning,
+        entity_org_overlap_info=entity_org_overlap_info,
         entity_org_error_warning=entity_org_error_warning,
     )
 

--- a/application/blueprints/datamanager/controllers/preview.py
+++ b/application/blueprints/datamanager/controllers/preview.py
@@ -28,6 +28,67 @@ from ..utils.csv_formats import (
 logger = logging.getLogger(__name__)
 
 
+def _build_entity_organisation_summary(new_entities, authoritative, pipeline_summary):
+    """
+    Build entity-organisation CSV preview context - only relevant when new
+    entities were actually created; otherwise there is nothing to map.
+
+    Returns (entity_org_table_params, has_entity_org, entity_org_warning,
+    entity_org_overlap_warning, entity_org_error_warning)
+    """
+    entity_org_table_params = None
+    has_entity_org = False
+    entity_org_warning = None
+    entity_org_overlap_warning = None
+    entity_org_error_warning = None
+
+    if not new_entities:
+        return (
+            entity_org_table_params,
+            has_entity_org,
+            entity_org_warning,
+            entity_org_overlap_warning,
+            entity_org_error_warning,
+        )
+
+    if not authoritative:
+        entity_org_warning = "Non-authoritative data being submitted"
+        return (
+            entity_org_table_params,
+            has_entity_org,
+            entity_org_warning,
+            entity_org_overlap_warning,
+            entity_org_error_warning,
+        )
+
+    entity_organisation_data = pipeline_summary.get("entity-organisation") or []
+    if entity_organisation_data:
+        (
+            entity_org_table_params,
+            has_entity_org,
+        ) = build_entity_organisation_csv(entity_organisation_data)
+
+        entry = entity_organisation_data[0]
+        if entry.get("overlap"):
+            entity_org_overlap_warning = (
+                "Entity org range mapping already assigned for these new "
+                "entities - likely a single source dataset"
+            )
+        if entry.get("error"):
+            entity_org_error_warning = (
+                "An error occurred creating the entity-organisation csv, "
+                "please re-run if you believe this is required"
+            )
+
+    return (
+        entity_org_table_params,
+        has_entity_org,
+        entity_org_warning,
+        entity_org_overlap_warning,
+        entity_org_error_warning,
+    )
+
+
 def handle_entities_preview(request_id, req):
     # Check State
     status = req.get("status")
@@ -138,23 +199,15 @@ def handle_entities_preview(request_id, req):
                     }
                 )
 
-    # Build entity-organisation CSV preview (only for authoritative data)
+    # Build entity-organisation CSV preview
     authoritative = params.get("authoritative", False)
-    entity_org_table_params = None
-    has_entity_org = False
-    entity_org_warning = None
-
-    if authoritative:
-        entity_organisation_data = pipeline_summary.get("entity-organisation") or []
-        if entity_organisation_data:
-            (
-                entity_org_table_params,
-                has_entity_org,
-            ) = build_entity_organisation_csv(entity_organisation_data)
-    else:
-        entity_org_warning = (
-            "This must be manually created currently for non-authoritative data"
-        )
+    (
+        entity_org_table_params,
+        has_entity_org,
+        entity_org_warning,
+        entity_org_overlap_warning,
+        entity_org_error_warning,
+    ) = _build_entity_organisation_summary(new_entities, authoritative, pipeline_summary)
 
     return render_template(
         "datamanager/entities_preview.html",
@@ -177,6 +230,8 @@ def handle_entities_preview(request_id, req):
         entity_org_table_params=entity_org_table_params,
         has_entity_org=has_entity_org,
         entity_org_warning=entity_org_warning,
+        entity_org_overlap_warning=entity_org_overlap_warning,
+        entity_org_error_warning=entity_org_error_warning,
     )
 
 

--- a/application/blueprints/datamanager/controllers/preview.py
+++ b/application/blueprints/datamanager/controllers/preview.py
@@ -204,7 +204,9 @@ def handle_entities_preview(request_id, req):
         entity_org_warning,
         entity_org_overlap_info,
         entity_org_error_warning,
-    ) = _build_entity_organisation_summary(new_entities, authoritative, pipeline_summary)
+    ) = _build_entity_organisation_summary(
+        new_entities, authoritative, pipeline_summary
+    )
 
     return render_template(
         "datamanager/entities_preview.html",

--- a/application/blueprints/datamanager/services/github-add.md
+++ b/application/blueprints/datamanager/services/github-add.md
@@ -88,7 +88,7 @@ The workflow fetches request data from:
 {ASYNC_API_BASE_URL}/requests/{request_id}
 ```
 
-**Default base URL:** `http://development-pub-async-api-lb-69142969.eu-west-2.elb.amazonaws.com`
+**Default base URL:** `https://pub-async.development.planning.data.gov.uk`
 
 To override, set the `ASYNC_API_BASE_URL` repository variable in GitHub Settings > Secrets and variables > Actions > Variables.
 

--- a/application/templates/datamanager/entities_preview.html
+++ b/application/templates/datamanager/entities_preview.html
@@ -135,7 +135,7 @@
     {% endif %}
 
     <!-- Entity Org Summary -->
-    {% if entity_org_warning or (has_entity_org and entity_org_table_params) %}
+    {% if entity_org_warning or entity_org_overlap_warning or entity_org_error_warning or (has_entity_org and entity_org_table_params) %}
     <div class="govuk-!-margin-bottom-6">
       <h2 class="govuk-heading-m"><u>Entity Org Summary</u></h2>
       <div style="border: 1px solid #b1b4b6; padding: 20px;">
@@ -149,9 +149,27 @@
           </strong>
         </div>
         {% else %}
+        {% if has_entity_org and entity_org_table_params %}
         <div class="app-scrollable-container app-scrollable govuk-!-margin-bottom-2">
           {{ table(entity_org_table_params) }}
         </div>
+        {% endif %}
+        {% if entity_org_overlap_warning %}
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Warning</span>
+            {{ entity_org_overlap_warning }}
+          </strong>
+        </div>
+        {% endif %}
+        {% if entity_org_error_warning %}
+        <div class="govuk-error-summary" role="alert">
+          <strong class="govuk-error-message">
+            {{ entity_org_error_warning }}
+          </strong>
+        </div>
+        {% endif %}
         {% endif %}
       </div>
     </div>

--- a/application/templates/datamanager/entities_preview.html
+++ b/application/templates/datamanager/entities_preview.html
@@ -135,7 +135,7 @@
     {% endif %}
 
     <!-- Entity Org Summary -->
-    {% if entity_org_warning or entity_org_overlap_warning or entity_org_error_warning or (has_entity_org and entity_org_table_params) %}
+    {% if entity_org_warning or entity_org_overlap_info or entity_org_error_warning or (has_entity_org and entity_org_table_params) %}
     <div class="govuk-!-margin-bottom-6">
       <h2 class="govuk-heading-m"><u>Entity Org Summary</u></h2>
       <div style="border: 1px solid #b1b4b6; padding: 20px;">
@@ -148,28 +148,20 @@
             {{ entity_org_warning }}
           </strong>
         </div>
-        {% else %}
-        {% if has_entity_org and entity_org_table_params %}
-        <div class="app-scrollable-container app-scrollable govuk-!-margin-bottom-2">
-          {{ table(entity_org_table_params) }}
+        {% elif entity_org_overlap_info %}
+        <div class="govuk-inset-text">
+          {{ entity_org_overlap_info }}
         </div>
-        {% endif %}
-        {% if entity_org_overlap_warning %}
-        <div class="govuk-warning-text">
-          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text">
-            <span class="govuk-visually-hidden">Warning</span>
-            {{ entity_org_overlap_warning }}
-          </strong>
-        </div>
-        {% endif %}
-        {% if entity_org_error_warning %}
+        {% elif entity_org_error_warning %}
         <div class="govuk-error-summary" role="alert">
           <strong class="govuk-error-message">
             {{ entity_org_error_warning }}
           </strong>
         </div>
-        {% endif %}
+        {% elif has_entity_org and entity_org_table_params %}
+        <div class="app-scrollable-container app-scrollable govuk-!-margin-bottom-2">
+          {{ table(entity_org_table_params) }}
+        </div>
         {% endif %}
       </div>
     </div>

--- a/config/config.py
+++ b/config/config.py
@@ -100,9 +100,9 @@ def get_request_api_endpoint():
 
     mapping = {
         "local": "http://localhost:8000",
-        "development": "http://development-pub-async-api-lb-69142969.eu-west-2.elb.amazonaws.com",
-        "staging": "http://staging-pub-async-api-lb-12493311.eu-west-2.elb.amazonaws.com",
-        "production": "http://production-pub-async-api-lb-636110663.eu-west-2.elb.amazonaws.com",
+        "development": "https://pub-async.development.planning.data.gov.uk",
+        "staging": "https://pub-async.staging.planning.data.gov.uk",
+        "production": "https://pub-async.planning.data.gov.uk",
     }
 
     return mapping.get(env, mapping["local"])

--- a/tests/unit/blueprints/datamanager/controllers/test_preview.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_preview.py
@@ -17,24 +17,23 @@ def test_non_authoritative_is_informational_only():
         table_params,
         has_entity_org,
         warning,
-        overlap_warning,
+        overlap_info,
         error_warning,
     ) = _build_entity_organisation_summary(NEW_ENTITIES, False, {"entity-organisation": []})
 
     assert table_params is None
     assert has_entity_org is False
     assert warning == "Non-authoritative data being submitted"
-    assert overlap_warning is None
+    assert overlap_info is None
     assert error_warning is None
 
 
-def test_authoritative_overlap_shows_table_and_overlap_warning():
+def test_authoritative_overlap_shows_info_message_only():
+    """Overlap is informational, not a warning, and the table is skipped."""
     pipeline_summary = {
         "entity-organisation": [
             {
                 "dataset": "nature-improvement-area",
-                "entity-minimum": 10100002,
-                "entity-maximum": 10100002,
                 "organisation": "government-organisation:PB202",
                 "overlap": True,
                 "error": False,
@@ -46,27 +45,23 @@ def test_authoritative_overlap_shows_table_and_overlap_warning():
         table_params,
         has_entity_org,
         warning,
-        overlap_warning,
+        overlap_info,
         error_warning,
     ) = _build_entity_organisation_summary(NEW_ENTITIES, True, pipeline_summary)
 
-    assert has_entity_org is True
-    assert table_params is not None
+    assert has_entity_org is False
+    assert table_params is None
     assert warning is None
-    assert overlap_warning == (
-        "Entity org range mapping already assigned for these new "
-        "entities - likely a single source dataset"
-    )
+    assert overlap_info == "Entity org already exists - no action needed"
     assert error_warning is None
 
 
-def test_authoritative_error_shows_table_and_error_warning():
+def test_authoritative_error_shows_error_message_only():
+    """Error skips the table too, since there's no trustworthy range to show."""
     pipeline_summary = {
         "entity-organisation": [
             {
                 "dataset": "nature-improvement-area",
-                "entity-minimum": 10100002,
-                "entity-maximum": 10100002,
                 "organisation": "government-organisation:PB202",
                 "overlap": False,
                 "error": True,
@@ -78,18 +73,47 @@ def test_authoritative_error_shows_table_and_error_warning():
         table_params,
         has_entity_org,
         warning,
-        overlap_warning,
+        overlap_info,
+        error_warning,
+    ) = _build_entity_organisation_summary(NEW_ENTITIES, True, pipeline_summary)
+
+    assert has_entity_org is False
+    assert table_params is None
+    assert warning is None
+    assert overlap_info is None
+    assert error_warning == (
+        "An error occurred creating the entity-organisation csv, "
+        "please re-run if you believe this is required"
+    )
+
+
+def test_authoritative_no_overlap_or_error_shows_table():
+    pipeline_summary = {
+        "entity-organisation": [
+            {
+                "dataset": "nature-improvement-area",
+                "entity-minimum": 10100002,
+                "entity-maximum": 10100002,
+                "organisation": "government-organisation:PB202",
+                "overlap": False,
+                "error": False,
+            }
+        ]
+    }
+
+    (
+        table_params,
+        has_entity_org,
+        warning,
+        overlap_info,
         error_warning,
     ) = _build_entity_organisation_summary(NEW_ENTITIES, True, pipeline_summary)
 
     assert has_entity_org is True
     assert table_params is not None
     assert warning is None
-    assert overlap_warning is None
-    assert error_warning == (
-        "An error occurred creating the entity-organisation csv, "
-        "please re-run if you believe this is required"
-    )
+    assert overlap_info is None
+    assert error_warning is None
 
 
 def test_authoritative_no_entity_organisation_data_hides_section():

--- a/tests/unit/blueprints/datamanager/controllers/test_preview.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_preview.py
@@ -19,7 +19,9 @@ def test_non_authoritative_is_informational_only():
         warning,
         overlap_info,
         error_warning,
-    ) = _build_entity_organisation_summary(NEW_ENTITIES, False, {"entity-organisation": []})
+    ) = _build_entity_organisation_summary(
+        NEW_ENTITIES, False, {"entity-organisation": []}
+    )
 
     assert table_params is None
     assert has_entity_org is False

--- a/tests/unit/blueprints/datamanager/controllers/test_preview.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_preview.py
@@ -1,0 +1,100 @@
+from application.blueprints.datamanager.controllers.preview import (
+    _build_entity_organisation_summary,
+)
+
+NEW_ENTITIES = [{"entity": "10100002", "reference": "REF001"}]
+
+
+def test_no_new_entities_hides_section():
+    result = _build_entity_organisation_summary([], True, {"entity-organisation": []})
+
+    assert result == (None, False, None, None, None)
+
+
+def test_non_authoritative_is_informational_only():
+    """Non-authoritative just flags the data as such - nothing needs to be created."""
+    (
+        table_params,
+        has_entity_org,
+        warning,
+        overlap_warning,
+        error_warning,
+    ) = _build_entity_organisation_summary(NEW_ENTITIES, False, {"entity-organisation": []})
+
+    assert table_params is None
+    assert has_entity_org is False
+    assert warning == "Non-authoritative data being submitted"
+    assert overlap_warning is None
+    assert error_warning is None
+
+
+def test_authoritative_overlap_shows_table_and_overlap_warning():
+    pipeline_summary = {
+        "entity-organisation": [
+            {
+                "dataset": "nature-improvement-area",
+                "entity-minimum": 10100002,
+                "entity-maximum": 10100002,
+                "organisation": "government-organisation:PB202",
+                "overlap": True,
+                "error": False,
+            }
+        ]
+    }
+
+    (
+        table_params,
+        has_entity_org,
+        warning,
+        overlap_warning,
+        error_warning,
+    ) = _build_entity_organisation_summary(NEW_ENTITIES, True, pipeline_summary)
+
+    assert has_entity_org is True
+    assert table_params is not None
+    assert warning is None
+    assert overlap_warning == (
+        "Entity org range mapping already assigned for these new "
+        "entities - likely a single source dataset"
+    )
+    assert error_warning is None
+
+
+def test_authoritative_error_shows_table_and_error_warning():
+    pipeline_summary = {
+        "entity-organisation": [
+            {
+                "dataset": "nature-improvement-area",
+                "entity-minimum": 10100002,
+                "entity-maximum": 10100002,
+                "organisation": "government-organisation:PB202",
+                "overlap": False,
+                "error": True,
+            }
+        ]
+    }
+
+    (
+        table_params,
+        has_entity_org,
+        warning,
+        overlap_warning,
+        error_warning,
+    ) = _build_entity_organisation_summary(NEW_ENTITIES, True, pipeline_summary)
+
+    assert has_entity_org is True
+    assert table_params is not None
+    assert warning is None
+    assert overlap_warning is None
+    assert error_warning == (
+        "An error occurred creating the entity-organisation csv, "
+        "please re-run if you believe this is required"
+    )
+
+
+def test_authoritative_no_entity_organisation_data_hides_section():
+    result = _build_entity_organisation_summary(
+        NEW_ENTITIES, True, {"entity-organisation": []}
+    )
+
+    assert result == (None, False, None, None, None)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Updates the entity-organisation CSV preview to match the new `overlap`/`error` flags returned by the async-request-backend:

- No new entities → entity-org section is hidden entirely.
- Non-authoritative data → informational message shown (nothing needs to be created).
- Overlap detected (entities already covered by an existing range) → informational banner "Entity org already exists - no action needed", table not shown.
- Error loading `entity-organisation.csv` on the backend → error message shown, table not shown.
- Otherwise → entity-organisation table renders as before.

## Related Tickets & Documents

- Ticket Link: 2765
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Entity Organisation CSV in Preview:

- No new entities = no render.
- New entities = Renders entity org table as before
- Overlap Detected =

<img width="1014" height="368" alt="image" src="https://github.com/user-attachments/assets/4b30b6db-6785-489b-83ea-d56d41fc5c6e" />
- Error in Creating/Accessing file =

Warning Message Flags instead

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] Are there any dependencies on other PRs or Work?

Depends on digital-land/async-request-backend#124 for the `overlap`/`error` fields in the pipeline-summary response.
