### PR TITLE
Refactor Assign Entities workflow and update related documentation

### DIFF
--- a/application/blueprints/datamanager/controllers/flagged_resources.py
+++ b/application/blueprints/datamanager/controllers/flagged_resources.py
@@ -348,7 +348,12 @@ def _get_resource_organisation(resource, dataset_id):
 
 
 def _submit_assign_entities_request(
-    dataset_input, resource, organisation=None, return_endpoint=None
+    dataset_input,
+    resource,
+    organisation=None,
+    return_endpoint=None,
+    selected_entities=None,
+    selected_redirects=None,
 ):
     dataset_id, collection_id = _resolve_dataset_and_collection(dataset_input)
     organisation = organisation or _get_resource_organisation(resource, dataset_id)
@@ -365,6 +370,10 @@ def _submit_assign_entities_request(
         params["organisation"] = organisation
     if return_endpoint:
         params["return_endpoint"] = return_endpoint
+    if selected_entities is not None:
+        params["selected_entities"] = selected_entities
+    if selected_redirects is not None:
+        params["selected_redirects"] = selected_redirects
     preview_id = submit_request(params)
     record_branch_baseline(preview_id, params["github_branch"])
     return preview_id

--- a/application/blueprints/datamanager/controllers/flagged_resources.py
+++ b/application/blueprints/datamanager/controllers/flagged_resources.py
@@ -352,7 +352,7 @@ def _submit_assign_entities_request(
     resource,
     organisation=None,
     return_endpoint=None,
-    selected_entities=None,
+    excluded_references=None,
     selected_redirects=None,
 ):
     dataset_id, collection_id = _resolve_dataset_and_collection(dataset_input)
@@ -370,8 +370,8 @@ def _submit_assign_entities_request(
         params["organisation"] = organisation
     if return_endpoint:
         params["return_endpoint"] = return_endpoint
-    if selected_entities is not None:
-        params["selected_entities"] = selected_entities
+    if excluded_references is not None:
+        params["excluded_references"] = excluded_references
     if selected_redirects is not None:
         params["selected_redirects"] = selected_redirects
     preview_id = submit_request(params)

--- a/application/blueprints/datamanager/controllers/preview.py
+++ b/application/blueprints/datamanager/controllers/preview.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from datetime import date
 
 from flask import (
     render_template,
@@ -102,8 +101,8 @@ def _load_json_list(value: str | None) -> list:
     return loaded if isinstance(loaded, list) else []
 
 
-def build_old_entity_redirect_table(entity_redirects: list[dict]) -> dict | None:
-    if not entity_redirects:
+def build_old_entity_redirect_table(old_entity_rows: list[dict]) -> dict | None:
+    if not old_entity_rows:
         return None
 
     columns = [
@@ -115,22 +114,30 @@ def build_old_entity_redirect_table(entity_redirects: list[dict]) -> dict | None
         "entry-date",
         "start-date",
     ]
-    entry_date = date.today().isoformat()
     rows = []
-    for redirect in entity_redirects:
+    for old_entity in old_entity_rows:
+        if not isinstance(old_entity, dict):
+            continue
         row = {
-            "old-entity": str(redirect.get("old_entity", "")),
-            "status": "301",
-            "entity": str(redirect.get("entity", "")),
-            "notes": str(
-                redirect.get("notes")
-                or "Redirect duplicate entity selected in Assign Entities"
+            "old-entity": str(
+                old_entity.get("old-entity", "") or old_entity.get("old_entity", "")
             ),
-            "end-date": "",
-            "entry-date": entry_date,
-            "start-date": "",
+            "status": str(old_entity.get("status", "")),
+            "entity": str(old_entity.get("entity", "")),
+            "notes": str(old_entity.get("notes", "")),
+            "end-date": str(
+                old_entity.get("end-date", "") or old_entity.get("end_date", "")
+            ),
+            "entry-date": str(
+                old_entity.get("entry-date", "") or old_entity.get("entry_date", "")
+            ),
+            "start-date": str(
+                old_entity.get("start-date", "") or old_entity.get("start_date", "")
+            ),
         }
         rows.append({"columns": {c: {"value": row[c]} for c in columns}})
+    if not rows:
+        return None
 
     return {
         "columns": columns,
@@ -260,10 +267,13 @@ def handle_entities_preview(request_id, req):
     endpoints_to_retire = (
         _load_json_list(request_meta.endpoints_to_retire) if request_meta else []
     )
-    entity_redirects = (
-        _load_json_list(request_meta.entity_redirects) if request_meta else []
+    old_entity_rows = pipeline_summary.get("old-entity") or []
+    old_entity_redirect_table_params = build_old_entity_redirect_table(old_entity_rows)
+    old_entity_redirect_count = (
+        len(old_entity_redirect_table_params["rows"])
+        if old_entity_redirect_table_params
+        else 0
     )
-    old_entity_redirect_table_params = build_old_entity_redirect_table(entity_redirects)
     existing_endpoints = (
         source_summary_data.get("existing_endpoint_for_organisation_dataset") or []
     )
@@ -306,9 +316,9 @@ def handle_entities_preview(request_id, req):
         source_flow=source_flow,
         return_url=return_url,
         retire_summary=retire_summary,
-        entity_redirects=entity_redirects,
         old_entity_redirect_table_params=old_entity_redirect_table_params,
-        new_count=int(pipeline_summary.get("new-in-resource") or 0),
+        old_entity_redirect_count=old_entity_redirect_count,
+        new_count=len(new_entities),
         existing_count=int(pipeline_summary.get("existing-in-resource") or 0),
         endpoint_already_exists=endpoint_already_exists,
         endpoint_url=endpoint_url,
@@ -336,9 +346,6 @@ def handle_add_data_confirm(
     request_meta = db.session.get(RequestMeta, request_id)
     endpoints_to_retire = (
         _load_json_list(request_meta.endpoints_to_retire) if request_meta else []
-    )
-    entity_redirects = (
-        _load_json_list(request_meta.entity_redirects) if request_meta else []
     )
 
     # Stale-assessment guard: if the config branch has advanced for this collection
@@ -386,7 +393,6 @@ def handle_add_data_confirm(
             triggered_by=f"{session.get('user', {}).get('login', 'unknown')}",
             github_branch=github_branch,
             endpoints_to_retire=endpoints_to_retire,
-            entity_redirects=entity_redirects,
         )
     except GitHubWorkflowError as e:
         logger.exception(f"GitHub async workflow error: {e}")

--- a/application/blueprints/datamanager/controllers/preview.py
+++ b/application/blueprints/datamanager/controllers/preview.py
@@ -101,6 +101,15 @@ def _load_json_list(value: str | None) -> list:
     return loaded if isinstance(loaded, list) else []
 
 
+def _count_excluded_references(params: dict) -> int:
+    references = params.get("excluded_references") or []
+    if not isinstance(references, list):
+        return 0
+    return len(
+        {str(reference).strip() for reference in references if str(reference).strip()}
+    )
+
+
 def build_old_entity_redirect_table(old_entity_rows: list[dict]) -> dict | None:
     if not old_entity_rows:
         return None
@@ -319,6 +328,7 @@ def handle_entities_preview(request_id, req):
         old_entity_redirect_table_params=old_entity_redirect_table_params,
         old_entity_redirect_count=old_entity_redirect_count,
         new_count=len(new_entities),
+        excluded_count=_count_excluded_references(params),
         existing_count=int(pipeline_summary.get("existing-in-resource") or 0),
         endpoint_already_exists=endpoint_already_exists,
         endpoint_url=endpoint_url,

--- a/application/blueprints/datamanager/controllers/preview.py
+++ b/application/blueprints/datamanager/controllers/preview.py
@@ -122,9 +122,9 @@ def build_old_entity_redirect_table(old_entity_rows: list[dict]) -> dict | None:
             "old-entity": str(
                 old_entity.get("old-entity", "") or old_entity.get("old_entity", "")
             ),
-            "status": str(old_entity.get("status", "")),
-            "entity": str(old_entity.get("entity", "")),
-            "notes": str(old_entity.get("notes", "")),
+            "status": str(old_entity.get("status", "") or ""),
+            "entity": str(old_entity.get("entity", "") or ""),
+            "notes": str(old_entity.get("notes", "") or ""),
             "end-date": str(
                 old_entity.get("end-date", "") or old_entity.get("end_date", "")
             ),

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -220,66 +220,48 @@ def _build_entities_data(resp_details: list, platform_entities: list) -> dict:
     return {"columns": columns, "rows": rows}
 
 
-def _normalise_selected_entities(selected_entities) -> set:
-    """Return selected entity keys from async request params.
+def _normalise_excluded_references(excluded_references) -> set:
+    """Return explicitly excluded references from async request params.
 
-    A missing or empty param is handled by callers as "all new entities"; this
-    function returns only explicit organisation/reference selections.
+    A missing or empty param means no references were excluded from assignment.
     """
-    if not selected_entities:
+    if not excluded_references:
         return set()
-    if not isinstance(selected_entities, list):
+    if not isinstance(excluded_references, list):
         return set()
     return {
-        (
-            str(entity.get("organisation", "")).strip(),
-            str(entity.get("reference", "")).strip(),
-        )
-        for entity in selected_entities
-        if isinstance(entity, dict)
-        and entity.get("organisation")
-        and entity.get("reference")
+        str(reference).strip()
+        for reference in excluded_references
+        if str(reference).strip()
     }
 
 
-def _entity_selection_form_value(organisation: str, reference: str) -> str:
-    return json.dumps(
-        {
-            "organisation": organisation,
-            "reference": reference,
-        },
-        separators=(",", ":"),
-    )
+def _entity_selection_form_value(reference: str) -> str:
+    return reference
 
 
 def _add_assign_entities_selection_metadata(
     entities_data: dict,
-    organisation: str,
-    selected_entities,
+    excluded_references,
 ) -> dict:
     """Add checkbox metadata to Assign Entities rows.
 
-    Only rows categorised as new can be assigned entity numbers. If async did
-    not receive explicit selected_entities, every selectable new row starts
-    checked; otherwise only matching organisation/reference pairs start checked.
+    Only rows categorised as new can be assigned entity numbers. Async request
+    params contain references excluded from assignment, so every selectable row
+    starts checked unless its reference is explicitly excluded.
     """
-    selected_entity_keys = _normalise_selected_entities(selected_entities)
-    select_all_new = not selected_entity_keys
+    excluded_reference_set = _normalise_excluded_references(excluded_references)
 
     for row in entities_data.get("rows", []):
         fields = row.get("fields") or {}
         reference = str(fields.get("reference", "")).strip()
         can_select = row.get("category") == "new" and bool(reference)
-        selected = can_select and (
-            select_all_new or (organisation, reference) in selected_entity_keys
-        )
+        selected = can_select and reference not in excluded_reference_set
         row["entity_selection"] = {
             "can_select": can_select,
             "selected": selected,
             "form_value": (
-                _entity_selection_form_value(organisation, reference)
-                if reference
-                else ""
+                _entity_selection_form_value(reference) if reference else ""
             ),
         }
 
@@ -315,38 +297,23 @@ def _old_entity_redirect_key(row: dict) -> tuple[str, str]:
     )
 
 
-def _dedup_candidate_selected_entity_key(
-    candidate: dict, organisation: str
-) -> tuple[str, str]:
-    return (
-        str(
-            candidate.get("new_organisation")
-            or candidate.get("organisation")
-            or organisation
-            or ""
-        ).strip(),
-        str(
-            candidate.get("new_reference", "") or candidate.get("reference", "") or ""
-        ).strip(),
-    )
+def _dedup_candidate_selected_entity_reference(candidate: dict) -> str:
+    return str(
+        candidate.get("new_reference", "") or candidate.get("reference", "") or ""
+    ).strip()
 
 
-def _dedup_candidate_selected_redirect_key(
-    candidate: dict, organisation: str
-) -> tuple[str, str, str]:
+def _dedup_candidate_selected_redirect_key(candidate: dict) -> tuple[str, str]:
     """Return the key used to compare a Dedup candidate with selected_redirects."""
-    entity_key = _dedup_candidate_selected_entity_key(candidate, organisation)
     return (
-        entity_key[0],
-        entity_key[1],
+        _dedup_candidate_selected_entity_reference(candidate),
         str(candidate.get("old_entity", "") or "").strip(),
     )
 
 
-def _selected_redirect_key(redirect: dict) -> tuple[str, str, str]:
+def _selected_redirect_key(redirect: dict) -> tuple[str, str]:
     """Return the async selected_redirects key for a submitted redirect param."""
     return (
-        str(redirect.get("organisation", "") or "").strip(),
         str(redirect.get("reference", "") or "").strip(),
         str(
             redirect.get("old_entity_number", "")
@@ -379,7 +346,7 @@ def _prepare_duplicate_candidates(
     candidates: list[dict],
     old_entity_rows: list[dict] | None = None,
     organisation: str = "",
-    selected_entities=None,
+    excluded_references=None,
     selected_redirects=None,
 ) -> list[dict]:
     """Prepare Dedup candidates for rendering and selection.
@@ -403,8 +370,7 @@ def _prepare_duplicate_candidates(
         for redirect in (selected_redirects or [])
         if isinstance(redirect, dict) and all(_selected_redirect_key(redirect))
     }
-    selected_entity_keys = _normalise_selected_entities(selected_entities)
-    select_all_new = not selected_entity_keys
+    excluded_reference_set = _normalise_excluded_references(excluded_references)
     return [
         {
             **candidate,
@@ -412,13 +378,10 @@ def _prepare_duplicate_candidates(
             in preselected_redirects,
             "redirect_locked": _dedup_candidate_redirect_key(candidate)
             in preselected_redirects
-            and _dedup_candidate_selected_redirect_key(candidate, organisation)
+            and _dedup_candidate_selected_redirect_key(candidate)
             not in selected_redirect_keys,
-            "redirect_can_select": (
-                select_all_new
-                or _dedup_candidate_selected_entity_key(candidate, organisation)
-                in selected_entity_keys
-            ),
+            "redirect_can_select": _dedup_candidate_selected_entity_reference(candidate)
+            not in excluded_reference_set,
             "form_value": _dedup_candidate_form_value(candidate),
         }
         for candidate in candidates
@@ -476,8 +439,7 @@ def _paginate_entity_data(
     entity_search: str,
     entity_filter: str = "",
     include_selection: bool = False,
-    organisation: str = "",
-    selected_entities=None,
+    excluded_references=None,
 ) -> tuple:
     entity_start_offset = (entity_page - 1) * _ROWS_PER_PAGE
     entities_data_full = _build_entities_data(all_resp_details, platform_entities)
@@ -511,8 +473,7 @@ def _paginate_entity_data(
     if include_selection:
         entities_data = _add_assign_entities_selection_metadata(
             entities_data,
-            organisation,
-            selected_entities,
+            excluded_references,
         )
     return (
         entities_data,
@@ -766,7 +727,7 @@ def handle_check_transform(
     """
     params = req.get("params") or {}
     organisation_code = params.get("organisationName") or params.get("organisation", "")
-    selected_entities = params.get("selected_entities")
+    excluded_references = params.get("excluded_references")
     dataset_id = params.get("dataset", "")
     is_assign_entities = transform_endpoint == "assign_entities.flagged_resource_detail"
     resource_hash = params.get("resource", "")
@@ -816,7 +777,7 @@ def handle_check_transform(
         pipeline_summary.get("duplicate-candidates") or [] if show_dedup_tab else [],
         pipeline_summary.get("old-entity") or [],
         organisation=organisation_code,
-        selected_entities=selected_entities,
+        excluded_references=excluded_references,
         selected_redirects=params.get("selected_redirects"),
     )
 
@@ -847,8 +808,7 @@ def handle_check_transform(
         entity_search,
         entity_filter,
         include_selection=is_assign_entities,
-        organisation=organisation_code,
-        selected_entities=selected_entities,
+        excluded_references=excluded_references,
     )
     transformed_table = _build_transform_table(resp_details)
     issue_log_table = _build_issue_log_table(resp_details)

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -539,10 +539,7 @@ def _paginate_entity_data(
 ) -> tuple:
     entity_start_offset = (entity_page - 1) * _ROWS_PER_PAGE
     entities_data_full = _build_entities_data(all_resp_details, platform_entities)
-    if include_selection:
-        entities_data_full = _add_all_entity_candidates(
-            entities_data_full, all_entities or []
-        )
+
     # Counts cover every entity, independent of the current search/filter, so the
     # summary boxes always show the full picture.
     category_counts = _count_categories(entities_data_full["rows"])

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -220,63 +220,6 @@ def _build_entities_data(resp_details: list, platform_entities: list) -> dict:
     return {"columns": columns, "rows": rows}
 
 
-def _entity_candidate_reference_key(entity: dict) -> tuple:
-    return (
-        str(entity.get("organisation", "")).strip(),
-        str(entity.get("reference", "")).strip(),
-    )
-
-
-def _add_all_entity_candidates(entities_data: dict, all_entities: list) -> dict:
-    if not all_entities:
-        return entities_data
-
-    columns = list(entities_data.get("columns") or [])
-    for priority_col in _ENTITY_COL_PRIORITY:
-        if priority_col not in columns:
-            columns.append(priority_col)
-    for entity in all_entities:
-        if not isinstance(entity, dict):
-            continue
-        for col in entity:
-            if col not in _ENTITY_COL_EXCLUDE and col not in columns:
-                columns.append(col)
-
-    existing_entity_ids = {
-        _normalise_entity_id((row.get("fields") or {}).get("entity", ""))
-        for row in entities_data.get("rows", [])
-        if _normalise_entity_id((row.get("fields") or {}).get("entity", ""))
-    }
-    existing_reference_keys = {
-        _entity_candidate_reference_key(row.get("fields") or {})
-        for row in entities_data.get("rows", [])
-        if all(_entity_candidate_reference_key(row.get("fields") or {}))
-    }
-    rows = list(entities_data.get("rows", []))
-    for entity in all_entities:
-        if not isinstance(entity, dict):
-            continue
-        entity_id = _normalise_entity_id(entity.get("entity", ""))
-        reference_key = _entity_candidate_reference_key(entity)
-        if entity_id and entity_id in existing_entity_ids:
-            continue
-        if all(reference_key) and reference_key in existing_reference_keys:
-            continue
-        rows.append(
-            {
-                "fields": {col: str(entity.get(col, "")) for col in columns},
-                "category": "new",
-                "changed_fields": {},
-            }
-        )
-        if entity_id:
-            existing_entity_ids.add(entity_id)
-        if all(reference_key):
-            existing_reference_keys.add(reference_key)
-
-    return {"columns": columns, "rows": rows}
-
-
 def _normalise_selected_entities(selected_entities) -> set:
     """Return selected entity keys from async request params.
 
@@ -535,7 +478,6 @@ def _paginate_entity_data(
     include_selection: bool = False,
     organisation: str = "",
     selected_entities=None,
-    all_entities=None,
 ) -> tuple:
     entity_start_offset = (entity_page - 1) * _ROWS_PER_PAGE
     entities_data_full = _build_entities_data(all_resp_details, platform_entities)
@@ -869,7 +811,6 @@ def handle_check_transform(
     existing_endpoints = _resolve_existing_endpoints(source_summary)
     pipelines_append_required = source_summary.get("pipelines_append_required")
     pipeline_summary = response_data.get("pipeline-summary") or {}
-    all_entities = pipeline_summary.get("all-entities") or []
     show_dedup_tab = is_assign_entities and dataset_id == "conservation-area"
     duplicate_candidates = _prepare_duplicate_candidates(
         pipeline_summary.get("duplicate-candidates") or [] if show_dedup_tab else [],
@@ -908,7 +849,6 @@ def handle_check_transform(
         include_selection=is_assign_entities,
         organisation=organisation_code,
         selected_entities=selected_entities,
-        all_entities=all_entities,
     )
     transformed_table = _build_transform_table(resp_details)
     issue_log_table = _build_issue_log_table(resp_details)

--- a/application/blueprints/datamanager/controllers/transform.py
+++ b/application/blueprints/datamanager/controllers/transform.py
@@ -220,6 +220,129 @@ def _build_entities_data(resp_details: list, platform_entities: list) -> dict:
     return {"columns": columns, "rows": rows}
 
 
+def _entity_candidate_reference_key(entity: dict) -> tuple:
+    return (
+        str(entity.get("organisation", "")).strip(),
+        str(entity.get("reference", "")).strip(),
+    )
+
+
+def _add_all_entity_candidates(entities_data: dict, all_entities: list) -> dict:
+    if not all_entities:
+        return entities_data
+
+    columns = list(entities_data.get("columns") or [])
+    for priority_col in _ENTITY_COL_PRIORITY:
+        if priority_col not in columns:
+            columns.append(priority_col)
+    for entity in all_entities:
+        if not isinstance(entity, dict):
+            continue
+        for col in entity:
+            if col not in _ENTITY_COL_EXCLUDE and col not in columns:
+                columns.append(col)
+
+    existing_entity_ids = {
+        _normalise_entity_id((row.get("fields") or {}).get("entity", ""))
+        for row in entities_data.get("rows", [])
+        if _normalise_entity_id((row.get("fields") or {}).get("entity", ""))
+    }
+    existing_reference_keys = {
+        _entity_candidate_reference_key(row.get("fields") or {})
+        for row in entities_data.get("rows", [])
+        if all(_entity_candidate_reference_key(row.get("fields") or {}))
+    }
+    rows = list(entities_data.get("rows", []))
+    for entity in all_entities:
+        if not isinstance(entity, dict):
+            continue
+        entity_id = _normalise_entity_id(entity.get("entity", ""))
+        reference_key = _entity_candidate_reference_key(entity)
+        if entity_id and entity_id in existing_entity_ids:
+            continue
+        if all(reference_key) and reference_key in existing_reference_keys:
+            continue
+        rows.append(
+            {
+                "fields": {col: str(entity.get(col, "")) for col in columns},
+                "category": "new",
+                "changed_fields": {},
+            }
+        )
+        if entity_id:
+            existing_entity_ids.add(entity_id)
+        if all(reference_key):
+            existing_reference_keys.add(reference_key)
+
+    return {"columns": columns, "rows": rows}
+
+
+def _normalise_selected_entities(selected_entities) -> set:
+    """Return selected entity keys from async request params.
+
+    A missing or empty param is handled by callers as "all new entities"; this
+    function returns only explicit organisation/reference selections.
+    """
+    if not selected_entities:
+        return set()
+    if not isinstance(selected_entities, list):
+        return set()
+    return {
+        (
+            str(entity.get("organisation", "")).strip(),
+            str(entity.get("reference", "")).strip(),
+        )
+        for entity in selected_entities
+        if isinstance(entity, dict)
+        and entity.get("organisation")
+        and entity.get("reference")
+    }
+
+
+def _entity_selection_form_value(organisation: str, reference: str) -> str:
+    return json.dumps(
+        {
+            "organisation": organisation,
+            "reference": reference,
+        },
+        separators=(",", ":"),
+    )
+
+
+def _add_assign_entities_selection_metadata(
+    entities_data: dict,
+    organisation: str,
+    selected_entities,
+) -> dict:
+    """Add checkbox metadata to Assign Entities rows.
+
+    Only rows categorised as new can be assigned entity numbers. If async did
+    not receive explicit selected_entities, every selectable new row starts
+    checked; otherwise only matching organisation/reference pairs start checked.
+    """
+    selected_entity_keys = _normalise_selected_entities(selected_entities)
+    select_all_new = not selected_entity_keys
+
+    for row in entities_data.get("rows", []):
+        fields = row.get("fields") or {}
+        reference = str(fields.get("reference", "")).strip()
+        can_select = row.get("category") == "new" and bool(reference)
+        selected = can_select and (
+            select_all_new or (organisation, reference) in selected_entity_keys
+        )
+        row["entity_selection"] = {
+            "can_select": can_select,
+            "selected": selected,
+            "form_value": (
+                _entity_selection_form_value(organisation, reference)
+                if reference
+                else ""
+            ),
+        }
+
+    return entities_data
+
+
 def _entity_row_matches_search(row: dict, search_query: str) -> bool:
     if not search_query:
         return True
@@ -235,26 +358,59 @@ def _entity_row_matches_filter(row: dict, category_filter: str) -> bool:
     return row.get("category") == category_filter
 
 
-def _name_similarity_percent(value) -> float:
-    if value in (None, ""):
-        return 0
-    try:
-        similarity = float(str(value).strip().rstrip("%"))
-    except (TypeError, ValueError):
-        return 0
-    return similarity * 100 if 0 < similarity <= 1 else similarity
+def _dedup_candidate_redirect_key(candidate: dict) -> tuple[str, str]:
+    return (
+        str(candidate.get("old_entity", "") or "").strip(),
+        str(candidate.get("entity", "") or "").strip(),
+    )
 
 
-def _dedup_candidate_auto_select(candidate: dict) -> bool:
-    if candidate.get("old_entity_redirects"):
-        return False
+def _old_entity_redirect_key(row: dict) -> tuple[str, str]:
+    return (
+        str(row.get("old-entity", "") or row.get("old_entity", "") or "").strip(),
+        str(row.get("entity", "") or "").strip(),
+    )
 
-    match_type = str(candidate.get("match_type", "")).replace(" ", "_").lower()
-    if match_type == "complete_match":
-        return True
-    if match_type != "single_match":
-        return False
-    return _name_similarity_percent(candidate.get("name_similarity")) > 85
+
+def _dedup_candidate_selected_entity_key(
+    candidate: dict, organisation: str
+) -> tuple[str, str]:
+    return (
+        str(
+            candidate.get("new_organisation")
+            or candidate.get("organisation")
+            or organisation
+            or ""
+        ).strip(),
+        str(
+            candidate.get("new_reference", "") or candidate.get("reference", "") or ""
+        ).strip(),
+    )
+
+
+def _dedup_candidate_selected_redirect_key(
+    candidate: dict, organisation: str
+) -> tuple[str, str, str]:
+    """Return the key used to compare a Dedup candidate with selected_redirects."""
+    entity_key = _dedup_candidate_selected_entity_key(candidate, organisation)
+    return (
+        entity_key[0],
+        entity_key[1],
+        str(candidate.get("old_entity", "") or "").strip(),
+    )
+
+
+def _selected_redirect_key(redirect: dict) -> tuple[str, str, str]:
+    """Return the async selected_redirects key for a submitted redirect param."""
+    return (
+        str(redirect.get("organisation", "") or "").strip(),
+        str(redirect.get("reference", "") or "").strip(),
+        str(
+            redirect.get("old_entity_number", "")
+            or redirect.get("old_entity", "")
+            or ""
+        ).strip(),
+    )
 
 
 def _dedup_candidate_form_value(candidate: dict) -> str:
@@ -276,11 +432,50 @@ def _dedup_candidate_form_value(candidate: dict) -> str:
     )
 
 
-def _prepare_duplicate_candidates(candidates: list[dict]) -> list[dict]:
+def _prepare_duplicate_candidates(
+    candidates: list[dict],
+    old_entity_rows: list[dict] | None = None,
+    organisation: str = "",
+    selected_entities=None,
+    selected_redirects=None,
+) -> list[dict]:
+    """Prepare Dedup candidates for rendering and selection.
+
+    Async's ``pipeline-summary.old-entity`` is the source of initial redirect
+    preselection. Rows present in old-entity but absent from request
+    ``selected_redirects`` are inferred to be async auto-selected and are locked
+    in the UI so users cannot untick redirects generated by async policy.
+    """
+    preselected_redirects = {
+        key
+        for key in (
+            _old_entity_redirect_key(row)
+            for row in (old_entity_rows or [])
+            if isinstance(row, dict)
+        )
+        if all(key)
+    }
+    selected_redirect_keys = {
+        _selected_redirect_key(redirect)
+        for redirect in (selected_redirects or [])
+        if isinstance(redirect, dict) and all(_selected_redirect_key(redirect))
+    }
+    selected_entity_keys = _normalise_selected_entities(selected_entities)
+    select_all_new = not selected_entity_keys
     return [
         {
             **candidate,
-            "auto_select": _dedup_candidate_auto_select(candidate),
+            "auto_select": _dedup_candidate_redirect_key(candidate)
+            in preselected_redirects,
+            "redirect_locked": _dedup_candidate_redirect_key(candidate)
+            in preselected_redirects
+            and _dedup_candidate_selected_redirect_key(candidate, organisation)
+            not in selected_redirect_keys,
+            "redirect_can_select": (
+                select_all_new
+                or _dedup_candidate_selected_entity_key(candidate, organisation)
+                in selected_entity_keys
+            ),
             "form_value": _dedup_candidate_form_value(candidate),
         }
         for candidate in candidates
@@ -337,9 +532,17 @@ def _paginate_entity_data(
     entity_page: int,
     entity_search: str,
     entity_filter: str = "",
+    include_selection: bool = False,
+    organisation: str = "",
+    selected_entities=None,
+    all_entities=None,
 ) -> tuple:
     entity_start_offset = (entity_page - 1) * _ROWS_PER_PAGE
     entities_data_full = _build_entities_data(all_resp_details, platform_entities)
+    if include_selection:
+        entities_data_full = _add_all_entity_candidates(
+            entities_data_full, all_entities or []
+        )
     # Counts cover every entity, independent of the current search/filter, so the
     # summary boxes always show the full picture.
     category_counts = _count_categories(entities_data_full["rows"])
@@ -366,6 +569,12 @@ def _paginate_entity_data(
         "columns": entities_data_full["columns"],
         "rows": entity_page_rows,
     }
+    if include_selection:
+        entities_data = _add_assign_entities_selection_metadata(
+            entities_data,
+            organisation,
+            selected_entities,
+        )
     return (
         entities_data,
         has_next_entity_page,
@@ -618,6 +827,7 @@ def handle_check_transform(
     """
     params = req.get("params") or {}
     organisation_code = params.get("organisationName") or params.get("organisation", "")
+    selected_entities = params.get("selected_entities")
     dataset_id = params.get("dataset", "")
     is_assign_entities = transform_endpoint == "assign_entities.flagged_resource_detail"
     resource_hash = params.get("resource", "")
@@ -662,9 +872,14 @@ def handle_check_transform(
     existing_endpoints = _resolve_existing_endpoints(source_summary)
     pipelines_append_required = source_summary.get("pipelines_append_required")
     pipeline_summary = response_data.get("pipeline-summary") or {}
+    all_entities = pipeline_summary.get("all-entities") or []
     show_dedup_tab = is_assign_entities and dataset_id == "conservation-area"
     duplicate_candidates = _prepare_duplicate_candidates(
-        pipeline_summary.get("duplicate-candidates") or [] if show_dedup_tab else []
+        pipeline_summary.get("duplicate-candidates") or [] if show_dedup_tab else [],
+        pipeline_summary.get("old-entity") or [],
+        organisation=organisation_code,
+        selected_entities=selected_entities,
+        selected_redirects=params.get("selected_redirects"),
     )
 
     # Calculate pagination for transformed facts and issue logs, and for entities.
@@ -693,6 +908,10 @@ def handle_check_transform(
         entity_page,
         entity_search,
         entity_filter,
+        include_selection=is_assign_entities,
+        organisation=organisation_code,
+        selected_entities=selected_entities,
+        all_entities=all_entities,
     )
     transformed_table = _build_transform_table(resp_details)
     issue_log_table = _build_issue_log_table(resp_details)
@@ -746,6 +965,7 @@ def handle_check_transform(
         endpoint_url=endpoint_url,
         documentation_url=documentation_url,
         resource_hash=resource_hash,
+        is_assign_entities=is_assign_entities,
         show_dedup_tab=show_dedup_tab,
         duplicate_candidates=duplicate_candidates,
         planning_entity_base_url=(

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -312,139 +312,59 @@ def flagged_resource_detail(request_id):
         return render_template("datamanager/error.html", message=e.message)
 
 
-def _selected_entity_key(entity):
-    """Return the Assign Entities selection identity for an entity row."""
-    return (
-        str(entity.get("organisation", "")).strip(),
-        str(entity.get("reference", "")).strip(),
-    )
-
-
-def _parse_selected_entities(values, new_entities):
-    """Validate submitted entity checkbox values against async candidate rows.
-
-    The browser submits JSON values with only organisation and reference. Those
-    values are accepted only when the same pair exists in the current async
-    response, so hidden/form tampering cannot add extra references.
-    """
-    valid_entities_by_key = {}
-    for entity in new_entities:
-        if not isinstance(entity, dict):
-            continue
-        key = _selected_entity_key(entity)
-        if all(key):
-            valid_entities_by_key.setdefault(
-                key,
-                {
-                    "organisation": key[0],
-                    "reference": key[1],
-                },
-            )
-
-    selected = []
+def _normalise_reference_values(values):
+    """Return submitted reference values as a de-duplicated, ordered list."""
+    references = []
     seen = set()
-    for value in values:
-        try:
-            submitted = json.loads(value)
-        except (TypeError, json.JSONDecodeError):
+    for value in values or []:
+        reference = str(value or "").strip()
+        if not reference or reference in seen:
             continue
-        if not isinstance(submitted, dict):
-            continue
-        key = _selected_entity_key(submitted)
-        if key not in valid_entities_by_key or key in seen:
-            continue
-        selected.append(valid_entities_by_key[key])
-        seen.add(key)
-
-    return selected, list(valid_entities_by_key.values())
+        references.append(reference)
+        seen.add(reference)
+    return references
 
 
-def _current_selected_entities(current_selected_entities, all_entities):
-    """Expand request-param selected_entities into the current candidate rows."""
-    if not current_selected_entities:
-        return all_entities
-
-    current_keys = {
-        _selected_entity_key(entity)
-        for entity in current_selected_entities
-        if isinstance(entity, dict)
-    }
-    return [
-        entity
-        for entity in all_entities
-        if _selected_entity_key(entity) in current_keys
-    ]
-
-
-def _merge_visible_selected_entities(
-    current_entities, visible_entities, selected_visible
+def _merge_visible_excluded_references(
+    current_excluded_references,
+    visible_references,
+    selected_visible_references,
 ):
-    """Merge current full selection with selections from the visible page.
-
-    Entity search and pagination mean the browser only posts rows rendered on
-    the current page. This keeps selections from other pages/search states and
-    replaces only the visible subset with the user's latest checkbox state.
-    """
-    visible_keys = {_selected_entity_key(entity) for entity in visible_entities}
-    selected_visible_keys = {
-        _selected_entity_key(entity) for entity in selected_visible
-    }
-    selected_keys = {
-        _selected_entity_key(entity)
-        for entity in current_entities
-        if _selected_entity_key(entity) not in visible_keys
-    } | selected_visible_keys
-    merged = []
-    seen = set()
-    for entity in current_entities + selected_visible:
-        key = _selected_entity_key(entity)
-        if key in selected_keys and key not in seen:
-            merged.append(entity)
-            seen.add(key)
-    return merged
+    """Merge current exclusions with checkbox state from the visible page."""
+    current_excluded = set(_normalise_reference_values(current_excluded_references))
+    visible = set(_normalise_reference_values(visible_references))
+    selected_visible = set(_normalise_reference_values(selected_visible_references))
+    excluded = (current_excluded - visible) | (visible - selected_visible)
+    return sorted(excluded)
 
 
-def _selected_redirects_for_async(redirects, organisation, selected_entities=None):
+def _selected_redirects_for_async(redirects, excluded_references=None):
     """Map validated Dedup rows to async selected_redirects params.
 
     Config-manager's Dedup form values use old/new entity field names, while
-    async expects ``organisation``, ``reference`` and ``old_entity_number``.
-    When selected_entities is supplied, redirects for unselected entities are
-    dropped because async can only redirect entities being assigned.
+    async expects ``reference`` and ``old_entity_number``. Redirects for
+    explicitly excluded references are dropped because async can only redirect
+    entities being assigned.
     """
-    selected_entity_keys = (
-        {_selected_entity_key(entity) for entity in selected_entities}
-        if selected_entities is not None
-        else None
-    )
+    excluded_references = set(_normalise_reference_values(excluded_references))
     selected_redirects = []
     seen = set()
     for redirect_row in redirects:
         reference = str(
             redirect_row.get("new_reference") or redirect_row.get("reference") or ""
         ).strip()
-        redirect_organisation = str(
-            redirect_row.get("new_organisation")
-            or redirect_row.get("organisation")
-            or organisation
-            or ""
-        ).strip()
         old_entity_number = str(
             redirect_row.get("old_entity")
             or redirect_row.get("old_entity_number")
             or ""
         ).strip()
-        if (
-            selected_entity_keys is not None
-            and (redirect_organisation, reference) not in selected_entity_keys
-        ):
+        if reference in excluded_references:
             continue
-        key = (redirect_organisation, reference, old_entity_number)
+        key = (reference, old_entity_number)
         if not all(key) or key in seen:
             continue
         selected_redirects.append(
             {
-                "organisation": redirect_organisation,
                 "reference": reference,
                 "old_entity_number": old_entity_number,
             }
@@ -463,28 +383,12 @@ def flagged_resource_detail_post(request_id):
     redirects = parse_selected_redirects(
         request.form.getlist("entity_redirects"), duplicate_candidates
     )
-    selectable_entities = (
-        pipeline_summary.get("all-entities")
-        or pipeline_summary.get("new-entities")
-        or []
-    )
-    selected_entities, all_selectable_entities = _parse_selected_entities(
-        request.form.getlist("selected_entities"), selectable_entities
-    )
     if request.form.get("entity_selection_changed") == "true":
-        visible_entities, _ = _parse_selected_entities(
-            request.form.getlist("visible_selected_entities"), selectable_entities
+        excluded_references = _merge_visible_excluded_references(
+            params.get("excluded_references") or [],
+            request.form.getlist("visible_entity_references"),
+            request.form.getlist("selected_entity_references"),
         )
-        current_entities = _current_selected_entities(
-            params.get("selected_entities"), all_selectable_entities
-        )
-        selected_entities = _merge_visible_selected_entities(
-            current_entities, visible_entities, selected_entities
-        )
-        if not selected_entities:
-            raise ControllerError(
-                "Select at least one new entity. The async service treats an empty selection as selecting all entities."
-            )
         try:
             new_request_id = _submit_assign_entities_request(
                 params.get("dataset", ""),
@@ -492,9 +396,9 @@ def flagged_resource_detail_post(request_id):
                 organisation=organisation,
                 return_endpoint=params.get("return_endpoint")
                 or "assign_entities.flagged_resources_start",
-                selected_entities=selected_entities,
+                excluded_references=excluded_references,
                 selected_redirects=_selected_redirects_for_async(
-                    redirects, organisation, selected_entities
+                    redirects, excluded_references
                 ),
             )
         except AsyncAPIError as e:

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -411,16 +411,6 @@ def flagged_resource_detail_post(request_id):
             )
         )
 
-    meta = db.session.get(RequestMeta, request_id)
-    if meta is None:
-        meta = RequestMeta(
-            request_id=request_id,
-            entity_redirects=json.dumps(redirects),
-        )
-        db.session.add(meta)
-    else:
-        meta.entity_redirects = json.dumps(redirects)
-    db.session.commit()
     return redirect(url_for("datamanager.entities_preview", request_id=request_id))
 
 

--- a/application/blueprints/datamanager/router.py
+++ b/application/blueprints/datamanager/router.py
@@ -25,6 +25,7 @@ from .controllers.form import (
 )
 from .controllers.flagged_resources import (
     REQUIRED_COLUMNS,
+    _submit_assign_entities_request,
     handle_flagged_resource_detail,
     handle_flagged_resource_submit,
     handle_flagged_resources_import,
@@ -311,14 +312,201 @@ def flagged_resource_detail(request_id):
         return render_template("datamanager/error.html", message=e.message)
 
 
+def _selected_entity_key(entity):
+    """Return the Assign Entities selection identity for an entity row."""
+    return (
+        str(entity.get("organisation", "")).strip(),
+        str(entity.get("reference", "")).strip(),
+    )
+
+
+def _parse_selected_entities(values, new_entities):
+    """Validate submitted entity checkbox values against async candidate rows.
+
+    The browser submits JSON values with only organisation and reference. Those
+    values are accepted only when the same pair exists in the current async
+    response, so hidden/form tampering cannot add extra references.
+    """
+    valid_entities_by_key = {}
+    for entity in new_entities:
+        if not isinstance(entity, dict):
+            continue
+        key = _selected_entity_key(entity)
+        if all(key):
+            valid_entities_by_key.setdefault(
+                key,
+                {
+                    "organisation": key[0],
+                    "reference": key[1],
+                },
+            )
+
+    selected = []
+    seen = set()
+    for value in values:
+        try:
+            submitted = json.loads(value)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(submitted, dict):
+            continue
+        key = _selected_entity_key(submitted)
+        if key not in valid_entities_by_key or key in seen:
+            continue
+        selected.append(valid_entities_by_key[key])
+        seen.add(key)
+
+    return selected, list(valid_entities_by_key.values())
+
+
+def _current_selected_entities(current_selected_entities, all_entities):
+    """Expand request-param selected_entities into the current candidate rows."""
+    if not current_selected_entities:
+        return all_entities
+
+    current_keys = {
+        _selected_entity_key(entity)
+        for entity in current_selected_entities
+        if isinstance(entity, dict)
+    }
+    return [
+        entity
+        for entity in all_entities
+        if _selected_entity_key(entity) in current_keys
+    ]
+
+
+def _merge_visible_selected_entities(
+    current_entities, visible_entities, selected_visible
+):
+    """Merge current full selection with selections from the visible page.
+
+    Entity search and pagination mean the browser only posts rows rendered on
+    the current page. This keeps selections from other pages/search states and
+    replaces only the visible subset with the user's latest checkbox state.
+    """
+    visible_keys = {_selected_entity_key(entity) for entity in visible_entities}
+    selected_visible_keys = {
+        _selected_entity_key(entity) for entity in selected_visible
+    }
+    selected_keys = {
+        _selected_entity_key(entity)
+        for entity in current_entities
+        if _selected_entity_key(entity) not in visible_keys
+    } | selected_visible_keys
+    merged = []
+    seen = set()
+    for entity in current_entities + selected_visible:
+        key = _selected_entity_key(entity)
+        if key in selected_keys and key not in seen:
+            merged.append(entity)
+            seen.add(key)
+    return merged
+
+
+def _selected_redirects_for_async(redirects, organisation, selected_entities=None):
+    """Map validated Dedup rows to async selected_redirects params.
+
+    Config-manager's Dedup form values use old/new entity field names, while
+    async expects ``organisation``, ``reference`` and ``old_entity_number``.
+    When selected_entities is supplied, redirects for unselected entities are
+    dropped because async can only redirect entities being assigned.
+    """
+    selected_entity_keys = (
+        {_selected_entity_key(entity) for entity in selected_entities}
+        if selected_entities is not None
+        else None
+    )
+    selected_redirects = []
+    seen = set()
+    for redirect_row in redirects:
+        reference = str(
+            redirect_row.get("new_reference") or redirect_row.get("reference") or ""
+        ).strip()
+        redirect_organisation = str(
+            redirect_row.get("new_organisation")
+            or redirect_row.get("organisation")
+            or organisation
+            or ""
+        ).strip()
+        old_entity_number = str(
+            redirect_row.get("old_entity")
+            or redirect_row.get("old_entity_number")
+            or ""
+        ).strip()
+        if (
+            selected_entity_keys is not None
+            and (redirect_organisation, reference) not in selected_entity_keys
+        ):
+            continue
+        key = (redirect_organisation, reference, old_entity_number)
+        if not all(key) or key in seen:
+            continue
+        selected_redirects.append(
+            {
+                "organisation": redirect_organisation,
+                "reference": reference,
+                "old_entity_number": old_entity_number,
+            }
+        )
+        seen.add(key)
+    return selected_redirects
+
+
 def flagged_resource_detail_post(request_id):
     req = fetch_request(request_id)
+    params = req.get("params") or {}
     response_data = (req.get("response") or {}).get("data") or {}
     pipeline_summary = response_data.get("pipeline-summary") or {}
+    organisation = params.get("organisation") or params.get("organisationName") or None
     duplicate_candidates = pipeline_summary.get("duplicate-candidates") or []
     redirects = parse_selected_redirects(
         request.form.getlist("entity_redirects"), duplicate_candidates
     )
+    selectable_entities = (
+        pipeline_summary.get("all-entities")
+        or pipeline_summary.get("new-entities")
+        or []
+    )
+    selected_entities, all_selectable_entities = _parse_selected_entities(
+        request.form.getlist("selected_entities"), selectable_entities
+    )
+    if request.form.get("entity_selection_changed") == "true":
+        visible_entities, _ = _parse_selected_entities(
+            request.form.getlist("visible_selected_entities"), selectable_entities
+        )
+        current_entities = _current_selected_entities(
+            params.get("selected_entities"), all_selectable_entities
+        )
+        selected_entities = _merge_visible_selected_entities(
+            current_entities, visible_entities, selected_entities
+        )
+        if not selected_entities:
+            raise ControllerError(
+                "Select at least one new entity. The async service treats an empty selection as selecting all entities."
+            )
+        try:
+            new_request_id = _submit_assign_entities_request(
+                params.get("dataset", ""),
+                params.get("resource", ""),
+                organisation=organisation,
+                return_endpoint=params.get("return_endpoint")
+                or "assign_entities.flagged_resources_start",
+                selected_entities=selected_entities,
+                selected_redirects=_selected_redirects_for_async(
+                    redirects, organisation, selected_entities
+                ),
+            )
+        except AsyncAPIError as e:
+            raise ControllerError(
+                f"Assign entities submission failed: {e.detail}"
+            ) from e
+        return redirect(
+            url_for(
+                "assign_entities.flagged_resource_detail", request_id=new_request_id
+            )
+        )
+
     meta = db.session.get(RequestMeta, request_id)
     if meta is None:
         meta = RequestMeta(

--- a/application/blueprints/datamanager/services/github.py
+++ b/application/blueprints/datamanager/services/github.py
@@ -2,7 +2,6 @@
 GitHub App service for authenticating and triggering workflows.
 """
 
-import json
 import time
 import logging
 import requests
@@ -279,7 +278,6 @@ def trigger_add_data_async_workflow(
     triggered_by: str = "config-manager",
     github_branch: str = None,
     endpoints_to_retire: list = None,
-    entity_redirects: list = None,
 ) -> dict:
     """
     Trigger the 'add-data-async-script' workflow in the digital-land/config repository.
@@ -298,11 +296,6 @@ def trigger_add_data_async_workflow(
                 "branch": github_branch,
                 "retire_endpoints": (
                     ",".join(endpoints_to_retire or []) if endpoints_to_retire else ""
-                ),
-                "entity_redirects": (
-                    json.dumps(entity_redirects, separators=(",", ":"))
-                    if entity_redirects
-                    else ""
                 ),
                 "environment": current_app.config.get("ENVIRONMENT"),
             },

--- a/application/db/models.py
+++ b/application/db/models.py
@@ -448,7 +448,6 @@ class RequestMeta(db.Model):
     endpoints_to_retire = db.Column(
         db.Text, nullable=True
     )  # JSON list of endpoint hashes
-    entity_redirects = db.Column(db.Text, nullable=True)  # JSON list of old-entity rows
     branch_sha = db.Column(
         db.Text, nullable=True
     )  # config-manager-update HEAD SHA when the assessment was submitted

--- a/application/templates/components/check-transform-base.html
+++ b/application/templates/components/check-transform-base.html
@@ -161,9 +161,9 @@
                   <div class="govuk-checkboxes govuk-checkboxes--small app-checkboxes--table-header" data-module="govuk-checkboxes">
                     <div class="govuk-checkboxes__item">
                       {% if selection.can_select %}
-                      <input type="hidden" name="visible_selected_entities" value="{{ selection.form_value | e }}" form="duplicate-redirect-form">
+                      <input type="hidden" name="visible_entity_references" value="{{ selection.form_value | e }}" form="duplicate-redirect-form">
                       {% endif %}
-                      <input class="govuk-checkboxes__input entity-selection-checkbox" id="selected-entity-{{ loop.index }}" name="selected_entities" type="checkbox" value="{{ selection.form_value | e }}" form="duplicate-redirect-form" {% if selection.selected %}checked{% endif %} {% if not selection.can_select %}disabled{% endif %}>
+                      <input class="govuk-checkboxes__input entity-selection-checkbox" id="selected-entity-{{ loop.index }}" name="selected_entity_references" type="checkbox" value="{{ selection.form_value | e }}" form="duplicate-redirect-form" {% if selection.selected %}checked{% endif %} {% if not selection.can_select %}disabled{% endif %}>
                       <label class="govuk-label govuk-checkboxes__label" for="selected-entity-{{ loop.index }}">
                         <span class="govuk-visually-hidden">Select entity {{ row.fields.entity }}</span>
                       </label>

--- a/application/templates/components/check-transform-base.html
+++ b/application/templates/components/check-transform-base.html
@@ -131,6 +131,18 @@
           <table class="govuk-table dl-table app-table">
             <thead class="govuk-table__head">
               <tr class="govuk-table__row">
+                {% if is_assign_entities %}
+                <th scope="col" class="govuk-table__header app-checkbox-header">
+                  <div class="govuk-checkboxes govuk-checkboxes--small app-checkboxes--table-header" data-module="govuk-checkboxes">
+                    <div class="govuk-checkboxes__item">
+                      <input class="govuk-checkboxes__input" id="entity-select-all" type="checkbox">
+                      <label class="govuk-label govuk-checkboxes__label" for="entity-select-all">
+                        <span class="govuk-visually-hidden">Select all new entities</span>
+                      </label>
+                    </div>
+                  </div>
+                </th>
+                {% endif %}
                 {% for col in entities_data.columns %}
                 <th scope="col" class="govuk-table__header">{{ col }}</th>
                 {% endfor %}
@@ -143,6 +155,22 @@
               {% elif row.category == 'new' %}{% set _row_bg = '#d4edda' %}
               {% else %}{% set _row_bg = '#d0e4f7' %}{% endif %}
               <tr class="govuk-table__row" style="background-color: {{ _row_bg }};">
+                {% if is_assign_entities %}
+                {% set selection = row.entity_selection or {} %}
+                <td class="govuk-table__cell">
+                  <div class="govuk-checkboxes govuk-checkboxes--small app-checkboxes--table-header" data-module="govuk-checkboxes">
+                    <div class="govuk-checkboxes__item">
+                      {% if selection.can_select %}
+                      <input type="hidden" name="visible_selected_entities" value="{{ selection.form_value | e }}" form="duplicate-redirect-form">
+                      {% endif %}
+                      <input class="govuk-checkboxes__input entity-selection-checkbox" id="selected-entity-{{ loop.index }}" name="selected_entities" type="checkbox" value="{{ selection.form_value | e }}" form="duplicate-redirect-form" {% if selection.selected %}checked{% endif %} {% if not selection.can_select %}disabled{% endif %}>
+                      <label class="govuk-label govuk-checkboxes__label" for="selected-entity-{{ loop.index }}">
+                        <span class="govuk-visually-hidden">Select entity {{ row.fields.entity }}</span>
+                      </label>
+                    </div>
+                  </div>
+                </td>
+                {% endif %}
                 {% for col in entities_data.columns %}
                 {% set _changed = row.changed_fields and col in row.changed_fields %}
                 <td class="govuk-table__cell app-wrap{% if _changed %} app-cell-changed{% endif %}"{% if _changed %} title="Platform value: {{ row.changed_fields[col] }}" data-platform-value="Platform value: {{ row.changed_fields[col] }}"{% endif %}>
@@ -155,6 +183,17 @@
             </tbody>
           </table>
         </div>
+        {% if is_assign_entities %}
+        {% set selected_entity_count = entities_data.rows | selectattr('entity_selection.selected') | list | length %}
+        {% set selectable_entity_count = entities_data.rows | selectattr('entity_selection.can_select') | list | length %}
+        <p class="govuk-!-margin-top-2" id="entity-selected-count" style="white-space: nowrap;">
+          {% if selectable_entity_count %}
+          {{ selected_entity_count }} of {{ selectable_entity_count }} {{ 'entity' if selectable_entity_count == 1 else 'entities' }} selected for assignment
+          {% else %}
+          No entities available for assignment
+          {% endif %}
+        </p>
+        {% endif %}
         {% elif entity_search or entity_filter %}
         <p class="govuk-body">No entities match your search or filter.</p>
         {% else %}
@@ -330,6 +369,135 @@
 {% endblock %}
 
 {% block pageScripts %}{{ super() }}
+<style {% if config["ENV"]=="production" %}nonce="{{ csp_nonce() }}" {% endif %}>
+  .app-checkbox-header {
+    padding-bottom: 10px;
+    padding-top: 10px;
+    text-align: center;
+    width: 24px;
+  }
+  .app-checkboxes--table-header {
+    display: inline-block;
+    height: 24px;
+    margin: 0;
+    vertical-align: middle;
+    width: 24px;
+  }
+  .app-checkboxes--table-header .govuk-checkboxes__item {
+    display: block;
+    height: 24px;
+    min-height: 24px;
+    position: relative;
+    width: 24px;
+  }
+  .app-checkboxes--table-header .govuk-checkboxes__input {
+    height: 24px;
+    left: 0;
+    margin: 0;
+    position: absolute;
+    top: 0;
+    width: 24px;
+  }
+  .app-checkboxes--table-header .govuk-checkboxes__label::before {
+    left: 0;
+    top: 0;
+  }
+  .app-checkboxes--table-header .govuk-checkboxes__label::after {
+    left: 6px;
+    top: 7px;
+  }
+  .app-checkboxes--table-header .govuk-checkboxes__label {
+    display: block;
+    height: 24px;
+    min-height: 0;
+    max-width: none;
+    padding: 0;
+    width: 24px;
+  }
+</style>
+<script {% if config["ENV"]=="production" %}nonce="{{ csp_nonce() }}" {% endif %}>
+  var entitySelectedCount = document.getElementById('entity-selected-count');
+  var entityCheckboxes = document.querySelectorAll('.entity-selection-checkbox');
+  var duplicateCheckboxesForSelection = document.querySelectorAll('.duplicate-checkbox');
+  var entitySelectAllCheckbox = document.getElementById('entity-select-all');
+  var entitySelectionChanged = document.getElementById('entity-selection-changed');
+  var entitySelectionSubmit = document.getElementById('entity-selection-submit');
+  var initialEntitySelection = Array.prototype.map.call(entityCheckboxes, function(checkbox) {
+    return !checkbox.disabled && checkbox.checked ? checkbox.value : null;
+  }).filter(Boolean).sort().join('|');
+  var initialRedirectSelection = Array.prototype.map.call(duplicateCheckboxesForSelection, function(checkbox) {
+    return !checkbox.disabled && checkbox.checked ? checkbox.value : null;
+  }).filter(Boolean).sort().join('|');
+  function currentRedirectSelection() {
+    return Array.prototype.map.call(duplicateCheckboxesForSelection, function(checkbox) {
+      return !checkbox.disabled && checkbox.checked ? checkbox.value : null;
+    }).filter(Boolean).sort().join('|');
+  }
+  function darkenRowColour(colour) {
+    var match = (colour || '').match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+    if (!match) return colour || '';
+    var amount = 18;
+    return 'rgb(' + [1, 2, 3].map(function(index) {
+      return Math.max(0, Number(match[index]) - amount);
+    }).join(', ') + ')';
+  }
+  function updateEntitySelection() {
+    if (!entitySelectedCount || !entityCheckboxes.length) return;
+    var count = 0;
+    var selectableCount = 0;
+    var selectableSelectedCount = 0;
+    var currentSelection = [];
+    entityCheckboxes.forEach(function(checkbox) {
+      var row = checkbox.closest('.govuk-table__row');
+      if (row && row.dataset.originalBackground === undefined) {
+        row.dataset.originalBackground = row.style.backgroundColor || '';
+      }
+      if (!checkbox.disabled) {
+        selectableCount += 1;
+        if (checkbox.checked) selectableSelectedCount += 1;
+      }
+      if (checkbox.checked && !checkbox.disabled) {
+        count += 1;
+        currentSelection.push(checkbox.value);
+        if (row) row.style.backgroundColor = darkenRowColour(row.dataset.originalBackground);
+      } else if (row && checkbox.disabled === false) {
+        row.style.backgroundColor = row.dataset.originalBackground || '';
+      }
+    });
+    entitySelectedCount.textContent = selectableCount
+      ? count + ' of ' + selectableCount + ' ' + (selectableCount === 1 ? 'entity' : 'entities') + ' selected for assignment'
+      : 'No entities available for assignment';
+    if (entitySelectAllCheckbox) {
+      entitySelectAllCheckbox.checked = selectableCount > 0 && selectableSelectedCount === selectableCount;
+      entitySelectAllCheckbox.indeterminate = selectableSelectedCount > 0 && selectableSelectedCount < selectableCount;
+      entitySelectAllCheckbox.disabled = selectableCount === 0;
+    }
+    var selectionChanged = currentSelection.sort().join('|') !== initialEntitySelection
+      || currentRedirectSelection() !== initialRedirectSelection;
+    if (entitySelectionChanged) {
+      entitySelectionChanged.value = selectionChanged ? 'true' : 'false';
+    }
+    if (entitySelectionSubmit) {
+      entitySelectionSubmit.textContent = selectionChanged ? 'Process entities' : 'Continue to preview';
+    }
+  }
+  window.updateEntitySelectionState = updateEntitySelection;
+  entityCheckboxes.forEach(function(checkbox) {
+    checkbox.addEventListener('change', updateEntitySelection);
+  });
+  duplicateCheckboxesForSelection.forEach(function(checkbox) {
+    checkbox.addEventListener('change', updateEntitySelection);
+  });
+  if (entitySelectAllCheckbox) {
+    entitySelectAllCheckbox.addEventListener('change', function() {
+      entityCheckboxes.forEach(function(checkbox) {
+        if (!checkbox.disabled) checkbox.checked = entitySelectAllCheckbox.checked;
+      });
+      updateEntitySelection();
+    });
+  }
+  updateEntitySelection();
+</script>
 <script src="{{ url_for('static', filename='javascripts/entity-table-tooltip.js') }}"></script>
 {% if geometries %}
 <script>

--- a/application/templates/datamanager/assign-entities-check-results.html
+++ b/application/templates/datamanager/assign-entities-check-results.html
@@ -246,27 +246,24 @@
   var duplicateCheckboxes = document.querySelectorAll('.duplicate-checkbox');
   var selectAllCheckbox = document.getElementById('entity-redirect-select-all');
   var entitySelectionCheckboxes = document.querySelectorAll('.entity-selection-checkbox');
-  function entitySelectionValue(checkbox) {
-    try {
-      return JSON.parse(checkbox.value || '{}');
-    } catch (e) {
-      return {};
-    }
+  var entitySelectAllCheckbox = document.getElementById('entity-select-all');
+  function entitySelectionReference(checkbox) {
+    return checkbox.value || '';
   }
   function visibleEntityReferences() {
     var references = {};
     entitySelectionCheckboxes.forEach(function(checkbox) {
-      var value = entitySelectionValue(checkbox);
-      if (value.reference) references[value.reference] = checkbox;
+      var reference = entitySelectionReference(checkbox);
+      if (reference) references[reference] = checkbox;
     });
     return references;
   }
   function selectedEntityReferences() {
     var references = {};
     entitySelectionCheckboxes.forEach(function(checkbox) {
-      var value = entitySelectionValue(checkbox);
-      if (value.reference && checkbox.checked && !checkbox.disabled) {
-        references[value.reference] = true;
+      var reference = entitySelectionReference(checkbox);
+      if (reference && checkbox.checked && !checkbox.disabled) {
+        references[reference] = true;
       }
     });
     return references;
@@ -341,6 +338,9 @@
       });
       updateDuplicateSelection();
     });
+  }
+  if (entitySelectAllCheckbox) {
+    entitySelectAllCheckbox.addEventListener('change', updateDuplicateSelection);
   }
   updateDuplicateSelection();
 </script>

--- a/application/templates/datamanager/assign-entities-check-results.html
+++ b/application/templates/datamanager/assign-entities-check-results.html
@@ -59,6 +59,7 @@
       <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="duplicates-table">
         <p class="govuk-hint govuk-!-margin-bottom-4">Possible spatial duplicates between entities in this resource and existing platform entities for this dataset. <strong style="color: #00703c;">Green</strong> is the new provision entity. <strong style="color: #d4692a;">Orange</strong> is the existing platform entity.</p>
         <form method="post" action="{{ url_for('assign_entities.flagged_resource_detail_post', request_id=request_id) }}" id="duplicate-redirect-form">
+          <input type="hidden" name="entity_selection_changed" id="entity-selection-changed" value="false">
           {% if duplicate_candidates %}
           <div class="govuk-!-margin-bottom-2" style="display: flex; align-items: center; gap: 15px; flex-wrap: wrap;">
             <span class="govuk-body-s govuk-!-margin-bottom-0" style="color: #505a5f;"><strong style="color: #00703c;">&#9679;</strong> Green: new provision entity</span>
@@ -95,10 +96,7 @@
                   <td class="govuk-table__cell">
                     <div class="govuk-checkboxes govuk-checkboxes--small app-checkboxes--table-header" data-module="govuk-checkboxes">
                       <div class="govuk-checkboxes__item">
-                        {% if row.auto_select %}
-                        <input type="hidden" name="entity_redirects" value="{{ row.form_value | e }}">
-                        {% endif %}
-                        <input class="govuk-checkboxes__input duplicate-checkbox" id="entity-redirect-{{ loop.index }}" name="entity_redirects" type="checkbox" value="{{ row.form_value | e }}" {% if row.auto_select %}checked disabled{% endif %}>
+                        <input class="govuk-checkboxes__input duplicate-checkbox" id="entity-redirect-{{ loop.index }}" name="entity_redirects" type="checkbox" value="{{ row.form_value | e }}" data-entity-reference="{{ row.new_reference or row.reference or '' }}" data-restore-checked="{{ 'true' if row.auto_select else 'false' }}" data-redirect-locked="{{ 'true' if row.redirect_locked else 'false' }}" {% if row.auto_select and row.redirect_can_select %}checked{% endif %} {% if row.redirect_locked or not row.redirect_can_select %}disabled{% endif %}>
                         <label class="govuk-label govuk-checkboxes__label" for="entity-redirect-{{ loop.index }}">
                           <span class="govuk-visually-hidden">Select redirect for entity {{ row.entity }}</span>
                         </label>
@@ -155,11 +153,12 @@
             </table>
           </div>
           {% set selected_count = duplicate_candidates | selectattr('auto_select') | list | length %}
+          {% set selectable_count = duplicate_candidates | rejectattr('auto_select') | list | length %}
           <p class="govuk-!-margin-top-2" id="duplicate-selected-count" style="white-space: nowrap;">
-            {% if selected_count %}
-            {{ selected_count }} {{ 'entity' if selected_count == 1 else 'entities' }} selected for redirection
+            {% if duplicate_candidates %}
+            {{ selected_count }} of {{ selectable_count + selected_count }} {{ 'entity' if (selectable_count + selected_count) == 1 else 'entities' }} selected for redirection
             {% else %}
-            No entities selected for redirection
+            No entities available for redirection
             {% endif %}
           </p>
           {% else %}
@@ -168,13 +167,15 @@
         </form>
       </div>
       {% else %}
-      <form method="post" action="{{ url_for('assign_entities.flagged_resource_detail_post', request_id=request_id) }}" id="duplicate-redirect-form"></form>
+      <form method="post" action="{{ url_for('assign_entities.flagged_resource_detail_post', request_id=request_id) }}" id="duplicate-redirect-form">
+        <input type="hidden" name="entity_selection_changed" id="entity-selection-changed" value="false">
+      </form>
       {% endif %}
 {% endblock %}
 
 {% block action_buttons %}
     <div class="govuk-button-group govuk-!-margin-top-6">
-      <button type="submit" form="duplicate-redirect-form" class="govuk-button" data-module="govuk-button">
+      <button type="submit" form="duplicate-redirect-form" class="govuk-button" data-module="govuk-button" id="entity-selection-submit">
         Continue to preview
       </button>
       <a href="{{ url_for('datamanager.dashboard_get') }}" class="govuk-link">
@@ -244,7 +245,58 @@
   var selectedCount = document.getElementById('duplicate-selected-count');
   var duplicateCheckboxes = document.querySelectorAll('.duplicate-checkbox');
   var selectAllCheckbox = document.getElementById('entity-redirect-select-all');
+  var entitySelectionCheckboxes = document.querySelectorAll('.entity-selection-checkbox');
+  function entitySelectionValue(checkbox) {
+    try {
+      return JSON.parse(checkbox.value || '{}');
+    } catch (e) {
+      return {};
+    }
+  }
+  function visibleEntityReferences() {
+    var references = {};
+    entitySelectionCheckboxes.forEach(function(checkbox) {
+      var value = entitySelectionValue(checkbox);
+      if (value.reference) references[value.reference] = checkbox;
+    });
+    return references;
+  }
+  function selectedEntityReferences() {
+    var references = {};
+    entitySelectionCheckboxes.forEach(function(checkbox) {
+      var value = entitySelectionValue(checkbox);
+      if (value.reference && checkbox.checked && !checkbox.disabled) {
+        references[value.reference] = true;
+      }
+    });
+    return references;
+  }
+  function updateDuplicateAvailability() {
+    var visibleReferences = visibleEntityReferences();
+    var selectedReferences = selectedEntityReferences();
+    duplicateCheckboxes.forEach(function(checkbox) {
+      var reference = checkbox.dataset.entityReference || '';
+      if (!reference || !visibleReferences[reference]) return;
+      var canSelect = Boolean(selectedReferences[reference]);
+      var isLocked = checkbox.dataset.redirectLocked === 'true';
+      if (!canSelect) {
+        checkbox.dataset.restoreChecked = checkbox.checked ? 'true' : checkbox.dataset.restoreChecked;
+        checkbox.checked = false;
+        checkbox.disabled = true;
+      } else if (isLocked) {
+        checkbox.checked = true;
+        checkbox.disabled = true;
+      } else {
+        checkbox.disabled = false;
+        if (checkbox.dataset.restoreChecked === 'true') {
+          checkbox.checked = true;
+          checkbox.dataset.restoreChecked = 'false';
+        }
+      }
+    });
+  }
   function updateDuplicateSelection() {
+    updateDuplicateAvailability();
     var count = 0;
     var selectableCount = 0;
     var selectableSelectedCount = 0;
@@ -267,12 +319,19 @@
       selectAllCheckbox.indeterminate = selectableSelectedCount > 0 && selectableSelectedCount < selectableCount;
     }
     if (selectedCount) {
-      selectedCount.textContent = count === 0
-        ? 'No entities selected for redirection'
-        : count + ' ' + (count === 1 ? 'entity' : 'entities') + ' selected for redirection';
+      var totalCount = duplicateCheckboxes.length;
+      selectedCount.textContent = totalCount
+        ? count + ' of ' + totalCount + ' ' + (totalCount === 1 ? 'entity' : 'entities') + ' selected for redirection'
+        : 'No entities available for redirection';
+    }
+    if (window.updateEntitySelectionState) {
+      window.updateEntitySelectionState();
     }
   }
   duplicateCheckboxes.forEach(function(checkbox) {
+    checkbox.addEventListener('change', updateDuplicateSelection);
+  });
+  entitySelectionCheckboxes.forEach(function(checkbox) {
     checkbox.addEventListener('change', updateDuplicateSelection);
   });
   if (selectAllCheckbox) {

--- a/application/templates/datamanager/entities_preview.html
+++ b/application/templates/datamanager/entities_preview.html
@@ -139,8 +139,8 @@
     <div class="govuk-!-margin-bottom-6">
       <h2 class="govuk-heading-m"><u>Entity Org Summary</u></h2>
       <div style="border: 1px solid #b1b4b6; padding: 20px;">
-        <h3 class="govuk-heading-s">entity-organisation.csv</h3>
         {% if entity_org_warning %}
+        <h3 class="govuk-heading-s">entity-organisation.csv</h3>
         <div class="govuk-warning-text">
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
           <strong class="govuk-warning-text__text">
@@ -149,16 +149,19 @@
           </strong>
         </div>
         {% elif entity_org_overlap_info %}
+        <h3 class="govuk-heading-s">entity-organisation.csv</h3>
         <div class="govuk-inset-text">
           {{ entity_org_overlap_info }}
         </div>
         {% elif entity_org_error_warning %}
+        <h3 class="govuk-heading-s">entity-organisation.csv</h3>
         <div class="govuk-error-summary" role="alert">
           <strong class="govuk-error-message">
             {{ entity_org_error_warning }}
           </strong>
         </div>
         {% elif has_entity_org and entity_org_table_params %}
+        <h3 class="govuk-heading-s">entity-organisation.csv</h3>
         <div class="app-scrollable-container app-scrollable govuk-!-margin-bottom-2">
           {{ table(entity_org_table_params) }}
         </div>
@@ -199,6 +202,17 @@
     <div class="govuk-!-margin-bottom-6">
       <h2 class="govuk-heading-m"><u>Old Entity Summary</u></h2>
       <div style="border: 1px solid #b1b4b6; padding: 20px;">
+        <div style="background-color: #f3f2f1; padding: 10px 15px; margin-bottom: 30px;">
+        <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Number of redirects
+            </dt>
+            <dd class="govuk-summary-list__value">{{ old_entity_redirect_count }}</dd>
+          </div>
+        </dl>
+        </div>
+
         <h3 class="govuk-heading-s">old-entity.csv</h3>
         <div class="app-scrollable-container app-scrollable govuk-!-margin-bottom-2">
           {{ table(old_entity_redirect_table_params) }}

--- a/application/templates/datamanager/entities_preview.html
+++ b/application/templates/datamanager/entities_preview.html
@@ -30,6 +30,14 @@
             </dt>
             <dd class="govuk-summary-list__value">{{ new_count }}</dd>
           </div>
+          {% if source_flow == 'assign_entities' %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Rows that will <span class="govuk-!-font-weight-bold" style="color: #d4351c;">NOT</span> create new entities
+            </dt>
+            <dd class="govuk-summary-list__value">{{ excluded_count }}</dd>
+          </div>
+          {% endif %}
         </dl>
         </div>
 

--- a/application/templates/datamanager/entities_preview.html
+++ b/application/templates/datamanager/entities_preview.html
@@ -16,7 +16,7 @@
     <div class="govuk-!-margin-bottom-6">
       <h2 class="govuk-heading-m"><u>Entity Summary</u></h2>
       <div style="border: 1px solid #b1b4b6; padding: 20px;">
-        <div style="background-color: #f3f2f1; padding: 10px 15px; margin-bottom: 30px;">
+        <div class="govuk-!-background-colour-light-grey govuk-!-padding-3 govuk-!-margin-bottom-6">
         <dl class="govuk-summary-list govuk-!-margin-bottom-0">
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/docs/assign-entities/architecture.md
+++ b/docs/assign-entities/architecture.md
@@ -1,8 +1,8 @@
 # Assign Entities - Architecture
 
 This document describes the Assign Entities process end to end: how config-manager starts async
-processing, how entity and redirect selections are represented, what the preview shows, what is
-committed to config, and where to look when the flow behaves unexpectedly.
+processing, how entity and redirect selections are represented, what the preview shows, which
+async result fields become config rows, and where to look when the flow behaves unexpectedly.
 
 Assign Entities is not a separate async request type. It is a specialised config-manager journey
 that submits an async `add_data` request for an existing resource hash, then reuses the add-data
@@ -198,8 +198,7 @@ On confirmation, config-manager calls `trigger_add_data_async_workflow` with:
 - `retire_endpoints`
 - `environment`
 
-It does not send entity selections or redirect selections to GitHub. The config repo workflow uses
-the `request_id` to fetch the completed async result and appends:
+The config repo workflow uses the `request_id` to fetch the completed async result and appends:
 
 - `pipeline/{collection}/lookup.csv` from `pipeline-summary.new-entities`
 - `pipeline/{collection}/entity-organisation.csv` from `pipeline-summary.entity-organisation`
@@ -264,12 +263,6 @@ The preview only shows async output. If a row is missing from preview, go back t
 Entities check-results page and process a new selection. The preview should not be used to add or
 remove selected references.
 
-### GitHub does not receive redirects
-
-Redirect selections are only sent to async as `selected_redirects` during **Process entities**.
-GitHub confirmation sends only a request id; `old-entity.csv` rows are read by the config repo from
-`pipeline-summary.old-entity`.
-
 ### Branch state can make results stale
 
 Assign Entities uses the same stale-assessment protection as add-data. If the shared config branch
@@ -329,13 +322,12 @@ Check the POST body from the Assign Entities page:
 ### Preview old-entity count is wrong
 
 The count is the number of rows rendered from `pipeline-summary.old-entity`. Check the async result
-first. Stored `RequestMeta.entity_redirects` is not used for this preview summary.
+first.
 
 ### GitHub PR does not contain old-entity rows
 
-Check the async request fetched by the config repo workflow. The GitHub payload does not include
-redirect rows. The config repo should append `old-entity.csv` from
-`pipeline-summary.old-entity`.
+Check `pipeline-summary.old-entity` in the completed async result fetched by the config repo
+workflow.
 
 ### Entity numbers look stale or collide
 

--- a/docs/assign-entities/architecture.md
+++ b/docs/assign-entities/architecture.md
@@ -81,8 +81,8 @@ The page is rendered from:
 
 - `response-details` rows fetched by `fetch_response_details(request_id)`
 - platform entities from the planning data API, for comparison and row categories
-- `pipeline-summary.all-entities`, falling back to `pipeline-summary.new-entities`, for Assign
-  Entities selectable rows
+- `response-details.transformed_row`, for Assign Entities rows
+- request param `selected_entities`, for Assign Entities checked state
 - `pipeline-summary.duplicate-candidates`, for the Dedup tab
 - `pipeline-summary.old-entity`, for preselected duplicate redirects
 
@@ -230,11 +230,11 @@ authoritative and valid.
 Async treats missing `selected_entities` and `selected_entities: []` as "assign all new entities".
 The UI prevents processing an empty selected set to avoid accidental all-entity assignment.
 
-### `all-entities` vs `new-entities`
+### Transformed rows vs `new-entities`
 
-The Entities tab renders from `pipeline-summary.all-entities` when present. This lets the user see
-unselected new rows after processing a subset. The preview uses `pipeline-summary.new-entities`,
-which should contain only the rows async will actually assign.
+The Entities tab renders from transformed rows and platform comparison data. It expects async to
+return transformed rows for all resource entities, selected or not. The preview uses
+`pipeline-summary.new-entities`, which should contain only the rows async will actually assign.
 
 ### Existing rows are visible but not selectable
 
@@ -287,16 +287,15 @@ Check the replacement async request params:
 
 - Does it include a non-empty `selected_entities` array?
 - Are entries shaped as `{ "organisation": "...", "reference": "..." }`?
-- Do the organisation/reference values match `pipeline-summary.all-entities`?
+- Do the organisation/reference values match the transformed row references?
 
 If `selected_entities` is missing or empty, async will process all new entities.
 
 ### A selected row disappeared from the Entities tab
 
-Check whether async returned `pipeline-summary.all-entities`. The Assign Entities tab needs this
-field to keep unassigned candidates visible after a subset is processed. If only
-`pipeline-summary.new-entities` is returned, the page can only render the entities async actually
-assigned.
+Check whether async returned the row in `response-details.transformed_row`. The Assign Entities tab
+expects transformed rows for all resource entities, including unselected candidates. The preview is
+allowed to contain only assigned rows in `pipeline-summary.new-entities`.
 
 ### A selected row does not appear in preview
 

--- a/docs/assign-entities/architecture.md
+++ b/docs/assign-entities/architecture.md
@@ -1,0 +1,370 @@
+# Assign Entities - Architecture
+
+This document describes the Assign Entities process end to end: how config-manager starts async
+processing, how entity and redirect selections are represented, what the preview shows, what is
+committed to config, and where to look when the flow behaves unexpectedly.
+
+Assign Entities is not a separate async request type. It is a specialised config-manager journey
+that submits an async `add_data` request for an existing resource hash, then reuses the add-data
+preview and GitHub commit flow once async has produced the final config rows.
+
+---
+
+## Repositories involved
+
+| Repo | Responsibility |
+| --- | --- |
+| `config-manager` | User journey, selection UI, validation, async request creation, preview, GitHub dispatch |
+| `async-request-backend` | Processes the resource, filters selected entities, assigns entity numbers, generates old-entity rows |
+| `digital-land/config` | Fetches the completed async request and appends returned CSV rows |
+
+config-manager does not calculate entity number ranges and does not create `old-entity.csv` rows
+itself. It passes selected references to async, then displays and commits whatever async returns.
+
+---
+
+## Code map
+
+| Area | File | Role |
+| --- | --- | --- |
+| Routes | `application/blueprints/datamanager/router.py` | Assign Entities routes, selection POST handling, replacement async request |
+| Start/import | `application/blueprints/datamanager/controllers/flagged_resources.py` | Direct resource/dataset entry, flagged-resources CSV import, async request submission |
+| Results page | `application/blueprints/datamanager/controllers/transform.py` | Builds Entities and Dedup tab data from async response |
+| Shared results template | `application/templates/components/check-transform-base.html` | Entities tab table, entity checkboxes, selection count, shared button state |
+| Dedup template | `application/templates/datamanager/assign-entities-check-results.html` | Dedup tab, duplicate redirect checkboxes, hidden changed flag |
+| Preview | `application/blueprints/datamanager/controllers/preview.py` | Displays async-generated lookup, entity-organisation, and old-entity rows |
+| GitHub dispatch | `application/blueprints/datamanager/services/github.py` | Triggers the config repo workflow with the completed async request id |
+| Redirect parsing | `application/blueprints/datamanager/services/duplicates.py` | Validates submitted Dedup checkbox values against async candidates |
+
+---
+
+## Full process
+
+### 1. Start Assign Entities
+
+The user starts at `/assign-entities/` by entering a dataset/resource pair, or by uploading/pasting
+a flagged-resources CSV.
+
+`controllers/flagged_resources.py` resolves:
+
+- `dataset`
+- `collection`
+- `resource`
+- resource `organisation`, from resource metadata when possible
+- shared `github_branch` from `CONFIG_REPO_BRANCH`
+
+It then submits an async request using `_submit_assign_entities_request`.
+
+```json
+{
+  "type": "add_data",
+  "resource": "resource-hash",
+  "dataset": "conservation-area",
+  "collection": "conservation-area",
+  "authoritative": true,
+  "github_branch": "config-manager-update",
+  "organisationName": "local-authority:ABC",
+  "organisation": "local-authority:ABC",
+  "return_endpoint": "assign_entities.flagged_resources_start"
+}
+```
+
+At this point no explicit selection is sent, so async treats the request as "assign all new
+entities".
+
+### 2. Show async result
+
+`router.py` fetches the request from async and delegates to `handle_check_transform` in
+`controllers/transform.py`.
+
+The page is rendered from:
+
+- `response-details` rows fetched by `fetch_response_details(request_id)`
+- platform entities from the planning data API, for comparison and row categories
+- `pipeline-summary.all-entities`, falling back to `pipeline-summary.new-entities`, for Assign
+  Entities selectable rows
+- `pipeline-summary.duplicate-candidates`, for the Dedup tab
+- `pipeline-summary.old-entity`, for preselected duplicate redirects
+
+### 3. Select entities
+
+The Entities tab includes a checkbox column only in the Assign Entities flow.
+
+| Row category | Meaning | Checkbox |
+| --- | --- | --- |
+| `new` | Reference is not already on the platform | enabled |
+| `changed` | Entity exists on the platform but differs from the resource | disabled |
+| `in_both` | Entity exists and matches | disabled |
+| `existing` | Entity exists on the platform only | disabled |
+
+Each enabled checkbox submits this JSON value:
+
+```json
+{ "organisation": "local-authority:ABC", "reference": "REF-1" }
+```
+
+This organisation/reference pair is the selection identity. Entity numbers are not used as the
+selection key because the point of the flow is to decide which references should receive numbers.
+
+Initial checkbox state comes from async request params:
+
+- missing or empty `selected_entities`: all selectable `new` rows are checked
+- non-empty `selected_entities`: only matching organisation/reference pairs are checked
+
+Search and pagination render only a subset of rows. To avoid losing selections from other pages,
+the template posts the visible row values separately and `router.py` merges the visible changes back
+into the current full selection before it submits a replacement async request.
+
+### 4. Select duplicate redirects
+
+The Dedup tab is currently shown for Assign Entities `conservation-area` requests.
+
+Candidate rows come from `pipeline-summary.duplicate-candidates`. Initial checked state comes from
+`pipeline-summary.old-entity`, not from a score threshold in config-manager.
+
+When an entity is not selected, any duplicate checkbox for that entity is disabled. This matters
+because async can only redirect old entity numbers to new entity numbers it is assigning in the
+same processed selection.
+
+Rows in `pipeline-summary.old-entity` that are not present in request param `selected_redirects`
+are treated as async auto-selected. Those checkboxes stay checked and locked in the UI so the user
+cannot remove redirects generated by async policy.
+
+### 5. Process entities
+
+Changing either the Entities tab or the Dedup tab changes the submit button text to
+**Process entities**.
+
+On POST, `flagged_resource_detail_post`:
+
+1. Fetches the current async response.
+2. Parses selected entity checkbox values.
+3. Validates selected entities against the current async response.
+4. Parses selected Dedup checkbox values against `duplicate-candidates`.
+5. Merges visible entity selections with current full selection.
+6. Filters Dedup redirects to only selected entity references.
+7. Submits a replacement async request with `selected_entities` and `selected_redirects`.
+8. Redirects to the new request's Assign Entities check-results page.
+
+The replacement request looks like:
+
+```json
+{
+  "type": "add_data",
+  "resource": "resource-hash",
+  "dataset": "conservation-area",
+  "collection": "conservation-area",
+  "authoritative": true,
+  "github_branch": "config-manager-update",
+  "organisationName": "local-authority:ABC",
+  "organisation": "local-authority:ABC",
+  "return_endpoint": "assign_entities.flagged_resources_start",
+  "selected_entities": [
+    { "organisation": "local-authority:ABC", "reference": "REF-1" }
+  ],
+  "selected_redirects": [
+    {
+      "organisation": "local-authority:ABC",
+      "reference": "REF-1",
+      "old_entity_number": "100"
+    }
+  ]
+}
+```
+
+config-manager blocks submitting no selected entities from the UI. This is deliberate: async treats
+`selected_entities: []` as assign all, so an empty UI selection would otherwise do the opposite of
+what the user intended.
+
+### 6. Preview
+
+Once the user continues from the refreshed Assign Entities result, the add-data preview shows the
+completed async output. It does not recalculate Assign Entities rows.
+
+| Preview section | Source |
+| --- | --- |
+| Rows that will create new entities | `pipeline-summary.new-entities` |
+| Entity organisation CSV | `pipeline-summary.entity-organisation` |
+| Old Entity Summary / `old-entity.csv` | `pipeline-summary.old-entity` |
+
+The "Number of redirects" value is the number of rendered `old-entity` rows.
+
+### 7. Confirm and commit
+
+On confirmation, config-manager calls `trigger_add_data_async_workflow` with:
+
+- `request_id`
+- `triggered_by`
+- `github_branch`
+- `retire_endpoints`
+- `environment`
+
+It does not send entity selections or redirect selections to GitHub. The config repo workflow uses
+the `request_id` to fetch the completed async result and appends:
+
+- `pipeline/{collection}/lookup.csv` from `pipeline-summary.new-entities`
+- `pipeline/{collection}/entity-organisation.csv` from `pipeline-summary.entity-organisation`
+- `pipeline/{collection}/old-entity.csv` from `pipeline-summary.old-entity`
+
+---
+
+## Entity number behaviour
+
+Entity number generation happens in async, before the result is returned to config-manager.
+
+Selection is applied before async adds lookup entries, so unselected references do not consume
+numbers. That means selection should not create gaps in the assigned range. If gaps appear in a
+preview, debug async's generated `pipeline-summary.new-entities` and the branch it assessed
+against, not config-manager's preview code.
+
+`entity-organisation` is also async-owned. config-manager only renders the returned
+`pipeline-summary.entity-organisation` rows and the config repo appends those rows when
+authoritative and valid.
+
+---
+
+## Gotchas
+
+### Empty selection means assign all in async
+
+Async treats missing `selected_entities` and `selected_entities: []` as "assign all new entities".
+The UI prevents processing an empty selected set to avoid accidental all-entity assignment.
+
+### `all-entities` vs `new-entities`
+
+The Entities tab renders from `pipeline-summary.all-entities` when present. This lets the user see
+unselected new rows after processing a subset. The preview uses `pipeline-summary.new-entities`,
+which should contain only the rows async will actually assign.
+
+### Existing rows are visible but not selectable
+
+Existing, changed, and in-both rows keep their row category and colour semantics. Their checkboxes
+are disabled because config-manager must only submit references eligible for new entity numbers.
+
+### Dedup selection depends on entity selection
+
+A Dedup checkbox can be disabled even when it is a good duplicate candidate. If the corresponding
+new entity is not selected, the redirect cannot be submitted because async will not assign that new
+entity number.
+
+### Auto-selected redirects are inferred
+
+config-manager treats old-entity rows returned by async but absent from request param
+`selected_redirects` as auto-selected. Those rows are locked in the UI. This is an inference from
+the async result and params, not a separate stored flag in config-manager.
+
+### Button text is stateful
+
+The shared results page changes "Continue to preview" to "Process entities" when either entity
+selection or Dedup selection changes. If this does not happen, inspect the hidden
+`entity_selection_changed` input and the checkbox data attributes in the rendered HTML.
+
+### Preview is not the selection editor
+
+The preview only shows async output. If a row is missing from preview, go back to the Assign
+Entities check-results page and process a new selection. The preview should not be used to add or
+remove selected references.
+
+### GitHub does not receive redirects
+
+Redirect selections are only sent to async as `selected_redirects` during **Process entities**.
+GitHub confirmation sends only a request id; `old-entity.csv` rows are read by the config repo from
+`pipeline-summary.old-entity`.
+
+### Branch state can make results stale
+
+Assign Entities uses the same stale-assessment protection as add-data. If the shared config branch
+moves for the collection between assessment and confirmation, the confirm page can block and ask
+the user to re-run.
+
+---
+
+## Debugging
+
+### The page shows all entities selected after processing
+
+Check the replacement async request params:
+
+- Does it include a non-empty `selected_entities` array?
+- Are entries shaped as `{ "organisation": "...", "reference": "..." }`?
+- Do the organisation/reference values match `pipeline-summary.all-entities`?
+
+If `selected_entities` is missing or empty, async will process all new entities.
+
+### A selected row disappeared from the Entities tab
+
+Check whether async returned `pipeline-summary.all-entities`. The Assign Entities tab needs this
+field to keep unassigned candidates visible after a subset is processed. If only
+`pipeline-summary.new-entities` is returned, the page can only render the entities async actually
+assigned.
+
+### A selected row does not appear in preview
+
+Inspect the completed async response:
+
+- `pipeline-summary.new-entities`
+- `pipeline-summary.entity-organisation`
+- `pipeline-summary.old-entity`
+- `response.error`
+
+The preview uses those fields directly. If the row is not there, the issue is earlier than preview.
+
+### Dedup checkbox is disabled
+
+Check:
+
+- The candidate's `new_reference` or `reference`
+- The request param `selected_entities`
+- The rendered row's `redirect_can_select`
+- Whether the row is locked because it is in `pipeline-summary.old-entity` but absent from
+  `selected_redirects`
+
+### Dedup selection was not sent to async
+
+Check the POST body from the Assign Entities page:
+
+- `entity_selection_changed` should be `true`
+- selected duplicate checkboxes should post as `entity_redirects`
+- parsed redirects must match a row in `pipeline-summary.duplicate-candidates`
+- redirects for unselected entity references are deliberately filtered out
+
+### Preview old-entity count is wrong
+
+The count is the number of rows rendered from `pipeline-summary.old-entity`. Check the async result
+first. Stored `RequestMeta.entity_redirects` is not used for this preview summary.
+
+### GitHub PR does not contain old-entity rows
+
+Check the async request fetched by the config repo workflow. The GitHub payload does not include
+redirect rows. The config repo should append `old-entity.csv` from
+`pipeline-summary.old-entity`.
+
+### Entity numbers look stale or collide
+
+Check:
+
+- `github_branch` sent in the async request
+- the `RequestMeta.branch_sha` baseline captured for the request
+- whether the confirm-time stale check blocked or was skipped
+- whether another add-data workflow changed `pipeline/{collection}/` while the page was open
+
+---
+
+## Useful focused tests
+
+```bash
+./.venv/bin/pytest tests/unit/blueprints/datamanager/controllers/test_transform.py -q
+./.venv/bin/pytest tests/unit/blueprints/datamanager/controllers/test_add.py -q
+./.venv/bin/pytest tests/acceptance/blueprints/datamanager/test_flagged_resources.py -q
+```
+
+Use the focused tests when changing the selection or preview flow. Run the broader datamanager
+suite before merging changes that touch shared templates or GitHub dispatch behaviour.
+
+---
+
+## Related
+
+- [Datamanager GitHub workflow](../datamanager/github-add.md)
+- [Datamanager stale-assessment check](../datamanager/stale-check.md)
+- [Datamanager blueprint architecture](../datamanager/architecture.md)

--- a/docs/assign-entities/architecture.md
+++ b/docs/assign-entities/architecture.md
@@ -82,7 +82,7 @@ The page is rendered from:
 - `response-details` rows fetched by `fetch_response_details(request_id)`
 - platform entities from the planning data API, for comparison and row categories
 - `response-details.transformed_row`, for Assign Entities rows
-- request param `selected_entities`, for Assign Entities checked state
+- request param `excluded_references`, for Assign Entities checked state
 - `pipeline-summary.duplicate-candidates`, for the Dedup tab
 - `pipeline-summary.old-entity`, for preselected duplicate redirects
 
@@ -97,19 +97,19 @@ The Entities tab includes a checkbox column only in the Assign Entities flow.
 | `in_both` | Entity exists and matches | disabled |
 | `existing` | Entity exists on the platform only | disabled |
 
-Each enabled checkbox submits this JSON value:
+Each enabled checkbox submits the row reference as its value:
 
-```json
-{ "organisation": "local-authority:ABC", "reference": "REF-1" }
+```text
+REF-1
 ```
 
-This organisation/reference pair is the selection identity. Entity numbers are not used as the
-selection key because the point of the flow is to decide which references should receive numbers.
+The reference is the selection identity. Entity numbers are not used as the selection key because
+the point of the flow is to decide which references should receive numbers.
 
 Initial checkbox state comes from async request params:
 
-- missing or empty `selected_entities`: all selectable `new` rows are checked
-- non-empty `selected_entities`: only matching organisation/reference pairs are checked
+- missing or empty `excluded_references`: all selectable `new` rows are checked
+- non-empty `excluded_references`: matching references are unchecked
 
 Search and pagination render only a subset of rows. To avoid losing selections from other pages,
 the template posts the visible row values separately and `router.py` merges the visible changes back
@@ -138,12 +138,12 @@ Changing either the Entities tab or the Dedup tab changes the submit button text
 On POST, `flagged_resource_detail_post`:
 
 1. Fetches the current async response.
-2. Parses selected entity checkbox values.
-3. Validates selected entities against the current async response.
+2. Parses selected entity checkbox reference values.
+3. Calculates excluded references from the visible rows and current request params.
 4. Parses selected Dedup checkbox values against `duplicate-candidates`.
-5. Merges visible entity selections with current full selection.
-6. Filters Dedup redirects to only selected entity references.
-7. Submits a replacement async request with `selected_entities` and `selected_redirects`.
+5. Merges visible entity selections with the current excluded references.
+6. Filters Dedup redirects to exclude references that will not receive entity numbers.
+7. Submits a replacement async request with `excluded_references` and `selected_redirects`.
 8. Redirects to the new request's Assign Entities check-results page.
 
 The replacement request looks like:
@@ -159,12 +159,11 @@ The replacement request looks like:
   "organisationName": "local-authority:ABC",
   "organisation": "local-authority:ABC",
   "return_endpoint": "assign_entities.flagged_resources_start",
-  "selected_entities": [
-    { "organisation": "local-authority:ABC", "reference": "REF-1" }
+  "excluded_references": [
+    "REF-2"
   ],
   "selected_redirects": [
     {
-      "organisation": "local-authority:ABC",
       "reference": "REF-1",
       "old_entity_number": "100"
     }
@@ -172,9 +171,8 @@ The replacement request looks like:
 }
 ```
 
-config-manager blocks submitting no selected entities from the UI. This is deliberate: async treats
-`selected_entities: []` as assign all, so an empty UI selection would otherwise do the opposite of
-what the user intended.
+`excluded_references` contains only references that should not receive entity numbers.
+An empty list means nothing was excluded from assignment.
 
 ### 6. Preview
 
@@ -184,6 +182,7 @@ completed async output. It does not recalculate Assign Entities rows.
 | Preview section | Source |
 | --- | --- |
 | Rows that will create new entities | `pipeline-summary.new-entities` |
+| Rows that will NOT create new entities | `params.excluded_references` |
 | Entity organisation CSV | `pipeline-summary.entity-organisation` |
 | Old Entity Summary / `old-entity.csv` | `pipeline-summary.old-entity` |
 
@@ -212,7 +211,7 @@ the `request_id` to fetch the completed async result and appends:
 
 Entity number generation happens in async, before the result is returned to config-manager.
 
-Selection is applied before async adds lookup entries, so unselected references do not consume
+Selection is applied before async adds lookup entries, so excluded references do not consume
 numbers. That means selection should not create gaps in the assigned range. If gaps appear in a
 preview, debug async's generated `pipeline-summary.new-entities` and the branch it assessed
 against, not config-manager's preview code.
@@ -225,10 +224,10 @@ authoritative and valid.
 
 ## Gotchas
 
-### Empty selection means assign all in async
+### Empty excluded references means assign all
 
-Async treats missing `selected_entities` and `selected_entities: []` as "assign all new entities".
-The UI prevents processing an empty selected set to avoid accidental all-entity assignment.
+Async treats missing or empty `excluded_references` as "exclude nothing". The UI can send
+an empty list when every selectable reference is selected.
 
 ### Transformed rows vs `new-entities`
 
@@ -285,16 +284,16 @@ the user to re-run.
 
 Check the replacement async request params:
 
-- Does it include a non-empty `selected_entities` array?
-- Are entries shaped as `{ "organisation": "...", "reference": "..." }`?
-- Do the organisation/reference values match the transformed row references?
+- Does `excluded_references` contain the references that were unchecked?
+- Is it a list of reference strings?
+- Do the reference values match the transformed row references?
 
-If `selected_entities` is missing or empty, async will process all new entities.
+If `excluded_references` is missing or empty, async will process all new entities.
 
 ### A selected row disappeared from the Entities tab
 
 Check whether async returned the row in `response-details.transformed_row`. The Assign Entities tab
-expects transformed rows for all resource entities, including unselected candidates. The preview is
+expects transformed rows for all resource entities, including excluded candidates. The preview is
 allowed to contain only assigned rows in `pipeline-summary.new-entities`.
 
 ### A selected row does not appear in preview
@@ -313,7 +312,7 @@ The preview uses those fields directly. If the row is not there, the issue is ea
 Check:
 
 - The candidate's `new_reference` or `reference`
-- The request param `selected_entities`
+- The request param `excluded_references`
 - The rendered row's `redirect_can_select`
 - Whether the row is locked because it is in `pipeline-summary.old-entity` but absent from
   `selected_redirects`
@@ -325,7 +324,7 @@ Check the POST body from the Assign Entities page:
 - `entity_selection_changed` should be `true`
 - selected duplicate checkboxes should post as `entity_redirects`
 - parsed redirects must match a row in `pipeline-summary.duplicate-candidates`
-- redirects for unselected entity references are deliberately filtered out
+- redirects for excluded references are deliberately filtered out
 
 ### Preview old-entity count is wrong
 

--- a/docs/datamanager/architecture.md
+++ b/docs/datamanager/architecture.md
@@ -7,7 +7,8 @@ This document describes the structure of the `datamanager` blueprint and how to 
 ## Directory layout
 
 > Docs for this blueprint live in `docs/datamanager/` (this file, plus `github-add.md` and
-> `stale-check.md`).
+> `stale-check.md`). Assign Entities has its own workflow docs in
+> `docs/assign-entities/architecture.md`.
 
 ```
 application/blueprints/datamanager/

--- a/docs/datamanager/github-add.md
+++ b/docs/datamanager/github-add.md
@@ -34,7 +34,6 @@ The trigger lives in `services/github.py` (`trigger_add_data_async_workflow`, ca
     "triggered_by": "your-name-or-system",
     "branch": "config-manager-update",
     "retire_endpoints": "hash1,hash2",
-    "entity_redirects": "[{\"old_entity\":\"100\",\"entity\":\"200\"}]",
     "environment": "production"
   }
 }
@@ -47,7 +46,6 @@ The trigger lives in `services/github.py` (`trigger_add_data_async_workflow`, ca
 | `client_payload.triggered_by` | no | Who/what triggered it (used in commit/PR content) |
 | `client_payload.branch` | no | Target branch — see [Branch behaviour](#branch-behaviour) |
 | `client_payload.retire_endpoints` | no | Comma-separated endpoint hashes to end-date |
-| `client_payload.entity_redirects` | no | JSON list of old→new entity redirects |
 | `client_payload.environment` | no | Async API environment: `development` \| `staging` \| `production` (default `staging`) |
 
 The branch config-manager sends is its `CONFIG_REPO_BRANCH` setting — `config-manager-update` in
@@ -111,7 +109,7 @@ URL is resolved from the `environment` in the payload:
     "data": {
       "endpoint-summary": { "new_endpoint_entry": {}, "endpoint_url_in_endpoint_csv": false },
       "source-summary": { "new_source_entry": {}, "documentation_url_in_source_csv": false },
-      "pipeline-summary": { "new-entities": [], "entity-organisation": [] }
+      "pipeline-summary": { "new-entities": [], "entity-organisation": [], "old-entity": [] }
     },
     "error": null
   }
@@ -127,7 +125,7 @@ URL is resolved from the `environment` in the payload:
 | `pipeline/{collection}/lookup.csv` | `pipeline-summary.new-entities` | array non-empty |
 | `pipeline/{collection}/column.csv` | `params.column_mapping` | mapping non-empty |
 | `pipeline/{collection}/entity-organisation.csv` | `pipeline-summary.entity-organisation` | `params.authoritative` true, and not an overlap/error |
-| `pipeline/{collection}/old-entity.csv` | `client_payload.entity_redirects` | redirects provided |
+| `pipeline/{collection}/old-entity.csv` | `pipeline-summary.old-entity` | array non-empty |
 
 Retiring endpoints (`retire_endpoints`) does not append rows — it sets `end-date` on the matching
 rows in `collection/{collection}/endpoint.csv` and `source.csv`.
@@ -148,4 +146,6 @@ The workflow fails if `request_id` is empty, the request cannot be fetched, its 
 
 - [stale-check.md](stale-check.md) — how config-manager avoids committing stale entity numbers when
   the branch advances between assessment and confirmation.
+- [Assign Entities architecture](../assign-entities/architecture.md) — how Assign Entities
+  selections are sent to async.
 - [architecture.md](architecture.md) — the datamanager blueprint structure.

--- a/migrations/versions/7b8c9d0e1f2a_drop_request_meta_entity_redirects.py
+++ b/migrations/versions/7b8c9d0e1f2a_drop_request_meta_entity_redirects.py
@@ -1,0 +1,26 @@
+"""drop request_meta entity_redirects column
+
+Revision ID: 7b8c9d0e1f2a
+Revises: f6a7b8c9d0e1
+Create Date: 2026-07-22 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "7b8c9d0e1f2a"
+down_revision = "f6a7b8c9d0e1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("request_meta", "entity_redirects")
+
+
+def downgrade():
+    op.add_column(
+        "request_meta",
+        sa.Column("entity_redirects", sa.Text(), nullable=True),
+    )

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -14,6 +14,16 @@ from config.config import get_request_api_endpoint
 ASYNC_BASE = f"{get_request_api_endpoint()}/requests"
 
 
+def _selected_entity_checkbox(response_data, reference):
+    response_text = response_data.decode()
+    match = re.search(
+        rf'<input\b[^>]*name="selected_entities"[^>]*value="[^"]*{re.escape(reference)}[^"]*"[^>]*>',
+        response_text,
+    )
+    assert match, f"Could not find selected_entities checkbox for {reference}"
+    return match.group(0)
+
+
 CSV_INPUT = (
     "dataset,resource,organisation,reference,status,entities_created,error_code,message\n"
     "tree,resource-a,local-authority:ABC,ref-1,error,12%,LARGE_NUMBER_OF_NEW_ENTITIES,Entity growth is 12%\n"
@@ -535,6 +545,14 @@ def test_assign_entities_check_results_uses_selected_entities_param(client):
         f"{ASYNC_BASE}/assign-selected-id/response-details",
         json=[
             {
+                "entry_number": 1,
+                "transformed_row": [
+                    {"entity": "1", "field": "reference", "value": "ref-1"},
+                    {"entity": "1", "field": "name", "value": "Name 1"},
+                ],
+                "issue_logs": [],
+            },
+            {
                 "entry_number": 2,
                 "transformed_row": [
                     {"entity": "2", "field": "reference", "value": "ref-2"},
@@ -577,11 +595,13 @@ def test_assign_entities_check_results_uses_selected_entities_param(client):
                         )
 
     assert response.status_code == 200
-    assert b'ref-1&#34;}" form="duplicate-redirect-form"  >' in response.data
-    assert b'ref-2&#34;}" form="duplicate-redirect-form" checked' in response.data
-    assert (
-        b'existing-ref&#34;}" form="duplicate-redirect-form"  disabled' in response.data
-    )
+    ref_1_checkbox = _selected_entity_checkbox(response.data, "ref-1")
+    ref_2_checkbox = _selected_entity_checkbox(response.data, "ref-2")
+    existing_checkbox = _selected_entity_checkbox(response.data, "existing-ref")
+    assert "checked" not in ref_1_checkbox
+    assert "disabled" not in ref_1_checkbox
+    assert "checked" in ref_2_checkbox
+    assert "disabled" in existing_checkbox
     assert b"1 of 2 entities selected for assignment" in response.data
 
 

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -1,4 +1,5 @@
 import json
+import re
 from datetime import datetime
 from io import BytesIO
 from unittest.mock import patch
@@ -382,7 +383,19 @@ def test_assign_entities_check_results_does_not_show_retire_endpoints(client):
                     "source-summary": {
                         "existing_endpoint_for_organisation_dataset": ["endpoint-a"]
                     },
-                    "pipeline-summary": {"new-in-resource": 1},
+                    "pipeline-summary": {
+                        "new-in-resource": 2,
+                        "new-entities": [
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-1",
+                            },
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-2",
+                            },
+                        ],
+                    },
                 }
             },
         },
@@ -466,6 +479,110 @@ def test_assign_entities_check_results_does_not_show_retire_endpoints(client):
     assert b"retire_endpoints" not in response.data
     assert b'action="/assign-entities/check-results/assign-id-1"' in response.data
     assert b'form="duplicate-redirect-form"' in response.data
+    assert b"entity-select-all" in response.data
+    assert b'name="selected_entities"' in response.data
+    assert b'ref-2&#34;}" form="duplicate-redirect-form" checked' in response.data
+    assert b"1 of 1 entity selected for assignment" in response.data
+
+
+@rsps.activate
+def test_assign_entities_check_results_uses_selected_entities_param(client):
+    rsps.add(
+        rsps.GET,
+        f"{ASYNC_BASE}/assign-selected-id",
+        json={
+            "status": "COMPLETE",
+            "params": {
+                "dataset": "tree",
+                "organisation": "local-authority:ABC",
+                "resource": "resource-a",
+                "selected_entities": [
+                    {"organisation": "local-authority:ABC", "reference": "ref-2"}
+                ],
+            },
+            "response": {
+                "data": {
+                    "source-summary": {},
+                    "pipeline-summary": {
+                        "new-in-resource": 2,
+                        "new-entities": [
+                            {
+                                "entity": "2",
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-2",
+                            }
+                        ],
+                        "all-entities": [
+                            {
+                                "entity": "1",
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-1",
+                            },
+                            {
+                                "entity": "2",
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-2",
+                            },
+                        ],
+                    },
+                }
+            },
+        },
+        status=200,
+    )
+    rsps.add(
+        rsps.GET,
+        f"{ASYNC_BASE}/assign-selected-id/response-details",
+        json=[
+            {
+                "entry_number": 2,
+                "transformed_row": [
+                    {"entity": "2", "field": "reference", "value": "ref-2"},
+                    {"entity": "2", "field": "name", "value": "Name 2"},
+                ],
+                "issue_logs": [],
+            },
+            {
+                "entry_number": 3,
+                "transformed_row": [
+                    {"entity": "3", "field": "reference", "value": "existing-ref"},
+                    {"entity": "3", "field": "name", "value": "Existing"},
+                ],
+                "issue_logs": [],
+            },
+        ],
+        status=200,
+    )
+
+    transform_controller = "application.blueprints.datamanager.controllers.transform"
+    with patch(f"{transform_controller}.get_org_entity", return_value=90):
+        with patch(f"{transform_controller}.get_organisation_name"):
+            with patch(f"{transform_controller}.get_dataset_name", return_value="Tree"):
+                with patch(
+                    f"{transform_controller}.get_entity_count_for_organisation_and_dataset",
+                    return_value=1,
+                ):
+                    with patch(
+                        f"{transform_controller}.get_entities_for_organisation_and_dataset",
+                        return_value=[
+                            {
+                                "entity": "3",
+                                "reference": "existing-ref",
+                                "name": "Existing",
+                            }
+                        ],
+                    ):
+                        response = client.get(
+                            "/assign-entities/check-results/assign-selected-id"
+                        )
+
+    assert response.status_code == 200
+    assert b'ref-1&#34;}" form="duplicate-redirect-form"  >' in response.data
+    assert b'ref-2&#34;}" form="duplicate-redirect-form" checked' in response.data
+    assert (
+        b'existing-ref&#34;}" form="duplicate-redirect-form"  disabled' in response.data
+    )
+    assert b"1 of 2 entities selected for assignment" in response.data
 
 
 @rsps.activate
@@ -540,6 +657,13 @@ def test_assign_entities_check_results_shows_duplicate_candidates(client):
                     "source-summary": {},
                     "pipeline-summary": {
                         "new-in-resource": 1,
+                        "old-entity": [
+                            {
+                                "old-entity": "100",
+                                "status": "301",
+                                "entity": "200",
+                            }
+                        ],
                         "duplicate-candidates": [
                             {
                                 "old_entity": "100",
@@ -636,7 +760,7 @@ def test_assign_entities_check_results_shows_duplicate_candidates(client):
         b'href="/assign-entities/check-results/assign-duplicates-id?'
         b'entity_search=200#entities-table"'
     ) in response.data
-    assert b'type="hidden" name="entity_redirects"' in response.data
+    assert b'type="hidden" name="entity_redirects"' not in response.data
     assert (
         b'id="entity-redirect-1" name="entity_redirects" type="checkbox"'
         in response.data
@@ -655,9 +779,13 @@ def test_assign_entities_check_results_shows_duplicate_candidates(client):
         b" checked disabled" not in response.data
     )
     assert b"old_entity" in response.data
-    assert b"checked disabled" in response.data
+    first_checkbox = re.search(
+        rb'<input[^>]*id="entity-redirect-1"[^>]*>', response.data
+    ).group(0)
+    assert b"checked" in first_checkbox
+    assert b"disabled" in first_checkbox
     assert b"entity-redirect-select-all" in response.data
-    assert b"entities selected for redirection" in response.data
+    assert b"1 of 2 entities selected for redirection" in response.data
 
 
 @rsps.activate
@@ -788,6 +916,290 @@ def test_assign_entities_check_results_post_stores_redirects(client):
             "notes": "Redirect duplicate entity selected in Assign Entities",
         }
     ]
+
+
+def test_assign_entities_check_results_post_resubmits_changed_entity_selection(client):
+    request_id = "assign-selection-id"
+    selected_value = json.dumps(
+        {"organisation": "local-authority:ABC", "reference": "ref-2"}
+    )
+    selected_redirect = json.dumps(
+        {
+            "old_entity": "100",
+            "entity": "200",
+            "dataset": "tree",
+            "old_reference": "old-ref",
+            "new_reference": "ref-2",
+            "match_type": "complete_match",
+        }
+    )
+    unselected_entity_redirect = json.dumps(
+        {
+            "old_entity": "101",
+            "entity": "201",
+            "dataset": "tree",
+            "old_reference": "old-ref-1",
+            "new_reference": "ref-1",
+            "match_type": "complete_match",
+        }
+    )
+    with patch(
+        "application.blueprints.datamanager.router.fetch_request",
+        return_value={
+            "params": {
+                "dataset": "tree",
+                "resource": "resource-a",
+                "organisation": "local-authority:ABC",
+                "return_endpoint": "assign_entities.flagged_resources_summary",
+            },
+            "response": {
+                "data": {
+                    "pipeline-summary": {
+                        "new-entities": [
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-2",
+                            },
+                        ],
+                        "all-entities": [
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-1",
+                            },
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-2",
+                            },
+                        ],
+                        "duplicate-candidates": [
+                            {
+                                "old_entity": "100",
+                                "entity": "200",
+                                "dataset": "tree",
+                            },
+                            {
+                                "old_entity": "101",
+                                "entity": "201",
+                                "dataset": "tree",
+                            },
+                        ],
+                    }
+                }
+            },
+        },
+    ):
+        with patch(
+            "application.blueprints.datamanager.router._submit_assign_entities_request",
+            return_value="replacement-id",
+        ) as submit_request:
+            response = client.post(
+                f"/assign-entities/check-results/{request_id}",
+                data={
+                    "entity_selection_changed": "true",
+                    "visible_selected_entities": [
+                        json.dumps(
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-1",
+                            }
+                        ),
+                        selected_value,
+                    ],
+                    "selected_entities": [selected_value],
+                    "entity_redirects": [
+                        selected_redirect,
+                        unselected_entity_redirect,
+                        json.dumps(
+                            {
+                                "old_entity": "999",
+                                "entity": "200",
+                                "dataset": "tree",
+                                "new_reference": "ref-2",
+                            }
+                        ),
+                    ],
+                },
+            )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(
+        "/assign-entities/check-results/replacement-id"
+    )
+    submit_request.assert_called_once_with(
+        "tree",
+        "resource-a",
+        organisation="local-authority:ABC",
+        return_endpoint="assign_entities.flagged_resources_summary",
+        selected_entities=[
+            {"organisation": "local-authority:ABC", "reference": "ref-2"}
+        ],
+        selected_redirects=[
+            {
+                "organisation": "local-authority:ABC",
+                "reference": "ref-2",
+                "old_entity_number": "100",
+            }
+        ],
+    )
+    assert db.session.get(RequestMeta, request_id) is None
+
+
+def test_assign_entities_check_results_post_continues_for_unchanged_entity_selection(
+    client,
+):
+    request_id = "assign-unchanged-id"
+    selected_values = [
+        json.dumps({"organisation": "local-authority:ABC", "reference": "ref-1"}),
+        json.dumps({"organisation": "local-authority:ABC", "reference": "ref-2"}),
+    ]
+    with patch(
+        "application.blueprints.datamanager.router.fetch_request",
+        return_value={
+            "params": {
+                "dataset": "tree",
+                "resource": "resource-a",
+                "organisation": "local-authority:ABC",
+            },
+            "response": {
+                "data": {
+                    "pipeline-summary": {
+                        "new-entities": [
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-1",
+                            },
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-2",
+                            },
+                        ],
+                        "all-entities": [
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-1",
+                            },
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-2",
+                            },
+                        ],
+                        "duplicate-candidates": [],
+                    }
+                }
+            },
+        },
+    ):
+        with patch(
+            "application.blueprints.datamanager.router._submit_assign_entities_request"
+        ) as submit_request:
+            response = client.post(
+                f"/assign-entities/check-results/{request_id}",
+                data={"selected_entities": selected_values},
+            )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(
+        f"/datamanager/add-data/{request_id}/entities"
+    )
+    submit_request.assert_not_called()
+    meta = db.session.get(RequestMeta, request_id)
+    assert json.loads(meta.entity_redirects) == []
+
+
+def test_assign_entities_check_results_post_resubmits_changed_redirect_selection(
+    client,
+):
+    request_id = "assign-redirect-selection-id"
+    selected_values = [
+        json.dumps({"organisation": "local-authority:ABC", "reference": "ref-1"}),
+        json.dumps({"organisation": "local-authority:ABC", "reference": "ref-2"}),
+    ]
+    selected_redirect = json.dumps(
+        {
+            "old_entity": "100",
+            "entity": "200",
+            "dataset": "tree",
+            "new_reference": "ref-1",
+        }
+    )
+    with patch(
+        "application.blueprints.datamanager.router.fetch_request",
+        return_value={
+            "params": {
+                "dataset": "tree",
+                "resource": "resource-a",
+                "organisation": "local-authority:ABC",
+            },
+            "response": {
+                "data": {
+                    "pipeline-summary": {
+                        "new-entities": [
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-1",
+                            },
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-2",
+                            },
+                        ],
+                        "all-entities": [
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-1",
+                            },
+                            {
+                                "organisation": "local-authority:ABC",
+                                "reference": "ref-2",
+                            },
+                        ],
+                        "duplicate-candidates": [
+                            {
+                                "old_entity": "100",
+                                "entity": "200",
+                                "dataset": "tree",
+                            }
+                        ],
+                    }
+                }
+            },
+        },
+    ):
+        with patch(
+            "application.blueprints.datamanager.router._submit_assign_entities_request",
+            return_value="replacement-id",
+        ) as submit_request:
+            response = client.post(
+                f"/assign-entities/check-results/{request_id}",
+                data={
+                    "entity_selection_changed": "true",
+                    "visible_selected_entities": selected_values,
+                    "selected_entities": selected_values,
+                    "entity_redirects": [selected_redirect],
+                },
+            )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(
+        "/assign-entities/check-results/replacement-id"
+    )
+    submit_request.assert_called_once_with(
+        "tree",
+        "resource-a",
+        organisation="local-authority:ABC",
+        return_endpoint="assign_entities.flagged_resources_start",
+        selected_entities=[
+            {"organisation": "local-authority:ABC", "reference": "ref-1"},
+            {"organisation": "local-authority:ABC", "reference": "ref-2"},
+        ],
+        selected_redirects=[
+            {
+                "organisation": "local-authority:ABC",
+                "reference": "ref-1",
+                "old_entity_number": "100",
+            }
+        ],
+    )
 
 
 @rsps.activate

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -17,10 +17,10 @@ ASYNC_BASE = f"{get_request_api_endpoint()}/requests"
 def _selected_entity_checkbox(response_data, reference):
     response_text = response_data.decode()
     match = re.search(
-        rf'<input\b[^>]*name="selected_entities"[^>]*value="[^"]*{re.escape(reference)}[^"]*"[^>]*>',
+        rf'<input\b[^>]*name="selected_entity_references"[^>]*value="{re.escape(reference)}"[^>]*>',
         response_text,
     )
-    assert match, f"Could not find selected_entities checkbox for {reference}"
+    assert match, f"Could not find selected_entity_references checkbox for {reference}"
     return match.group(0)
 
 
@@ -490,13 +490,13 @@ def test_assign_entities_check_results_does_not_show_retire_endpoints(client):
     assert b'action="/assign-entities/check-results/assign-id-1"' in response.data
     assert b'form="duplicate-redirect-form"' in response.data
     assert b"entity-select-all" in response.data
-    assert b'name="selected_entities"' in response.data
-    assert b'ref-2&#34;}" form="duplicate-redirect-form" checked' in response.data
+    assert b'name="selected_entity_references"' in response.data
+    assert b'value="ref-2" form="duplicate-redirect-form" checked' in response.data
     assert b"1 of 1 entity selected for assignment" in response.data
 
 
 @rsps.activate
-def test_assign_entities_check_results_uses_selected_entities_param(client):
+def test_assign_entities_check_results_uses_excluded_references_param(client):
     rsps.add(
         rsps.GET,
         f"{ASYNC_BASE}/assign-selected-id",
@@ -506,9 +506,7 @@ def test_assign_entities_check_results_uses_selected_entities_param(client):
                 "dataset": "tree",
                 "organisation": "local-authority:ABC",
                 "resource": "resource-a",
-                "selected_entities": [
-                    {"organisation": "local-authority:ABC", "reference": "ref-2"}
-                ],
+                "excluded_references": ["ref-1"],
             },
             "response": {
                 "data": {
@@ -521,18 +519,6 @@ def test_assign_entities_check_results_uses_selected_entities_param(client):
                                 "organisation": "local-authority:ABC",
                                 "reference": "ref-2",
                             }
-                        ],
-                        "all-entities": [
-                            {
-                                "entity": "1",
-                                "organisation": "local-authority:ABC",
-                                "reference": "ref-1",
-                            },
-                            {
-                                "entity": "2",
-                                "organisation": "local-authority:ABC",
-                                "reference": "ref-2",
-                            },
                         ],
                     },
                 }
@@ -806,6 +792,9 @@ def test_assign_entities_check_results_shows_duplicate_candidates(client):
     assert b"disabled" in first_checkbox
     assert b"entity-redirect-select-all" in response.data
     assert b"1 of 2 entities selected for redirection" in response.data
+    assert b"JSON.parse(checkbox.value" not in response.data
+    assert b"function entitySelectionReference(checkbox)" in response.data
+    assert b"entitySelectAllCheckbox.addEventListener" in response.data
 
 
 @rsps.activate
@@ -940,9 +929,7 @@ def test_assign_entities_check_results_post_stores_redirects(client):
 
 def test_assign_entities_check_results_post_resubmits_changed_entity_selection(client):
     request_id = "assign-selection-id"
-    selected_value = json.dumps(
-        {"organisation": "local-authority:ABC", "reference": "ref-2"}
-    )
+    selected_value = "ref-2"
     selected_redirect = json.dumps(
         {
             "old_entity": "100",
@@ -953,7 +940,7 @@ def test_assign_entities_check_results_post_resubmits_changed_entity_selection(c
             "match_type": "complete_match",
         }
     )
-    unselected_entity_redirect = json.dumps(
+    excluded_redirect = json.dumps(
         {
             "old_entity": "101",
             "entity": "201",
@@ -976,16 +963,6 @@ def test_assign_entities_check_results_post_resubmits_changed_entity_selection(c
                 "data": {
                     "pipeline-summary": {
                         "new-entities": [
-                            {
-                                "organisation": "local-authority:ABC",
-                                "reference": "ref-2",
-                            },
-                        ],
-                        "all-entities": [
-                            {
-                                "organisation": "local-authority:ABC",
-                                "reference": "ref-1",
-                            },
                             {
                                 "organisation": "local-authority:ABC",
                                 "reference": "ref-2",
@@ -1016,19 +993,14 @@ def test_assign_entities_check_results_post_resubmits_changed_entity_selection(c
                 f"/assign-entities/check-results/{request_id}",
                 data={
                     "entity_selection_changed": "true",
-                    "visible_selected_entities": [
-                        json.dumps(
-                            {
-                                "organisation": "local-authority:ABC",
-                                "reference": "ref-1",
-                            }
-                        ),
+                    "visible_entity_references": [
+                        "ref-1",
                         selected_value,
                     ],
-                    "selected_entities": [selected_value],
+                    "selected_entity_references": [selected_value],
                     "entity_redirects": [
                         selected_redirect,
-                        unselected_entity_redirect,
+                        excluded_redirect,
                         json.dumps(
                             {
                                 "old_entity": "999",
@@ -1050,12 +1022,9 @@ def test_assign_entities_check_results_post_resubmits_changed_entity_selection(c
         "resource-a",
         organisation="local-authority:ABC",
         return_endpoint="assign_entities.flagged_resources_summary",
-        selected_entities=[
-            {"organisation": "local-authority:ABC", "reference": "ref-2"}
-        ],
+        excluded_references=["ref-1"],
         selected_redirects=[
             {
-                "organisation": "local-authority:ABC",
                 "reference": "ref-2",
                 "old_entity_number": "100",
             }
@@ -1068,10 +1037,7 @@ def test_assign_entities_check_results_post_continues_for_unchanged_entity_selec
     client,
 ):
     request_id = "assign-unchanged-id"
-    selected_values = [
-        json.dumps({"organisation": "local-authority:ABC", "reference": "ref-1"}),
-        json.dumps({"organisation": "local-authority:ABC", "reference": "ref-2"}),
-    ]
+    selected_values = ["ref-1", "ref-2"]
     with patch(
         "application.blueprints.datamanager.router.fetch_request",
         return_value={
@@ -1093,16 +1059,6 @@ def test_assign_entities_check_results_post_continues_for_unchanged_entity_selec
                                 "reference": "ref-2",
                             },
                         ],
-                        "all-entities": [
-                            {
-                                "organisation": "local-authority:ABC",
-                                "reference": "ref-1",
-                            },
-                            {
-                                "organisation": "local-authority:ABC",
-                                "reference": "ref-2",
-                            },
-                        ],
                         "duplicate-candidates": [],
                     }
                 }
@@ -1114,7 +1070,7 @@ def test_assign_entities_check_results_post_continues_for_unchanged_entity_selec
         ) as submit_request:
             response = client.post(
                 f"/assign-entities/check-results/{request_id}",
-                data={"selected_entities": selected_values},
+                data={"selected_entity_references": selected_values},
             )
 
     assert response.status_code == 302
@@ -1130,10 +1086,7 @@ def test_assign_entities_check_results_post_resubmits_changed_redirect_selection
     client,
 ):
     request_id = "assign-redirect-selection-id"
-    selected_values = [
-        json.dumps({"organisation": "local-authority:ABC", "reference": "ref-1"}),
-        json.dumps({"organisation": "local-authority:ABC", "reference": "ref-2"}),
-    ]
+    selected_values = ["ref-1", "ref-2"]
     selected_redirect = json.dumps(
         {
             "old_entity": "100",
@@ -1163,16 +1116,6 @@ def test_assign_entities_check_results_post_resubmits_changed_redirect_selection
                                 "reference": "ref-2",
                             },
                         ],
-                        "all-entities": [
-                            {
-                                "organisation": "local-authority:ABC",
-                                "reference": "ref-1",
-                            },
-                            {
-                                "organisation": "local-authority:ABC",
-                                "reference": "ref-2",
-                            },
-                        ],
                         "duplicate-candidates": [
                             {
                                 "old_entity": "100",
@@ -1193,8 +1136,8 @@ def test_assign_entities_check_results_post_resubmits_changed_redirect_selection
                 f"/assign-entities/check-results/{request_id}",
                 data={
                     "entity_selection_changed": "true",
-                    "visible_selected_entities": selected_values,
-                    "selected_entities": selected_values,
+                    "visible_entity_references": selected_values,
+                    "selected_entity_references": selected_values,
                     "entity_redirects": [selected_redirect],
                 },
             )
@@ -1208,13 +1151,9 @@ def test_assign_entities_check_results_post_resubmits_changed_redirect_selection
         "resource-a",
         organisation="local-authority:ABC",
         return_endpoint="assign_entities.flagged_resources_start",
-        selected_entities=[
-            {"organisation": "local-authority:ABC", "reference": "ref-1"},
-            {"organisation": "local-authority:ABC", "reference": "ref-2"},
-        ],
+        excluded_references=[],
         selected_redirects=[
             {
-                "organisation": "local-authority:ABC",
                 "reference": "ref-1",
                 "old_entity_number": "100",
             }

--- a/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
+++ b/tests/acceptance/blueprints/datamanager/test_flagged_resources.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import responses as rsps
 
 from application.blueprints.base.views import ADD_DATA_LOCK, ASSIGN_ENTITIES_LOCK
-from application.db.models import RequestMeta, ServiceLock
+from application.db.models import ServiceLock
 from application.extensions import db
 from config.config import get_request_api_endpoint
 
@@ -861,7 +861,7 @@ def test_assign_entities_check_results_hides_dedup_for_other_datasets(client):
     assert b'id="duplicates-table"' not in response.data
 
 
-def test_assign_entities_check_results_post_stores_redirects(client):
+def test_assign_entities_check_results_post_continues_without_storing_redirects(client):
     request_id = "assign-post-id"
     with patch(
         "application.blueprints.datamanager.router.fetch_request",
@@ -913,18 +913,6 @@ def test_assign_entities_check_results_post_stores_redirects(client):
     assert response.headers["Location"].endswith(
         f"/datamanager/add-data/{request_id}/entities"
     )
-    meta = db.session.get(RequestMeta, request_id)
-    assert json.loads(meta.entity_redirects) == [
-        {
-            "old_entity": "100",
-            "entity": "200",
-            "dataset": "tree",
-            "old_reference": "old-ref",
-            "new_reference": "new-ref",
-            "match_type": "complete_match",
-            "notes": "Redirect duplicate entity selected in Assign Entities",
-        }
-    ]
 
 
 def test_assign_entities_check_results_post_resubmits_changed_entity_selection(client):
@@ -1030,7 +1018,6 @@ def test_assign_entities_check_results_post_resubmits_changed_entity_selection(c
             }
         ],
     )
-    assert db.session.get(RequestMeta, request_id) is None
 
 
 def test_assign_entities_check_results_post_continues_for_unchanged_entity_selection(
@@ -1078,8 +1065,6 @@ def test_assign_entities_check_results_post_continues_for_unchanged_entity_selec
         f"/datamanager/add-data/{request_id}/entities"
     )
     submit_request.assert_not_called()
-    meta = db.session.get(RequestMeta, request_id)
-    assert json.loads(meta.entity_redirects) == []
 
 
 def test_assign_entities_check_results_post_resubmits_changed_redirect_selection(

--- a/tests/unit/blueprints/datamanager/controllers/test_add.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_add.py
@@ -188,16 +188,6 @@ class TestAddDataConfirmRoute:
         assert b"govuk-error-summary" in response.data
 
     def test_confirm_does_not_pass_entity_redirects_to_workflow(self, client):
-        db.session.add(
-            RequestMeta(
-                request_id="confirm-redirect-id",
-                entity_redirects=(
-                    '[{"old_entity":"100","entity":"200",'
-                    '"dataset":"conservation-area"}]'
-                ),
-            )
-        )
-        db.session.commit()
         with client.session_transaction() as sess:
             sess["user"] = {"login": "test-user"}
         with patch(

--- a/tests/unit/blueprints/datamanager/controllers/test_add.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_add.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import patch
 
 from application.blueprints.datamanager.services.github import GitHubWorkflowError
@@ -22,22 +23,30 @@ class TestEntitiesPreviewRoute:
         assert b"Preparing entities preview" in response.data
 
     def test_renders_old_entity_redirect_table(self, client):
-        db.session.add(
-            RequestMeta(
-                request_id="test-id",
-                entity_redirects=(
-                    '[{"old_entity":"100","entity":"200",'
-                    '"dataset":"conservation-area"}]'
-                ),
-            )
-        )
-        db.session.commit()
         result = {
             "status": "COMPLETE",
             "params": {"dataset": "conservation-area", "authoritative": False},
             "response": {
                 "data": {
-                    "pipeline-summary": {"new-in-resource": 0},
+                    "pipeline-summary": {
+                        "new-in-resource": 0,
+                        "old-entity": [
+                            {
+                                "old-entity": "100",
+                                "status": "301",
+                                "entity": "200",
+                            },
+                            {
+                                "old-entity": "101",
+                                "status": "301",
+                                "entity": "201",
+                            },
+                        ],
+                        "new-entities": [
+                            {"entity": "200", "reference": "new-ref"},
+                            {"entity": "201", "reference": "other-ref"},
+                        ],
+                    },
                     "endpoint-summary": {},
                     "source-summary": {},
                 }
@@ -52,8 +61,17 @@ class TestEntitiesPreviewRoute:
         assert response.status_code == 200
         assert b"old-entity.csv" in response.data
         assert b"100" in response.data
+        assert b"101" in response.data
         assert b"301" in response.data
         assert b"200" in response.data
+        assert b"Number of redirects" in response.data
+        assert re.search(
+            rb"Number of redirects.*?<dd class=\"govuk-summary-list__value\">2</dd>",
+            response.data,
+            re.S,
+        )
+        assert b"Rows that will create new entities" in response.data
+        assert b'<dd class="govuk-summary-list__value">2</dd>' in response.data
 
 
 class TestAddDataConfirmRoute:
@@ -157,7 +175,7 @@ class TestAddDataConfirmRoute:
         assert response.status_code == 200
         assert b"govuk-error-summary" in response.data
 
-    def test_confirm_passes_entity_redirects_to_workflow(self, client):
+    def test_confirm_does_not_pass_entity_redirects_to_workflow(self, client):
         db.session.add(
             RequestMeta(
                 request_id="confirm-redirect-id",
@@ -179,10 +197,4 @@ class TestAddDataConfirmRoute:
             )
 
         assert response.status_code == 200
-        assert trigger.call_args.kwargs["entity_redirects"] == [
-            {
-                "old_entity": "100",
-                "entity": "200",
-                "dataset": "conservation-area",
-            }
-        ]
+        assert "entity_redirects" not in trigger.call_args.kwargs

--- a/tests/unit/blueprints/datamanager/controllers/test_add.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_add.py
@@ -25,7 +25,12 @@ class TestEntitiesPreviewRoute:
     def test_renders_old_entity_redirect_table(self, client):
         result = {
             "status": "COMPLETE",
-            "params": {"dataset": "conservation-area", "authoritative": False},
+            "params": {
+                "dataset": "conservation-area",
+                "authoritative": False,
+                "resource": "resource-a",
+                "excluded_references": ["not-selected", "not-selected", ""],
+            },
             "response": {
                 "data": {
                     "pipeline-summary": {
@@ -72,6 +77,13 @@ class TestEntitiesPreviewRoute:
         )
         assert b"Rows that will create new entities" in response.data
         assert b'<dd class="govuk-summary-list__value">2</dd>' in response.data
+        assert b"Rows that will" in response.data
+        assert b"NOT</span> create new entities" in response.data
+        assert re.search(
+            rb"Rows that will.*?NOT</span> create new entities.*?<dd class=\"govuk-summary-list__value\">1</dd>",
+            response.data,
+            re.S,
+        )
 
 
 class TestAddDataConfirmRoute:

--- a/tests/unit/blueprints/datamanager/controllers/test_preview.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_preview.py
@@ -1,8 +1,34 @@
 from application.blueprints.datamanager.controllers.preview import (
     _build_entity_organisation_summary,
+    build_old_entity_redirect_table,
 )
 
 NEW_ENTITIES = [{"entity": "10100002", "reference": "REF001"}]
+
+
+def test_old_entity_redirect_table_renders_null_values_as_empty_strings():
+    table_params = build_old_entity_redirect_table(
+        [
+            {
+                "old-entity": None,
+                "status": None,
+                "entity": None,
+                "notes": None,
+                "end-date": None,
+                "entry-date": None,
+                "start-date": None,
+            }
+        ]
+    )
+
+    row = table_params["rows"][0]["columns"]
+    assert row["old-entity"]["value"] == ""
+    assert row["status"]["value"] == ""
+    assert row["entity"]["value"] == ""
+    assert row["notes"]["value"] == ""
+    assert row["end-date"]["value"] == ""
+    assert row["entry-date"]["value"] == ""
+    assert row["start-date"]["value"] == ""
 
 
 def test_no_new_entities_hides_section():

--- a/tests/unit/blueprints/datamanager/controllers/test_transform.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_transform.py
@@ -35,55 +35,123 @@ def test_dedup_candidate_form_value_keeps_existing_value():
     )
 
 
-def test_prepare_duplicate_candidates_auto_selects_complete_matches():
+def test_prepare_duplicate_candidates_does_not_auto_select_complete_matches_without_old_entity():
     candidates = _prepare_duplicate_candidates(
         [
             {
+                "old_entity": "100",
+                "entity": "200",
                 "match_type": "complete_match",
                 "name_similarity": 10,
             }
         ]
     )
 
-    assert candidates[0]["auto_select"] is True
+    assert candidates[0]["auto_select"] is False
 
 
-def test_prepare_duplicate_candidates_does_not_auto_select_existing_redirects():
+def test_prepare_duplicate_candidates_auto_selects_old_entity_rows():
     candidates = _prepare_duplicate_candidates(
         [
             {
+                "old_entity": "100",
+                "entity": "200",
                 "match_type": "complete_match",
                 "old_entity_redirects": [
                     {"old-entity": "100", "entity": "300", "status": "301"}
                 ],
             }
-        ]
+        ],
+        [{"old-entity": "100", "entity": "200", "status": "301"}],
+    )
+
+    assert candidates[0]["auto_select"] is True
+    assert candidates[0]["redirect_locked"] is True
+    assert candidates[0]["redirect_can_select"] is True
+
+
+def test_prepare_duplicate_candidates_does_not_lock_selected_redirect_rows():
+    candidates = _prepare_duplicate_candidates(
+        [
+            {
+                "old_entity": "100",
+                "entity": "200",
+                "match_type": "complete_match",
+                "new_reference": "ref-1",
+            }
+        ],
+        [
+            {
+                "old-entity": "100",
+                "entity": "200",
+                "status": "301",
+            }
+        ],
+        organisation="local-authority:ABC",
+        selected_redirects=[
+            {
+                "organisation": "local-authority:ABC",
+                "reference": "ref-1",
+                "old_entity_number": "100",
+            }
+        ],
+    )
+
+    assert candidates[0]["auto_select"] is True
+    assert candidates[0]["redirect_locked"] is False
+
+
+def test_prepare_duplicate_candidates_does_not_auto_select_unmatched_old_entity_rows():
+    candidates = _prepare_duplicate_candidates(
+        [
+            {
+                "old_entity": "100",
+                "entity": "200",
+                "match_type": "single_match",
+                "name_similarity": 86,
+            }
+        ],
+        [{"old-entity": "101", "entity": "200", "status": "301"}],
     )
 
     assert candidates[0]["auto_select"] is False
 
 
-def test_prepare_duplicate_candidates_auto_selects_single_matches_over_threshold():
+def test_prepare_duplicate_candidates_keeps_old_entity_field_alias():
     candidates = _prepare_duplicate_candidates(
         [
             {
+                "old_entity": "100",
+                "entity": "200",
                 "match_type": "single_match",
-                "name_similarity": 86,
+                "name_similarity": 85,
             }
-        ]
+        ],
+        [{"old_entity": "100", "entity": "200", "status": "301"}],
     )
 
     assert candidates[0]["auto_select"] is True
 
 
-def test_prepare_duplicate_candidates_does_not_auto_select_single_matches_at_threshold():
+def test_prepare_duplicate_candidates_disables_redirects_for_unselected_entities():
     candidates = _prepare_duplicate_candidates(
         [
             {
-                "match_type": "single_match",
-                "name_similarity": 85,
-            }
-        ]
+                "old_entity": "100",
+                "entity": "200",
+                "new_reference": "ref-1",
+            },
+            {
+                "old_entity": "101",
+                "entity": "201",
+                "new_reference": "ref-2",
+            },
+        ],
+        organisation="local-authority:ABC",
+        selected_entities=[
+            {"organisation": "local-authority:ABC", "reference": "ref-2"}
+        ],
     )
 
-    assert candidates[0]["auto_select"] is False
+    assert candidates[0]["redirect_can_select"] is False
+    assert candidates[1]["redirect_can_select"] is True

--- a/tests/unit/blueprints/datamanager/controllers/test_transform.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_transform.py
@@ -90,7 +90,6 @@ def test_prepare_duplicate_candidates_does_not_lock_selected_redirect_rows():
         organisation="local-authority:ABC",
         selected_redirects=[
             {
-                "organisation": "local-authority:ABC",
                 "reference": "ref-1",
                 "old_entity_number": "100",
             }
@@ -133,7 +132,7 @@ def test_prepare_duplicate_candidates_keeps_old_entity_field_alias():
     assert candidates[0]["auto_select"] is True
 
 
-def test_prepare_duplicate_candidates_disables_redirects_for_unselected_entities():
+def test_prepare_duplicate_candidates_disables_redirects_for_excluded_references():
     candidates = _prepare_duplicate_candidates(
         [
             {
@@ -148,9 +147,7 @@ def test_prepare_duplicate_candidates_disables_redirects_for_unselected_entities
             },
         ],
         organisation="local-authority:ABC",
-        selected_entities=[
-            {"organisation": "local-authority:ABC", "reference": "ref-2"}
-        ],
+        excluded_references=["ref-1"],
     )
 
     assert candidates[0]["redirect_can_select"] is False

--- a/tests/unit/blueprints/datamanager/services/test_github.py
+++ b/tests/unit/blueprints/datamanager/services/test_github.py
@@ -100,7 +100,7 @@ class TestTriggerAddDataAsyncWorkflow:
         assert result["success"] is False
         assert result["status_code"] == 422
 
-    def test_includes_entity_redirects_in_payload(self, app):
+    def test_does_not_include_entity_redirects_in_payload(self, app):
         mock_dispatch = Mock()
         mock_dispatch.status_code = 204
 
@@ -120,22 +120,10 @@ class TestTriggerAddDataAsyncWorkflow:
                         "application.blueprints.datamanager.services.github.requests.post",
                         return_value=mock_dispatch,
                     ) as post:
-                        trigger_add_data_async_workflow(
-                            "request-123",
-                            entity_redirects=[
-                                {
-                                    "old_entity": "100",
-                                    "entity": "200",
-                                    "dataset": "conservation-area",
-                                }
-                            ],
-                        )
+                        trigger_add_data_async_workflow("request-123")
 
         payload = post.call_args.kwargs["json"]
-        assert payload["client_payload"]["entity_redirects"] == (
-            '[{"old_entity":"100","entity":"200","dataset":"conservation-area"}]'
-        )
-
+        assert "entity_redirects" not in payload["client_payload"]
 
 class TestGetBranchHeadSha:
     def test_returns_sha(self, app):

--- a/tests/unit/blueprints/datamanager/services/test_github.py
+++ b/tests/unit/blueprints/datamanager/services/test_github.py
@@ -125,6 +125,7 @@ class TestTriggerAddDataAsyncWorkflow:
         payload = post.call_args.kwargs["json"]
         assert "entity_redirects" not in payload["client_payload"]
 
+
 class TestGetBranchHeadSha:
     def test_returns_sha(self, app):
         resp = Mock()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Adds selection support to the Assign Entities flow so users can choose which new entity references should be processed before continuing to preview.

This updates the Assign Entities results page to support entity checkboxes, Dedup selection changes, replacement async requests using `selected_entities` and `selected_redirects`, and preview rendering from async-generated `new-entities` and `old-entity` output. It also removes the old GitHub `entity_redirects` dispatch path, since redirects now come from the completed async response.

Documentation has been added for the Assign Entities architecture, gotchas, and debugging steps.

## Related Tickets & Documents

- Related Issue #2661
- Docs: `docs/assign-entities/architecture.md`

## QA Instructions, Screenshots, Recordings

Test the Assign Entities journey:

1. Start an Assign Entities request for a resource with unknown entities.
2. On the Entities tab, confirm new rows have enabled checkboxes and existing/platform rows are disabled.
3. Change the entity selection and confirm the button changes to “Process entities”.
4. If Dedup rows are present, change a Dedup selection and confirm the button also changes to “Process entities”.
5. Process the selection and confirm the replacement request keeps unselected entities visible while placing selected/processed entities in the async output.
6. Continue to preview and confirm:
   - “Rows that will create new entities” matches `pipeline-summary.new-entities`
   - “Number of redirects” matches `pipeline-summary.old-entity`
7. Confirm the GitHub workflow payload no longer includes `entity_redirects`.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

Focused validation run:

```bash
./.venv/bin/pytest tests/unit/blueprints/datamanager/controllers/test_add.py tests/unit/blueprints/datamanager/services/test_github.py tests/unit/blueprints/datamanager/controllers/test_transform.py tests/acceptance/blueprints/datamanager/test_flagged_resources.py -q
./.venv/bin/black --check application/blueprints/datamanager/router.py application/blueprints/datamanager/controllers/transform.py application/blueprints/datamanager/controllers/preview.py application/blueprints/datamanager/services/github.py tests/unit/blueprints/datamanager/controllers/test_add.py tests/unit/blueprints/datamanager/services/test_github.py tests/unit/blueprints/datamanager/controllers/test_transform.py tests/acceptance/blueprints/datamanager/test_flagged_resources.py
./.venv/bin/flake8 application/blueprints/datamanager/router.py application/blueprints/datamanager/controllers/transform.py application/blueprints/datamanager/controllers/preview.py application/blueprints/datamanager/services/github.py tests/unit/blueprints/datamanager/controllers/test_add.py tests/unit/blueprints/datamanager/services/test_github.py tests/unit/blueprints/datamanager/controllers/test_transform.py tests/acceptance/blueprints/datamanager/test_flagged_resources.py
```

## [optional] Are there any post deployment tasks we need to perform?

No.

## [optional] Are there any dependencies on other PRs or Work?

Depends on async support for `selected_entities`, `selected_redirects`, `pipeline-summary.all-entities`, and `pipeline-summary.old-entity`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added entity assignment selection controls to the Assign Entities workflow, including select-all, per-row checkboxes, and selection state updates in the UI.
  * Enabled duplicate redirection selection and locking in the flagged resource “Assign Entities” flow, with selections submitted to the async process.
* **Bug Fixes**
  * Improved the old-entity redirect preview (including accurate “Number of redirects” and clearer handling of empty values).
* **Documentation**
  * Added Assign Entities end-to-end architecture documentation and updated related guidance.
* **Tests**
  * Expanded unit and acceptance coverage for the updated UI, selection state, and async submission behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->