### PR TITLE
align "should fix, must fix" with check and provide

### DIFF
--- a/application/blueprints/datamanager/controllers/check.py
+++ b/application/blueprints/datamanager/controllers/check.py
@@ -69,6 +69,8 @@ def _missing_column_tasks(task_log):
     """
     tasks = []
     for item in task_log:
+        if not isinstance(item, dict):
+            continue
         if item.get("task-source") != "column-field":
             continue
         details = _task_details(item) or {}
@@ -92,6 +94,8 @@ def _issue_tasks(task_log, quality_criteria_levels):
     """
     aggregated = {}
     for item in task_log:
+        if not isinstance(item, dict):
+            continue
         if item.get("task-source") != "issue":
             continue
         if item.get("responsibility") == "internal":

--- a/application/blueprints/datamanager/controllers/check.py
+++ b/application/blueprints/datamanager/controllers/check.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import datetime
 
@@ -19,6 +20,9 @@ from ..services.dataset import (
 from ..services.dataset_field import (
     get_field_names_for_dataset,
 )
+from ..services.issue_type import (
+    get_quality_criteria_levels,
+)
 from ..services.organisation import (
     get_organisation_name,
 )
@@ -33,12 +37,106 @@ logger = logging.getLogger(__name__)
 
 _ROWS_PER_PAGE = 500
 
+# Quality criteria levels same as check for block/non block
+_BLOCKING_LEVEL = 2
+_NON_BLOCKING_LEVEL = 3
+
 
 def _assign_column_mapping(column_mapping, col_name, field_name):
     for existing_col, existing_field in list(column_mapping.items()):
         if existing_col != col_name and existing_field == field_name:
             del column_mapping[existing_col]
     column_mapping[col_name] = field_name
+
+
+def _task_details(item):
+    """Parse the JSON `details` string on a task-log entry, or None if unusable."""
+    details = item.get("details")
+    if not isinstance(details, str) or not details:
+        return None
+    try:
+        parsed = json.loads(details)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _missing_column_tasks(task_log):
+    """Missing mandatory columns, from column-field task-log entries.
+
+    These always block adding data, whether or not the pipeline generated a
+    summary for them.
+    """
+    tasks = []
+    for item in task_log:
+        if item.get("task-source") != "column-field":
+            continue
+        details = _task_details(item) or {}
+        field = details.get("field")
+        summary = item.get("summary")
+        if not summary:
+            if not field:
+                continue
+            summary = f"{field} column is missing"
+        tasks.append(summary)
+    return tasks
+
+
+def _issue_tasks(task_log, quality_criteria_levels):
+    """Issues from the task log, aggregated by issue type and field.
+
+    Mirrors the check results in submit: internal issues are dropped, each
+    issue is given its quality criteria level from the issue_type table, and
+    only levels 2 and 3 are kept. Returns a list of
+    (quality_criteria_level, summary) tuples.
+    """
+    aggregated = {}
+    for item in task_log:
+        if item.get("task-source") != "issue":
+            continue
+        if item.get("responsibility") == "internal":
+            continue
+
+        details = _task_details(item)
+        if not details:
+            continue
+        issue_type = details.get("issue_type")
+        field = details.get("field")
+        if not issue_type or not field:
+            continue
+
+        level = quality_criteria_levels.get(issue_type)
+        # Field-specific override for 'missing value' issues on 'reference'
+        if issue_type == "missing value" and field == "reference":
+            level = _BLOCKING_LEVEL
+        if level not in (_BLOCKING_LEVEL, _NON_BLOCKING_LEVEL):
+            continue
+
+        count = details.get("count") or 1
+        key = (issue_type, field)
+        existing = aggregated.get(key)
+        if existing:
+            existing["count"] += count
+        else:
+            aggregated[key] = {
+                "issue_type": issue_type,
+                "field": field,
+                "level": level,
+                "count": count,
+                "summary": item.get("summary"),
+            }
+
+    tasks = []
+    for task in aggregated.values():
+        summary = task["summary"]
+        if not summary:
+            plural = "s" if task["count"] > 1 else ""
+            summary = (
+                f"{task['count']} issue{plural} of type "
+                f"{task['issue_type']} in {task['field']}"
+            )
+        tasks.append((task["level"], summary))
+    return tasks
 
 
 def handle_check_results(request_id, result):
@@ -172,18 +270,17 @@ def handle_check_results(request_id, result):
         column_mapping, unmapped_columns, user_column_mapping, spec_fields
     )
 
-    # must_fix: task-log entries flagged as missing columns (task-source == "column-field")
-    # fixable: all other task-log issues (value errors, etc.)
+    # must_fix: missing columns, plus issues whose quality criteria level is
+    #           blocking (level 2) - these stop data being added
+    # should_fix: issues at the non-blocking level (level 3)
     # passed_checks: every field that column-mapping confirms is present
-    must_fix = [
-        item["summary"]
-        for item in task_log
-        if item.get("task-source") == "column-field" and item.get("summary")
+    quality_criteria_levels = get_quality_criteria_levels()
+    issue_tasks = _issue_tasks(task_log, quality_criteria_levels)
+    must_fix = _missing_column_tasks(task_log) + [
+        summary for level, summary in issue_tasks if level == _BLOCKING_LEVEL
     ]
-    fixable = [
-        item["summary"]
-        for item in task_log
-        if item.get("task-source") != "column-field" and item.get("summary")
+    should_fix = [
+        summary for level, summary in issue_tasks if level == _NON_BLOCKING_LEVEL
     ]
     passed_checks = [
         f"Column mapped: {entry['field']}"
@@ -205,7 +302,7 @@ def handle_check_results(request_id, result):
         geometries=geometries,
         geometry_points=geometry_points,
         must_fix=must_fix,
-        fixable=fixable,
+        should_fix=should_fix,
         passed_checks=passed_checks,
         allow_add_data=allow_add_data,
         can_override=can_override,

--- a/application/blueprints/datamanager/services/issue_type.py
+++ b/application/blueprints/datamanager/services/issue_type.py
@@ -1,0 +1,76 @@
+import logging
+import time
+
+import requests
+from flask import current_app
+
+from ..utils import REQUESTS_TIMEOUT
+
+logger = logging.getLogger(__name__)
+
+_cache = {
+    "data": None,
+    "expires_at": 0,
+}
+CACHE_TTL_SECONDS = 300  # 5 minutes
+
+
+def get_quality_criteria_levels() -> dict[str, int]:
+    """Return a mapping of issue-type -> quality criteria level.
+
+    The level decides whether an issue blocks data being added:
+    level 2 issues are blocking ("must fix"), level 3 issues are
+    non-blocking ("should fix"). Issue types with no level (internal
+    responsibility or warning severity) are omitted.
+
+    Fetched from the datasette issue_type table and cached for 5 minutes.
+    """
+    now = time.monotonic()
+    if _cache["data"] is not None and now < _cache["expires_at"]:
+        return _cache["data"]
+
+    datasette_url = current_app.config.get("DATASETTE_BASE_URL")
+    url = f"{datasette_url}/issue_type.json?_shape=objects&_size=max"
+
+    levels: dict[str, int] = {}
+    try:
+        while url:
+            response = requests.get(
+                url,
+                timeout=REQUESTS_TIMEOUT,
+                headers={"User-Agent": "Planning Data - Manage"},
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            rows = data.get("rows", []) if isinstance(data, dict) else data
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                issue_type = row.get("issue_type")
+                level = row.get("quality_criteria_level")
+                if not issue_type or level in (None, ""):
+                    continue
+                try:
+                    levels[issue_type] = int(level)
+                except (TypeError, ValueError):
+                    logger.warning(
+                        f"Ignoring non-numeric quality_criteria_level "
+                        f"'{level}' for issue type '{issue_type}'"
+                    )
+
+            url = data.get("next_url") if isinstance(data, dict) else None
+            if url and url.startswith("/"):
+                url = f"{datasette_url.rstrip('/')}{url}"
+
+    except Exception:
+        logger.exception("Error fetching issue_type quality criteria levels")
+        if _cache["data"] is not None:
+            logger.warning("Returning stale issue_type cache after fetch failure")
+            return _cache["data"]
+        raise
+
+    _cache["data"] = levels
+    _cache["expires_at"] = now + CACHE_TTL_SECONDS
+
+    return levels

--- a/application/templates/datamanager/check-results.html
+++ b/application/templates/datamanager/check-results.html
@@ -10,7 +10,7 @@
       <h2 class="govuk-error-summary__title">Data cannot be added</h2>
       <div class="govuk-error-summary__body">
         <p>
-          <strong>Please address the columns not found before adding data</strong>
+          <strong>Please address the issues you must fix before adding data</strong>
         </p>
       </div>
     </div>
@@ -92,7 +92,7 @@
         <!-- Must fix (blocking issues) -->
         {% if must_fix %}
         <h2 class="govuk-heading-m govuk-!-margin-top-4">
-          Columns not found
+          Issues you must fix before adding data
         </h2>
         <div class="govuk-width-container">
           <ul class="govuk-task-list">
@@ -100,7 +100,7 @@
             <li class="govuk-task-list__item govuk-task-list__item--with-link">
               <div class="govuk-task-list__name-and-hint">{{ issue }}</div>
               <div class="govuk-task-list__status">
-                <strong class="govuk-tag govuk-tag--red">Not found</strong>
+                <strong class="govuk-tag govuk-tag--red">Must fix</strong>
               </div>
             </li>
             {% endfor %}
@@ -108,18 +108,19 @@
         </div>
         {% endif %}
 
-        <!-- Fixable issues -->
-        {% if fixable %}
+        <!-- Should fix (non-blocking issues) -->
+        {% if should_fix %}
         <h2 class="govuk-heading-m govuk-!-margin-top-4">
-          Error summary
+          Issues you should fix
         </h2>
+        <p class="govuk-body">Data can be added with these issues, but they should be fixed to improve data quality.</p>
         <div class="govuk-width-container">
           <ul class="govuk-task-list">
-            {% for issue in fixable %}
+            {% for issue in should_fix %}
             <li class="govuk-task-list__item govuk-task-list__item--with-link">
               <div class="govuk-task-list__name-and-hint">{{ issue }}</div>
               <div class="govuk-task-list__status">
-                <strong class="govuk-tag govuk-tag--yellow">Needs fixing</strong>
+                <strong class="govuk-tag govuk-tag--yellow">Needs improving</strong>
               </div>
             </li>
             {% endfor %}

--- a/tests/acceptance/blueprints/datamanager/test_add_data_journey.py
+++ b/tests/acceptance/blueprints/datamanager/test_add_data_journey.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 import responses as rsps
 
 ASYNC_BASE = "http://localhost:8000/requests"
+ISSUE_TYPE_URL = "https://datasette.planning.data.gov.uk/digital-land/issue_type.json"
 
 CSV_INPUT = (
     "organisation,pipelines,documentation-url,endpoint-url,start-date,plugin,licence\n"
@@ -243,6 +244,12 @@ class TestAddDataJourney:
             rsps.GET,
             f"{ASYNC_BASE}/check-id-1/response-details",
             json=RESP_DETAILS_WITH_GEOM,
+            status=200,
+        )
+        rsps.add(
+            rsps.GET,
+            ISSUE_TYPE_URL,
+            json={"rows": [], "next_url": None},
             status=200,
         )
         # Boundary URL fetch is not registered — rsps raises ConnectionError which check.py catches

--- a/tests/unit/blueprints/datamanager/controllers/test_check.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_check.py
@@ -1,4 +1,10 @@
+import json
 from unittest.mock import patch
+
+from application.blueprints.datamanager.controllers.check import (
+    _issue_tasks,
+    _missing_column_tasks,
+)
 
 PENDING_RESULT = {
     "status": "PENDING",
@@ -61,3 +67,99 @@ class TestCheckResultsRoute:
         assert "new-check-id" in response.headers["Location"]
         submitted_params = submit_request.call_args.args[0]
         assert submitted_params["column_mapping"] == {"MyColumn": "name"}
+
+
+def _issue_task(issue_type, field, count=1, summary="", responsibility="external"):
+    return {
+        "task-source": "issue",
+        "responsibility": responsibility,
+        "severity": "error",
+        "summary": summary,
+        "details": json.dumps(
+            {"issue_type": issue_type, "field": field, "count": count}
+        ),
+    }
+
+
+def _column_field_task(field, summary=""):
+    return {
+        "task-source": "column-field",
+        "responsibility": "external",
+        "severity": "error",
+        "summary": summary,
+        "details": json.dumps({"field": field}),
+    }
+
+
+QUALITY_CRITERIA_LEVELS = {
+    "invalid geometry": 2,
+    "invalid date": 3,
+    "missing value": 3,
+    "unknown entity": 2,
+}
+
+
+class TestIssueTasks:
+    def test_splits_issues_by_quality_criteria_level(self):
+        task_log = [
+            _issue_task("invalid geometry", "geometry", summary="Invalid geometry"),
+            _issue_task("invalid date", "start-date", summary="Invalid date"),
+        ]
+        tasks = _issue_tasks(task_log, QUALITY_CRITERIA_LEVELS)
+        assert sorted(tasks) == [(2, "Invalid geometry"), (3, "Invalid date")]
+
+    def test_missing_value_on_reference_is_blocking(self):
+        # 'missing value' is level 3 in general, but blocking on the reference field
+        task_log = [
+            _issue_task("missing value", "reference", summary="References missing"),
+            _issue_task("missing value", "name", summary="Names missing"),
+        ]
+        tasks = _issue_tasks(task_log, QUALITY_CRITERIA_LEVELS)
+        assert sorted(tasks) == [(2, "References missing"), (3, "Names missing")]
+
+    def test_excludes_internal_and_unlevelled_issues(self):
+        task_log = [
+            _issue_task(
+                "unknown entity",
+                "entity",
+                summary="Unknown entity",
+                responsibility="internal",
+            ),
+            _issue_task("not in the issue type table", "name", summary="Something"),
+        ]
+        assert _issue_tasks(task_log, QUALITY_CRITERIA_LEVELS) == []
+
+    def test_aggregates_counts_by_issue_type_and_field(self):
+        task_log = [
+            _issue_task("invalid date", "start-date", count=2),
+            _issue_task("invalid date", "start-date", count=3),
+        ]
+        tasks = _issue_tasks(task_log, QUALITY_CRITERIA_LEVELS)
+        assert tasks == [(3, "5 issues of type invalid date in start-date")]
+
+    def test_falls_back_to_generated_summary(self):
+        task_log = [_issue_task("invalid geometry", "geometry")]
+        tasks = _issue_tasks(task_log, QUALITY_CRITERIA_LEVELS)
+        assert tasks == [(2, "1 issue of type invalid geometry in geometry")]
+
+    def test_ignores_entries_with_unusable_details(self):
+        task_log = [
+            {"task-source": "issue", "details": "not json", "summary": "x"},
+            {"task-source": "issue", "details": "", "summary": "x"},
+            _issue_task("invalid geometry", "", summary="No field"),
+        ]
+        assert _issue_tasks(task_log, QUALITY_CRITERIA_LEVELS) == []
+
+
+class TestMissingColumnTasks:
+    def test_uses_summary_when_present(self):
+        task_log = [_column_field_task("reference", summary="Reference column missing")]
+        assert _missing_column_tasks(task_log) == ["Reference column missing"]
+
+    def test_generates_summary_when_missing(self):
+        task_log = [_column_field_task("reference")]
+        assert _missing_column_tasks(task_log) == ["reference column is missing"]
+
+    def test_ignores_non_column_field_entries(self):
+        task_log = [_issue_task("invalid date", "start-date", summary="Invalid date")]
+        assert _missing_column_tasks(task_log) == []

--- a/tests/unit/blueprints/datamanager/controllers/test_check.py
+++ b/tests/unit/blueprints/datamanager/controllers/test_check.py
@@ -142,6 +142,16 @@ class TestIssueTasks:
         tasks = _issue_tasks(task_log, QUALITY_CRITERIA_LEVELS)
         assert tasks == [(2, "1 issue of type invalid geometry in geometry")]
 
+    def test_ignores_non_dict_entries(self):
+        task_log = [
+            None,
+            "not a task",
+            _issue_task("invalid geometry", "geometry", summary="Invalid geometry"),
+        ]
+        assert _issue_tasks(task_log, QUALITY_CRITERIA_LEVELS) == [
+            (2, "Invalid geometry")
+        ]
+
     def test_ignores_entries_with_unusable_details(self):
         task_log = [
             {"task-source": "issue", "details": "not json", "summary": "x"},
@@ -163,3 +173,11 @@ class TestMissingColumnTasks:
     def test_ignores_non_column_field_entries(self):
         task_log = [_issue_task("invalid date", "start-date", summary="Invalid date")]
         assert _missing_column_tasks(task_log) == []
+
+    def test_ignores_non_dict_entries(self):
+        task_log = [
+            None,
+            "not a task",
+            _column_field_task("reference", summary="Reference column missing"),
+        ]
+        assert _missing_column_tasks(task_log) == ["Reference column missing"]

--- a/tests/unit/blueprints/datamanager/services/test_issue_type.py
+++ b/tests/unit/blueprints/datamanager/services/test_issue_type.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import application.blueprints.datamanager.services.issue_type as issue_type_module
+from application.blueprints.datamanager.services.issue_type import (
+    get_quality_criteria_levels,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Reset the module-level cache between tests."""
+    issue_type_module._cache["data"] = None
+    issue_type_module._cache["expires_at"] = 0
+    yield
+    issue_type_module._cache["data"] = None
+    issue_type_module._cache["expires_at"] = 0
+
+
+def _make_response(rows, next_url=None):
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"rows": rows, "next_url": next_url}
+    return mock_resp
+
+
+ISSUE_TYPE_ROWS = [
+    {"issue_type": "invalid geometry", "quality_criteria_level": 2},
+    {"issue_type": "invalid date", "quality_criteria_level": "3"},
+    {"issue_type": "combined-value", "quality_criteria_level": None},
+    {"issue_type": "unknown format", "quality_criteria_level": ""},
+    {"issue_type": "", "quality_criteria_level": 2},
+]
+
+
+class TestGetQualityCriteriaLevels:
+    def test_maps_issue_type_to_int_level(self, app):
+        with app.app_context():
+            with patch(
+                "application.blueprints.datamanager.services.issue_type.requests.get",
+                return_value=_make_response(ISSUE_TYPE_ROWS),
+            ):
+                levels = get_quality_criteria_levels()
+
+        assert levels == {"invalid geometry": 2, "invalid date": 3}
+
+    def test_follows_pagination(self, app):
+        page_one = _make_response(
+            [{"issue_type": "invalid geometry", "quality_criteria_level": 2}],
+            next_url="/digital-land/issue_type.json?_next=1",
+        )
+        page_two = _make_response(
+            [{"issue_type": "invalid date", "quality_criteria_level": 3}]
+        )
+        with app.app_context():
+            with patch(
+                "application.blueprints.datamanager.services.issue_type.requests.get",
+                side_effect=[page_one, page_two],
+            ) as mock_get:
+                levels = get_quality_criteria_levels()
+
+        assert mock_get.call_count == 2
+        assert levels == {"invalid geometry": 2, "invalid date": 3}
+
+    def test_caches_between_calls(self, app):
+        with app.app_context():
+            with patch(
+                "application.blueprints.datamanager.services.issue_type.requests.get",
+                return_value=_make_response(ISSUE_TYPE_ROWS),
+            ) as mock_get:
+                get_quality_criteria_levels()
+                get_quality_criteria_levels()
+
+        assert mock_get.call_count == 1
+
+    def test_returns_stale_cache_on_fetch_failure(self, app):
+        with app.app_context():
+            with patch(
+                "application.blueprints.datamanager.services.issue_type.requests.get",
+                return_value=_make_response(ISSUE_TYPE_ROWS),
+            ):
+                get_quality_criteria_levels()
+
+            issue_type_module._cache["expires_at"] = 0
+
+            with patch(
+                "application.blueprints.datamanager.services.issue_type.requests.get",
+                side_effect=Exception("datasette down"),
+            ):
+                levels = get_quality_criteria_levels()
+
+        assert levels == {"invalid geometry": 2, "invalid date": 3}
+
+    def test_raises_when_fetch_fails_with_no_cache(self, app):
+        with app.app_context():
+            with patch(
+                "application.blueprints.datamanager.services.issue_type.requests.get",
+                side_effect=Exception("datasette down"),
+            ):
+                with pytest.raises(Exception, match="datasette down"):
+                    get_quality_criteria_levels()


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In the check service, it pulls down the issue type table from datasette and uses this to help decide which tasks should block and which shouldn't. Manage never replicated this with the belief that it shouldn't be able to get here regardless. 

This now replicates it, with a service that loads and caches the issue type table. Then it takes the task details and runs them through this issue type blocking, criteria level 2 blocks, 3 should fix.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes # https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=223846344&issue=digital-land%7Cconfig%7C2871

## QA Instructions, Screenshots, Recordings

Try running a check result with a out of england bounds value, or a duplicate reference value. These issues should now stop the user proceeding past check results in the Manage Service.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
No
## [optional] Are there any dependencies on other PRs or Work?
No